### PR TITLE
Add pytest-probatio companion package (uv workspace)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,12 @@ jobs:
           subject-path: ${{ env.WHEEL_PYTEST }}
           sbom-path: pytest-probatio.cdx.json
       - name: 🚀 Publish to PyPI
+        # Uploads every distribution in dist/, so both probatio and
+        # pytest-probatio. Each is a separate PyPI project, so BOTH must have a
+        # trusted publisher configured for this repository, workflow, and the
+        # `release` environment, or PyPI rejects the upload with a 403 (after the
+        # first project has already published). The pytest-probatio publisher can be
+        # registered as a pending publisher before its first release.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,9 @@ jobs:
           # job that pushes artifacts to PyPI.
           enable-cache: false
           python-version: "3.13"
-      - name: 🏗 Set package version
+      - name: 🏗 Set package versions
+        # Stamp both workspace packages with the release version, so probatio and
+        # its pytest-probatio companion always ship the same number.
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
@@ -47,29 +49,43 @@ jobs:
           version="${version,,}"
           version="${version#v}"
           uv version "${version}"
-      - name: 🏗 Build package
-        run: uv build
-      - name: 🧭 Locate the built wheel
+          uv version --package pytest-probatio "${version}"
+      - name: 🏗 Build packages
+        run: uv build --all-packages
+      - name: 🧭 Locate the built wheels
         run: |
-          wheel_path=$(ls dist/probatio-*-py3-none-any.whl)
-          echo "WHEEL_PATH=${wheel_path}" >> "${GITHUB_ENV}"
-      - name: 📝 Generate a CycloneDX SBOM
+          echo "WHEEL_PROBATIO=$(ls dist/probatio-*-py3-none-any.whl)" >> "${GITHUB_ENV}"
+          echo "WHEEL_PYTEST=$(ls dist/pytest_probatio-*-py3-none-any.whl)" >> "${GITHUB_ENV}"
+      - name: 📝 Generate a CycloneDX SBOM for probatio
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          file: ${{ env.WHEEL_PATH }}
+          file: ${{ env.WHEEL_PROBATIO }}
           format: cyclonedx-json
           output-file: probatio.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+      - name: 📝 Generate a CycloneDX SBOM for pytest-probatio
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: ${{ env.WHEEL_PYTEST }}
+          format: cyclonedx-json
+          output-file: pytest-probatio.cdx.json
           upload-artifact: false
           upload-release-assets: false
       - name: 📝 Attest build provenance
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: "dist/*"
-      - name: 📝 Attest the SBOM against the built artifacts
+      - name: 📝 Attest the probatio SBOM against its wheel
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
-          subject-path: "dist/*"
+          subject-path: ${{ env.WHEEL_PROBATIO }}
           sbom-path: probatio.cdx.json
+      - name: 📝 Attest the pytest-probatio SBOM against its wheel
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ${{ env.WHEEL_PYTEST }}
+          sbom-path: pytest-probatio.cdx.json
       - name: 🚀 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,9 +35,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python }}
       - name: 🏗 Install dependencies
-        run: uv sync --locked --group test
+        run: uv sync --locked --all-packages --group test
       - name: 🚀 Run pytest
         run: uv run --no-sync pytest --cov probatio tests
+      - name: 🧩 Run workspace package tests
+        run: uv run --no-sync pytest packages/pytest-probatio/tests -o addopts=""
       - name: 📝 Verify documentation examples
         run: uv run --no-sync python docs/verify_examples.py
       - name: ⬆️ Upload coverage artifact

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -31,12 +31,14 @@ jobs:
           enable-cache: true
           python-version: "3.13"
       - name: 🏗 Install dependencies
-        run: uv sync --locked --group typing
+        run: uv sync --locked --all-packages --group typing
       - name: 🚀 Run mypy
         # The library is the typed, enforced surface ([tool.mypy] files, just
         # typecheck, the pre-commit hook). Tests deliberately feed wrong types,
         # so they are not type-checked.
         run: uv run --no-sync mypy src/probatio
+      - name: 🧩 Type-check workspace packages
+        run: uv run --no-sync mypy packages/pytest-probatio/src
 
   ty:
     name: ty

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -105,6 +105,10 @@ export default defineConfig({
               label: "JSON Schema and OpenAPI",
               slug: "guides/json-schema-and-openapi",
             },
+            {
+              label: "Testing with pytest-probatio",
+              slug: "guides/testing-with-pytest",
+            },
             { label: "Troubleshooting", slug: "guides/troubleshooting" },
           ],
         },

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -60,6 +60,38 @@ data does not match the probatio schema (==):
 So a failing `assert response == Exact(...)` points at the exact offending value
 rather than just reporting that the two are not equal.
 
+## Reuse a schema across tests
+
+A schema is data, so define the expected shape once and reuse it like any other
+constant. Keep the plain schema (a dict, a `Schema`, a validator) at module level
+and wrap it in `Exact` or `Partial` at each assertion, which also lets the same
+shape compose into larger ones:
+
+<!-- verify: skip -->
+
+```python
+from pytest_probatio import Exact
+from probatio import Email
+
+USER = {"id": int, "name": str, "email": Email()}
+
+
+def test_create_user():
+    assert create_user("ada@example.com") == Exact(USER)
+
+
+def test_get_user():
+    assert get_user(1) == Exact(USER)
+
+
+def test_list_users():
+    # The same shape, composed into a bigger one.
+    assert list_users() == Exact({"users": [USER], "total": int})
+```
+
+A pytest fixture that returns the schema works too, if you would rather inject it
+than import a module-level constant.
+
 ## Why a separate package
 
 The core `probatio` library has no required dependencies. A pytest plugin needs

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -60,6 +60,13 @@ data does not match the probatio schema (==):
 So a failing `assert response == Exact(...)` points at the exact offending value
 rather than just reporting that the two are not equal.
 
+:::tip[GitHub annotations]
+The explanation is plain pytest assertion output, so it flows straight into
+[`pytest-github-actions-annotate-failures`](https://github.com/pytest-dev/pytest-github-actions-annotate-failures).
+Install that plugin in CI and a failed schema match becomes a GitHub annotation on
+the test, listing each offending field by its path, with no extra setup here.
+:::
+
 ## Reuse a schema across tests
 
 A schema is data, so define the expected shape once and assert it across as many

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -89,6 +89,22 @@ def test_list_users():
     assert list_users() == Exact({"users": [USER], "total": int})
 ```
 
+The shape can also be a pre-built `Schema`, so a schema you already use elsewhere
+(a production config schema, say) doubles as a test matcher. `Exact` and `Partial`
+still control whether extra keys are allowed:
+
+<!-- verify: skip -->
+
+```python
+from pytest_probatio import Exact, Partial
+from probatio import Schema
+
+USER = Schema({"id": int, "name": str})
+
+assert get_user(1) == Exact(USER)  # no extra keys
+assert get_user(1) == Partial(USER)  # extra keys allowed
+```
+
 A pytest fixture that returns the schema works too, if you would rather inject it
 than import a module-level constant.
 

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -54,7 +54,7 @@ its path through the data, using probatio's errors:
 
 ```text
 data does not match the probatio schema (==):
-  data['port']: expected int
+  data['port']: expected a port number between 1 and 65535
 ```
 
 So a failing `assert response == Exact(...)` points at the exact offending value

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -62,51 +62,58 @@ rather than just reporting that the two are not equal.
 
 ## Reuse a schema across tests
 
-A schema is data, so define the expected shape once and reuse it like any other
-constant. Keep the plain schema (a dict, a `Schema`, a validator) at module level
-and wrap it in `Exact` or `Partial` at each assertion, which also lets the same
-shape compose into larger ones:
-
-<!-- verify: skip -->
-
-```python
-from pytest_probatio import Exact
-from probatio import Email
-
-USER = {"id": int, "name": str, "email": Email()}
-
-
-def test_create_user():
-    assert create_user("ada@example.com") == Exact(USER)
-
-
-def test_get_user():
-    assert get_user(1) == Exact(USER)
-
-
-def test_list_users():
-    # The same shape, composed into a bigger one.
-    assert list_users() == Exact({"users": [USER], "total": int})
-```
-
-The shape can also be a pre-built `Schema`, so a schema you already use elsewhere
-(a production config schema, say) doubles as a test matcher. `Exact` and `Partial`
-still control whether extra keys are allowed:
+A schema is data, so define the expected shape once and assert it across as many
+tests as you like. This is where the matcher earns its keep: one schema, many
+tests, and each failure still points at the offending field. A `Schema` you
+already use elsewhere (a production config or response schema) works as the
+matcher just as well as a fresh one.
 
 <!-- verify: skip -->
 
 ```python
 from pytest_probatio import Exact, Partial
-from probatio import Schema
+from probatio import Schema, Email, Range
 
-USER = Schema({"id": int, "name": str})
+# The shape of a user, defined once and shared by every test below.
+USER = Schema(
+    {
+        "id": Range(min=1),
+        "name": str,
+        "email": Email(),
+    }
+)
 
-assert get_user(1) == Exact(USER)  # no extra keys
-assert get_user(1) == Partial(USER)  # extra keys allowed
+
+def test_create_user_returns_the_created_user(api):
+    response = api.post("/users", json={"name": "Ada", "email": "ada@example.com"})
+    assert response.status_code == 201
+    assert response.json() == Exact(USER)
+
+
+def test_get_user_returns_the_user(api):
+    assert api.get("/users/1").json() == Exact(USER)
+
+
+def test_user_list_wraps_users_in_a_page(api):
+    # The same USER schema, composed into a larger shape.
+    page = Exact({"users": [USER], "total": Range(min=0)})
+    assert api.get("/users").json() == page
+
+
+def test_user_detail_may_carry_extra_fields(api):
+    # Partial: the response must contain a valid user; extra fields are allowed.
+    assert api.get("/users/1?expand=true").json() == Partial(USER)
 ```
 
-A pytest fixture that returns the schema works too, if you would rather inject it
-than import a module-level constant.
+Here `api` is your application's test client, an ordinary pytest fixture you
+provide (a `fixture` that returns the schema works the same way, if you would
+rather inject the schema than import a module-level constant). When a response is
+wrong, the failure names the exact field, even inside the composed list:
+
+```text
+data does not match the probatio schema (==):
+  data['users'][0]['email']: expected an email address
+```
 
 ## Why a separate package
 

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -1,0 +1,68 @@
+---
+title: Testing with pytest-probatio
+description: Use a probatio schema as a pytest assertion matcher, with path-precise failures.
+---
+
+`pytest-probatio` is a small companion package that lets a probatio schema stand
+in as a pytest assertion matcher. A schema reads as the expected shape, and a
+mismatch is explained by probatio's path-precise errors instead of a bare
+`assert`. It is handy for asserting the shape of API responses and other
+structured data in tests.
+
+It ships as a separate distribution, so the core library stays dependency-free,
+and it is released lock-step with probatio at the same version.
+
+## Installation
+
+```bash
+pip install pytest-probatio
+```
+
+The plugin registers itself with pytest; no configuration is needed.
+
+## Matchers
+
+Two matchers are exposed. The schema goes on one side of the comparison and the
+data on the other:
+
+<!-- verify: skip -->
+
+```python
+from pytest_probatio import Exact, Partial
+from probatio import Port
+
+
+def test_response(response):
+    # Exact: an extra key makes it unequal.
+    assert response == Exact({"name": str, "port": Port()})
+
+    # Partial: extra keys are allowed under ==.
+    assert response == Partial({"name": str})
+
+    # The <= operator relaxes Exact to a partial match too.
+    assert Exact({"name": str}) <= response
+```
+
+The right-hand schema may be any probatio schema: a type, a validator, a nested
+dict, markers, and so on. With `Exact`, `==` requires no extra keys and `<=`
+allows them; `Partial` allows extra keys under `==`.
+
+## Readable failures
+
+When the data does not match, pytest's assertion rewriting prints each error by
+its path through the data, using probatio's errors:
+
+```text
+data does not match the probatio schema (==):
+  data['port']: expected int
+```
+
+So a failing `assert response == Exact(...)` points at the exact offending value
+rather than just reporting that the two are not equal.
+
+## Why a separate package
+
+The core `probatio` library has no required dependencies. A pytest plugin needs
+pytest and registers a plugin entry point, which is a test-framework concern, so
+it lives in its own distribution. It shares probatio's repository, so the two are
+developed and released together.

--- a/justfile
+++ b/justfile
@@ -10,13 +10,18 @@
 default:
     @just --list
 
-# Install all development dependencies into the uv-managed environment.
+# Install all development dependencies into the uv-managed environment, including
+# every workspace package under packages/.
 setup:
-    uv sync
+    uv sync --all-packages
 
 # Run the test suite. Extra args pass through, e.g. `just test -k schema`.
 test *args:
     uv run --no-sync pytest {{args}}
+
+# Run the workspace packages' own suites (the core coverage gate does not apply).
+test-packages:
+    uv run --no-sync pytest packages/pytest-probatio/tests -o addopts=""
 
 # Lint and format-check Python (read-only; use `just fmt` to fix).
 lint:
@@ -32,6 +37,7 @@ fmt:
 typecheck:
     uv run --no-sync mypy src/probatio
     uv run --no-sync ty check src/probatio
+    uv run --no-sync mypy packages/pytest-probatio/src
 
 # Spell-check the codebase (codespell; config in pyproject.toml).
 spellcheck:
@@ -101,9 +107,11 @@ docs:
 docs-dev:
     cd docs && npm ci && npm run dev
 
-# Run the full local gate (CI parity): all pre-commit hooks, the suite, and docs.
+# Run the full local gate (CI parity): all pre-commit hooks, the suite, the
+# workspace packages, and docs.
 check: precommit
     uv run --no-sync pytest -q
+    uv run --no-sync pytest packages/pytest-probatio/tests -o addopts=""
     uv run --no-sync python docs/verify_examples.py
 
 # Remove build and tooling artifacts.

--- a/packages/pytest-probatio/LICENSE
+++ b/packages/pytest-probatio/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Franck Nijhof
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pytest-probatio/README.md
+++ b/packages/pytest-probatio/README.md
@@ -22,7 +22,7 @@ When the data does not match, the failure lists each error by its path:
 
 ```
 data does not match the probatio schema (==):
-  data['port']: expected int
+  data['port']: expected a port number between 1 and 65535
 ```
 
 Install it alongside pytest; the plugin registers itself:

--- a/packages/pytest-probatio/README.md
+++ b/packages/pytest-probatio/README.md
@@ -5,17 +5,17 @@ matcher. A schema reads as the expected shape, and a mismatch is explained by
 probatio's path-precise errors instead of a bare `assert`.
 
 ```python
-from pytest_probatio import S, Partial, Exact
+from pytest_probatio import Exact, Partial
 from probatio import Port
 
 
 def test_response(response):
-    # Strict: extra keys make it unequal.
-    assert response == S({"name": str, "port": Port()})
+    # Exact: extra keys make it unequal.
+    assert response == Exact({"name": str, "port": Port()})
 
     # Partial: extra keys are allowed.
     assert response == Partial({"name": str})
-    assert S({"name": str}) <= response
+    assert Exact({"name": str}) <= response
 ```
 
 When the data does not match, the failure lists each error by its path:

--- a/packages/pytest-probatio/README.md
+++ b/packages/pytest-probatio/README.md
@@ -1,0 +1,35 @@
+# pytest-probatio
+
+Use a [probatio](https://github.com/frenck/probatio) schema as a pytest assertion
+matcher. A schema reads as the expected shape, and a mismatch is explained by
+probatio's path-precise errors instead of a bare `assert`.
+
+```python
+from pytest_probatio import S, Partial, Exact
+from probatio import Port
+
+
+def test_response(response):
+    # Strict: extra keys make it unequal.
+    assert response == S({"name": str, "port": Port()})
+
+    # Partial: extra keys are allowed.
+    assert response == Partial({"name": str})
+    assert S({"name": str}) <= response
+```
+
+When the data does not match, the failure lists each error by its path:
+
+```
+data does not match the probatio schema (==):
+  data['port']: expected int
+```
+
+Install it alongside pytest; the plugin registers itself:
+
+```bash
+pip install pytest-probatio
+```
+
+This package lives in the probatio monorepo but ships separately, so the core
+`probatio` library stays dependency-free.

--- a/packages/pytest-probatio/pyproject.toml
+++ b/packages/pytest-probatio/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pytest-probatio"
+description = "Use a probatio schema as a pytest assertion matcher"
+readme = "README.md"
+requires-python = ">=3.13"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Franck Nijhof", email = "opensource@frenck.dev" }]
+maintainers = [{ name = "Franck Nijhof", email = "opensource@frenck.dev" }]
+keywords = ["pytest", "probatio", "validation", "schema", "testing"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Framework :: Pytest",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Software Development :: Testing",
+  "Typing :: Typed",
+]
+# Stays 0.0.0 in development; the release workflow stamps the real version from
+# the git tag at publish time, the same as the core package.
+version = "0.0.0"
+dependencies = ["probatio", "pytest>=8"]
+
+[project.urls]
+Homepage = "https://github.com/frenck/probatio"
+Repository = "https://github.com/frenck/probatio"
+Issues = "https://github.com/frenck/probatio/issues"
+
+# Register the plugin so pytest loads its assertion-explaining hook automatically.
+[project.entry-points.pytest11]
+probatio = "pytest_probatio.plugin"
+
+[tool.uv.sources]
+# Always build against the in-repo core, not a published release.
+probatio = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pytest_probatio"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/pytest_probatio", "tests", "pyproject.toml", "README.md", "LICENSE"]
+
+# Self-contained test config: this package is not held to the core's 100%-coverage
+# gate, so it runs its own plain pytest rather than inheriting the root addopts.
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/packages/pytest-probatio/pyproject.toml
+++ b/packages/pytest-probatio/pyproject.toml
@@ -27,7 +27,9 @@ classifiers = [
 # Stays 0.0.0 in development; the release workflow stamps the real version from
 # the git tag at publish time, the same as the core package.
 version = "0.0.0"
-dependencies = ["probatio", "pytest>=8"]
+# Released lock-step with probatio (same version), but the matcher only uses
+# probatio's stable public surface, so a floor is enough rather than an exact pin.
+dependencies = ["probatio>=0.1.0", "pytest>=8"]
 
 [project.urls]
 Homepage = "https://github.com/frenck/probatio"

--- a/packages/pytest-probatio/src/pytest_probatio/__init__.py
+++ b/packages/pytest-probatio/src/pytest_probatio/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from pytest_probatio.plugin import Exact, Partial, S
+from pytest_probatio.plugin import Exact, Partial
 
-__all__ = ["Exact", "Partial", "S"]
+__all__ = ["Exact", "Partial"]

--- a/packages/pytest-probatio/src/pytest_probatio/__init__.py
+++ b/packages/pytest-probatio/src/pytest_probatio/__init__.py
@@ -1,0 +1,7 @@
+"""pytest-probatio: use a probatio schema as a pytest assertion matcher."""
+
+from __future__ import annotations
+
+from pytest_probatio.plugin import Exact, Partial, S
+
+__all__ = ["Exact", "Partial", "S"]

--- a/packages/pytest-probatio/src/pytest_probatio/plugin.py
+++ b/packages/pytest-probatio/src/pytest_probatio/plugin.py
@@ -1,18 +1,16 @@
 """Use a probatio schema as a pytest assertion matcher.
 
-``assert response == S({"name": str, "port": Port()})`` validates ``response``
+``assert response == Exact({"name": str, "port": Port()})`` validates ``response``
 against the schema. On a mismatch, pytest's assertion rewriting calls the
 ``pytest_assertrepr_compare`` hook below, which renders each probatio error by its
 path, so the failure points at the exact offending value instead of a bare
 ``assert ... == ...``.
 
-Three matchers are exposed, mirroring pytest-voluptuous so the move is familiar:
+Two matchers are exposed:
 
-- ``S(schema)``: extra dict keys make it unequal; ``<=`` relaxes that to a partial
-  match (extra keys allowed).
+- ``Exact(schema)``: extra dict keys make it unequal; ``<=`` relaxes that to a
+  partial match (extra keys allowed).
 - ``Partial(schema)``: a partial match under ``==`` (extra keys allowed).
-- ``Exact(schema)``: a strict match under ``==`` (the default ``S`` behavior, named
-  for clarity at a nested position).
 
 This lives outside the ``probatio`` package on purpose: the core library is
 dependency-free, and a pytest plugin is a test-framework concern.
@@ -95,11 +93,15 @@ class _Matcher:
         return f"{type(self).__name__}({self._strict.schema!r})"
 
 
-class S(_Matcher):
-    """A schema matcher: ``==`` is a strict match, ``<=`` a partial one."""
+class Exact(_Matcher):
+    """A schema matcher: ``==`` requires an exact match, ``<=`` a partial one.
+
+    Exact means an extra dictionary key makes the data unequal; ``<=`` relaxes
+    that to allow extra keys, the same as ``Partial`` under ``==``.
+    """
 
     def __init__(self, schema: typing.Any) -> None:
-        """Wrap ``schema`` as a strict-by-equality matcher."""
+        """Wrap ``schema`` as an exact-by-equality matcher."""
         super().__init__(schema, partial=False)
 
 
@@ -109,14 +111,6 @@ class Partial(_Matcher):
     def __init__(self, schema: typing.Any) -> None:
         """Wrap ``schema`` as a partial-by-equality matcher."""
         super().__init__(schema, partial=True)
-
-
-class Exact(_Matcher):
-    """A schema matcher whose ``==`` requires an exact match (no extra keys)."""
-
-    def __init__(self, schema: typing.Any) -> None:
-        """Wrap ``schema`` as a strict-by-equality matcher."""
-        super().__init__(schema, partial=False)
 
 
 def _format_path(path: list[typing.Any]) -> str:

--- a/packages/pytest-probatio/src/pytest_probatio/plugin.py
+++ b/packages/pytest-probatio/src/pytest_probatio/plugin.py
@@ -26,11 +26,13 @@ from probatio import ALLOW_EXTRA, PREVENT_EXTRA, Invalid, MultipleInvalid, Schem
 def _compile(schema: typing.Any, extra: int) -> Schema:
     """Return ``schema`` as a ``Schema`` with the given extra-key policy.
 
-    A ready-made ``Schema`` is used as-is (its own ``extra`` is respected); anything
-    else is wrapped with the requested policy.
+    A ready-made ``Schema`` (you can build one once and reuse it across tests) is
+    rebuilt with the requested policy, its underlying schema and ``required`` flag
+    preserved, so ``Exact`` and ``Partial`` control extra keys the same way whether
+    they are given a raw shape or a ``Schema``.
     """
     if isinstance(schema, Schema):
-        return schema
+        return Schema(schema.schema, required=schema.required, extra=extra)
     return Schema(schema, extra=extra)
 
 

--- a/packages/pytest-probatio/src/pytest_probatio/plugin.py
+++ b/packages/pytest-probatio/src/pytest_probatio/plugin.py
@@ -50,7 +50,7 @@ class _Matcher:
         """Build the strict and partial schemas; ``partial`` picks which ``==`` uses."""
         self._strict = _compile(schema, PREVENT_EXTRA)
         self._loose = _compile(schema, ALLOW_EXTRA)
-        # ``Partial`` validates loosely under ``==``; ``S``/``Exact`` validate strictly.
+        # ``Partial`` validates loosely under ``==``; ``Exact`` validates strictly.
         self._strict_eq = not partial
         self._errors: list[Invalid] = []
 
@@ -73,7 +73,7 @@ class _Matcher:
         return True
 
     def __eq__(self, data: object) -> bool:
-        """Whether ``data`` validates (strictly for ``S``/``Exact``, loosely for ``Partial``)."""
+        """Whether ``data`` validates (strictly for ``Exact``, loosely for ``Partial``)."""
         return self._run(data, self._strict if self._strict_eq else self._loose)
 
     def __ne__(self, data: object) -> bool:
@@ -136,9 +136,12 @@ def pytest_assertrepr_compare(
         matcher = right
     else:
         return None
-    lines = [f"data does not match the probatio schema ({op}):"]
     if not matcher.errors:
-        lines.append("  (the schema matched; the assertion was negated)")
+        # A negated comparison (``!=``) that failed because the data *did* match.
+        return [
+            f"data matches the probatio schema, but the assertion ({op}) required it not to"
+        ]
+    lines = [f"data does not match the probatio schema ({op}):"]
     lines.extend(
         f"  {_format_path(error.path)}: {error.error_message or str(error)}"
         for error in matcher.errors

--- a/packages/pytest-probatio/src/pytest_probatio/plugin.py
+++ b/packages/pytest-probatio/src/pytest_probatio/plugin.py
@@ -1,0 +1,150 @@
+"""Use a probatio schema as a pytest assertion matcher.
+
+``assert response == S({"name": str, "port": Port()})`` validates ``response``
+against the schema. On a mismatch, pytest's assertion rewriting calls the
+``pytest_assertrepr_compare`` hook below, which renders each probatio error by its
+path, so the failure points at the exact offending value instead of a bare
+``assert ... == ...``.
+
+Three matchers are exposed, mirroring pytest-voluptuous so the move is familiar:
+
+- ``S(schema)``: extra dict keys make it unequal; ``<=`` relaxes that to a partial
+  match (extra keys allowed).
+- ``Partial(schema)``: a partial match under ``==`` (extra keys allowed).
+- ``Exact(schema)``: a strict match under ``==`` (the default ``S`` behavior, named
+  for clarity at a nested position).
+
+This lives outside the ``probatio`` package on purpose: the core library is
+dependency-free, and a pytest plugin is a test-framework concern.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from probatio import ALLOW_EXTRA, PREVENT_EXTRA, Invalid, MultipleInvalid, Schema
+
+
+def _compile(schema: typing.Any, extra: int) -> Schema:
+    """Return ``schema`` as a ``Schema`` with the given extra-key policy.
+
+    A ready-made ``Schema`` is used as-is (its own ``extra`` is respected); anything
+    else is wrapped with the requested policy.
+    """
+    if isinstance(schema, Schema):
+        return schema
+    return Schema(schema, extra=extra)
+
+
+class _Matcher:
+    """A schema that compares equal to data validating against it.
+
+    ``__eq__`` runs the schema and records the errors, so the assertion hook can
+    show them. It is not hashable (the recorded errors make it mutable), which also
+    keeps it out of places that expect a stable hash.
+    """
+
+    __slots__ = ("_errors", "_loose", "_strict", "_strict_eq")
+
+    def __init__(self, schema: typing.Any, *, partial: bool) -> None:
+        """Build the strict and partial schemas; ``partial`` picks which ``==`` uses."""
+        self._strict = _compile(schema, PREVENT_EXTRA)
+        self._loose = _compile(schema, ALLOW_EXTRA)
+        # ``Partial`` validates loosely under ``==``; ``S``/``Exact`` validate strictly.
+        self._strict_eq = not partial
+        self._errors: list[Invalid] = []
+
+    @property
+    def errors(self) -> list[Invalid]:
+        """The probatio errors from the most recent comparison (empty if it matched)."""
+        return self._errors
+
+    def _run(self, data: typing.Any, schema: Schema) -> bool:
+        """Validate ``data``, recording any errors, returning whether it matched."""
+        try:
+            schema(data)
+        except MultipleInvalid as exc:
+            self._errors = list(exc.errors)
+            return False
+        except Invalid as exc:
+            self._errors = [exc]
+            return False
+        self._errors = []
+        return True
+
+    def __eq__(self, data: object) -> bool:
+        """Whether ``data`` validates (strictly for ``S``/``Exact``, loosely for ``Partial``)."""
+        return self._run(data, self._strict if self._strict_eq else self._loose)
+
+    def __ne__(self, data: object) -> bool:
+        """Return the negation of ``__eq__``."""
+        return not self.__eq__(data)
+
+    def __le__(self, data: object) -> bool:
+        """Return a partial match: ``data`` validates with extra keys allowed."""
+        return self._run(data, self._loose)
+
+    def __ge__(self, data: object) -> bool:
+        """Support the reversed ``data <= matcher`` form (also a partial match)."""
+        return self._run(data, self._loose)
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        """Render with the underlying schema, so a failing assert reads clearly."""
+        return f"{type(self).__name__}({self._strict.schema!r})"
+
+
+class S(_Matcher):
+    """A schema matcher: ``==`` is a strict match, ``<=`` a partial one."""
+
+    def __init__(self, schema: typing.Any) -> None:
+        """Wrap ``schema`` as a strict-by-equality matcher."""
+        super().__init__(schema, partial=False)
+
+
+class Partial(_Matcher):
+    """A schema matcher whose ``==`` allows extra keys (a partial match)."""
+
+    def __init__(self, schema: typing.Any) -> None:
+        """Wrap ``schema`` as a partial-by-equality matcher."""
+        super().__init__(schema, partial=True)
+
+
+class Exact(_Matcher):
+    """A schema matcher whose ``==`` requires an exact match (no extra keys)."""
+
+    def __init__(self, schema: typing.Any) -> None:
+        """Wrap ``schema`` as a strict-by-equality matcher."""
+        super().__init__(schema, partial=False)
+
+
+def _format_path(path: list[typing.Any]) -> str:
+    """Render an error path as ``data['a'][0]``, or ``<root>`` when empty."""
+    if not path:
+        return "<root>"
+    return "data" + "".join(f"[{segment!r}]" for segment in path)
+
+
+def pytest_assertrepr_compare(
+    op: str,
+    left: object,
+    right: object,
+) -> list[str] | None:
+    """Explain a failed schema comparison by listing each error with its path."""
+    if op not in ("==", "!=", "<=", ">="):
+        return None
+    if isinstance(left, _Matcher):
+        matcher: _Matcher = left
+    elif isinstance(right, _Matcher):
+        matcher = right
+    else:
+        return None
+    lines = [f"data does not match the probatio schema ({op}):"]
+    if not matcher.errors:
+        lines.append("  (the schema matched; the assertion was negated)")
+    lines.extend(
+        f"  {_format_path(error.path)}: {error.error_message or str(error)}"
+        for error in matcher.errors
+    )
+    return lines

--- a/packages/pytest-probatio/tests/conftest.py
+++ b/packages/pytest-probatio/tests/conftest.py
@@ -1,0 +1,3 @@
+"""Enable the pytester fixture for the end-to-end plugin test."""
+
+pytest_plugins = ["pytester"]

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -43,6 +43,21 @@ def test_le_operator_is_a_partial_match() -> None:
     assert Exact({"name": str}) <= {"name": "app", "extra": 1}
 
 
+def test_ge_operator_is_a_reversed_partial_match() -> None:
+    """Data on the left of <= reaches __ge__, still a partial match (extra keys allowed)."""
+    assert {"name": "app", "extra": 1} <= Exact({"name": str})
+
+
+def test_assertrepr_hook_explains_partial_match_operators() -> None:
+    """The hook renders explanations for the <= and >= operators, not just ==/!=."""
+    matcher = Exact({"port": Port()})
+    matcher <= {"port": "nope"}  # noqa: B015 - run the comparison to record errors
+    for op in ("<=", ">="):
+        lines = pytest_assertrepr_compare(op, matcher, {"port": "nope"})
+        assert lines is not None
+        assert any("data['port']" in line for line in lines)
+
+
 def test_matcher_records_errors_with_paths() -> None:
     """A failed comparison records probatio errors carrying the offending path."""
     matcher = Exact({"server": {"port": Port()}})

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pytest_probatio import Exact, Partial, S
+from pytest_probatio import Exact, Partial
 from pytest_probatio.plugin import pytest_assertrepr_compare
 
 from probatio import Port
@@ -10,17 +10,17 @@ from probatio import Port
 
 def test_strict_match_passes() -> None:
     """A value matching the schema exactly compares equal."""
-    assert {"name": "app", "port": 8080} == S({"name": str, "port": Port()})
+    assert {"name": "app", "port": 8080} == Exact({"name": str, "port": Port()})
 
 
 def test_strict_match_rejects_extra_keys() -> None:
-    """An extra key makes a strict S matcher unequal."""
-    assert {"name": "app", "extra": 1} != S({"name": str})
+    """An extra key makes an Exact matcher unequal."""
+    assert {"name": "app", "extra": 1} != Exact({"name": str})
 
 
 def test_strict_match_rejects_a_bad_value() -> None:
     """A value of the wrong type compares unequal."""
-    assert {"port": "nope"} != S({"port": Port()})
+    assert {"port": "nope"} != Exact({"port": Port()})
 
 
 def test_partial_allows_extra_keys() -> None:
@@ -29,19 +29,13 @@ def test_partial_allows_extra_keys() -> None:
 
 
 def test_le_operator_is_a_partial_match() -> None:
-    """The <= operator relaxes S to a partial match (extra keys allowed)."""
-    assert S({"name": str}) <= {"name": "app", "extra": 1}
-
-
-def test_exact_requires_no_extra_keys() -> None:
-    """Exact behaves strictly under ==, like S."""
-    assert {"a": 1} == Exact({"a": int})
-    assert {"a": 1, "b": 2} != Exact({"a": int})
+    """The <= operator relaxes Exact to a partial match (extra keys allowed)."""
+    assert Exact({"name": str}) <= {"name": "app", "extra": 1}
 
 
 def test_matcher_records_errors_with_paths() -> None:
     """A failed comparison records probatio errors carrying the offending path."""
-    matcher = S({"server": {"port": Port()}})
+    matcher = Exact({"server": {"port": Port()}})
     assert {"server": {"port": 70000}} != matcher
     assert matcher.errors
     assert matcher.errors[0].path == ["server", "port"]
@@ -49,7 +43,7 @@ def test_matcher_records_errors_with_paths() -> None:
 
 def test_assertrepr_hook_lists_errors_by_path() -> None:
     """The pytest hook renders each error as a path and message."""
-    matcher = S({"port": Port()})
+    matcher = Exact({"port": Port()})
     matcher == {"port": "nope"}  # noqa: B015 - run the comparison to record errors
     lines = pytest_assertrepr_compare("==", matcher, {"port": "nope"})
     assert lines is not None
@@ -66,22 +60,22 @@ def test_matcher_is_unhashable() -> None:
     import pytest  # noqa: PLC0415
 
     with pytest.raises(TypeError):
-        hash(S({"a": int}))
+        hash(Exact({"a": int}))
 
 
 def test_plugin_explains_a_failed_assertion_end_to_end(pytester) -> None:
-    """A failing `data == S(...)` under pytest shows the schema error, via the hook.
+    """A failing `data == Exact(...)` under pytest shows the schema error, via the hook.
 
     This exercises the registered pytest11 plugin, not just the hook function: the
     entry point must be active for the explanation to appear in a real run.
     """
     pytester.makepyfile(
         """
-        from pytest_probatio import S
+        from pytest_probatio import Exact
         from probatio import Port
 
         def test_response():
-            assert {"port": "nope"} == S({"port": Port()})
+            assert {"port": "nope"} == Exact({"port": Port()})
         """
     )
     result = pytester.runpytest()

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -1,0 +1,91 @@
+"""Tests for the probatio schema matchers and the assertion-explaining hook."""
+
+from __future__ import annotations
+
+from pytest_probatio import Exact, Partial, S
+from pytest_probatio.plugin import pytest_assertrepr_compare
+
+from probatio import Port
+
+
+def test_strict_match_passes() -> None:
+    """A value matching the schema exactly compares equal."""
+    assert {"name": "app", "port": 8080} == S({"name": str, "port": Port()})
+
+
+def test_strict_match_rejects_extra_keys() -> None:
+    """An extra key makes a strict S matcher unequal."""
+    assert {"name": "app", "extra": 1} != S({"name": str})
+
+
+def test_strict_match_rejects_a_bad_value() -> None:
+    """A value of the wrong type compares unequal."""
+    assert {"port": "nope"} != S({"port": Port()})
+
+
+def test_partial_allows_extra_keys() -> None:
+    """Partial accepts extra keys under ==."""
+    assert {"name": "app", "extra": 1} == Partial({"name": str})
+
+
+def test_le_operator_is_a_partial_match() -> None:
+    """The <= operator relaxes S to a partial match (extra keys allowed)."""
+    assert S({"name": str}) <= {"name": "app", "extra": 1}
+
+
+def test_exact_requires_no_extra_keys() -> None:
+    """Exact behaves strictly under ==, like S."""
+    assert {"a": 1} == Exact({"a": int})
+    assert {"a": 1, "b": 2} != Exact({"a": int})
+
+
+def test_matcher_records_errors_with_paths() -> None:
+    """A failed comparison records probatio errors carrying the offending path."""
+    matcher = S({"server": {"port": Port()}})
+    assert {"server": {"port": 70000}} != matcher
+    assert matcher.errors
+    assert matcher.errors[0].path == ["server", "port"]
+
+
+def test_assertrepr_hook_lists_errors_by_path() -> None:
+    """The pytest hook renders each error as a path and message."""
+    matcher = S({"port": Port()})
+    matcher == {"port": "nope"}  # noqa: B015 - run the comparison to record errors
+    lines = pytest_assertrepr_compare("==", matcher, {"port": "nope"})
+    assert lines is not None
+    assert any("data['port']" in line for line in lines)
+
+
+def test_assertrepr_hook_ignores_unrelated_comparisons() -> None:
+    """The hook returns None when neither side is a matcher (no interference)."""
+    assert pytest_assertrepr_compare("==", 1, 2) is None
+
+
+def test_matcher_is_unhashable() -> None:
+    """The matcher is not hashable, since it records mutable error state."""
+    import pytest  # noqa: PLC0415
+
+    with pytest.raises(TypeError):
+        hash(S({"a": int}))
+
+
+def test_plugin_explains_a_failed_assertion_end_to_end(pytester) -> None:
+    """A failing `data == S(...)` under pytest shows the schema error, via the hook.
+
+    This exercises the registered pytest11 plugin, not just the hook function: the
+    entry point must be active for the explanation to appear in a real run.
+    """
+    pytester.makepyfile(
+        """
+        from pytest_probatio import S
+        from probatio import Port
+
+        def test_response():
+            assert {"port": "nope"} == S({"port": Port()})
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    output = result.stdout.str()
+    assert "does not match the probatio schema" in output
+    assert "data['port']" in output

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -28,6 +28,16 @@ def test_partial_allows_extra_keys() -> None:
     assert {"name": "app", "extra": 1} == Partial({"name": str})
 
 
+def test_accepts_a_prebuilt_schema() -> None:
+    """A ready-made Schema can be reused; Exact/Partial still govern extra keys."""
+    from probatio import Schema  # noqa: PLC0415
+
+    user = Schema({"id": int, "name": str})
+    assert {"id": 1, "name": "ada"} == Exact(user)
+    assert {"id": 1, "name": "ada", "extra": 1} != Exact(user)
+    assert {"id": 1, "name": "ada", "extra": 1} == Partial(user)
+
+
 def test_le_operator_is_a_partial_match() -> None:
     """The <= operator relaxes Exact to a partial match (extra keys allowed)."""
     assert Exact({"name": str}) <= {"name": "app", "extra": 1}

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -65,6 +65,17 @@ def test_assertrepr_hook_ignores_unrelated_comparisons() -> None:
     assert pytest_assertrepr_compare("==", 1, 2) is None
 
 
+def test_assertrepr_hook_explains_a_failed_negation() -> None:
+    """A failed `!=` (the data did match) gets a clear, non-contradictory message."""
+    matcher = Exact({"id": int})
+    matcher != {"id": 1}  # noqa: B015 - the data matches, so != fails; records no errors
+    lines = pytest_assertrepr_compare("!=", matcher, {"id": 1})
+    assert lines is not None
+    assert lines == [
+        "data matches the probatio schema, but the assertion (!=) required it not to"
+    ]
+
+
 def test_matcher_is_unhashable() -> None:
     """The matcher is not hashable, since it records mutable error state."""
     import pytest  # noqa: PLC0415

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ fast = ["orjson", "yamlrocks>=0.5.0"]
 yaml = ["PyYAML"]
 toml = ["tomli-w"]
 
+# The repository is a uv workspace: the core `probatio` package at the root, plus
+# separately published companion packages under `packages/`. They share one repo,
+# CI, and issue tracker, but each ships as its own distribution, so the core stays
+# dependency-free.
+[tool.uv.workspace]
+members = ["packages/*"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/probatio"]
 
@@ -148,6 +155,18 @@ ignore = [
 # FBT003: hypothesis's assume(False) takes a positional boolean by design.
 # DTZ001: naive datetimes are intentional fixtures (coercion tests, not tz logic).
 "tests/**" = ["S101", "SLF001", "PLR2004", "ANN", "D", "PLR0911", "FBT003", "DTZ001"]
+# The pytest-probatio matcher tests compare data on the left of a schema
+# (`data == S(...)`), which is the point of the API, not a Yoda condition (SIM300);
+# the tests directory is a plain pytest layout with no __init__.py (INP001).
+"packages/*/tests/**" = [
+  "S101",
+  "SLF001",
+  "ANN",
+  "D",
+  "PLR2004",
+  "SIM300",
+  "INP001",
+]
 # Benchmarks print results, time tiny throwaway callables, and are a script
 # directory rather than an importable package.
 "bench/**" = ["T201", "S101", "ANN", "D", "INP001"]
@@ -220,7 +239,12 @@ fail_under = 100
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-q --cov"
+# The pytest-probatio companion plugin (a workspace package) imports probatio at
+# plugin-load time, before pytest-cov starts, which would read probatio's
+# import-time code as uncovered. Disable it for the core suite; the package's own
+# tests run with `-o addopts=""`, so they still load it. The flag is a no-op when
+# the plugin is not installed.
+addopts = "-q --cov -p no:probatio"
 
 [tool.mypy]
 python_version = "3.13"

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -115,7 +115,11 @@ class Contains(_SafeValidator):
         """Return the value if it contains the item, else ContainsInvalid."""
         try:
             present = self.item in value
-        except (TypeError, ArithmeticError) as exc:
+        except (TypeError, ArithmeticError, AttributeError) as exc:
+            # ``in`` calls the container's ``__contains__``, which can raise more
+            # than TypeError: an ``ipaddress`` network checks ``other._version``,
+            # so ``5 in ip_network(...)`` raises AttributeError. Treat any such
+            # mismatch as "not a collection that contains the item".
             message = self.msg or "value is not a collection"
             raise ContainsInvalid(message) from exc
         if not present:

--- a/tests/validators/test_comparison.py
+++ b/tests/validators/test_comparison.py
@@ -82,6 +82,15 @@ def test_contains_on_non_collection() -> None:
     assert isinstance(caught.value.errors[0], ContainsInvalid)
 
 
+def test_contains_when_membership_raises_attributeerror() -> None:
+    """Contains stays clean when ``__contains__`` itself errors (ip_network)."""
+    import ipaddress  # noqa: PLC0415
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Contains(5))(ipaddress.ip_network("10.0.0.0/8"))
+    assert isinstance(caught.value.errors[0], ContainsInvalid)
+
+
 def test_range_accepts_and_rejects() -> None:
     """Range passes values in bounds and rejects values outside them."""
     assert Schema(Range(min=0, max=10))(5) == 5

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,12 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[manifest]
+members = [
+    "probatio",
+    "pytest-probatio",
+]
+
 [[package]]
 name = "ast-serialize"
 version = "0.5.0"
@@ -541,6 +547,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-probatio"
+version = "0.0.0"
+source = { editable = "packages/pytest-probatio" }
+dependencies = [
+    { name = "probatio" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "probatio", editable = "." },
+    { name = "pytest", specifier = ">=8" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. The core `probatio` package, its public API, and its dependency footprint are unchanged. This adds a separate distribution alongside it.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Turns the repository into a uv workspace: the core `probatio` package stays at the root, and a companion package `pytest-probatio` is added under `packages/`. The companion lets a probatio schema act as a pytest assertion matcher, inspired by pytest-voluptuous:

```python
from pytest_probatio import Exact, Partial

assert response == Exact({"name": str, "port": Port()})   # exact: no extra keys
assert response == Partial({"name": str})                 # extra keys allowed
assert Exact({"name": str}) <= response                   # partial via <=
```

A mismatch is explained by probatio's path-precise errors through a `pytest_assertrepr_compare` hook, instead of a bare assertion:

```
data does not match the probatio schema (==):
  data['port']: expected a port number between 1 and 65535
```

Why a workspace rather than the core package: a pytest plugin needs pytest and registers a `pytest11` entry point, which is a test-framework concern. Keeping it a separate distribution preserves the core's dependency-free posture (ADR-005) while sharing one repo, CI, and issue tracker. The plugin pins `probatio` as a workspace source, so it always builds against the in-repo core.

One coverage subtlety: the plugin imports `probatio` at pytest-startup (its entry point), before pytest-cov begins, which would read probatio's import-time code as uncovered. The core suite disables it with `-p no:probatio` in `addopts`; the package's own tests run with `-o addopts=""`, so they still load it.

Publishing is wired into `release.yaml`: a release stamps both packages with the tag version, builds with `uv build --all-packages`, and publishes both lock-step. Before the first release that includes it, the `pytest-probatio` PyPI project needs a trusted publisher configured (registerable now as a pending publisher) for this repo, `release.yaml`, and the `release` environment, otherwise the publish step would be rejected with a 403.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
