### PR TITLE
Run atheris fuzzers in CI on Python 3.13, fix the leaks it found

### DIFF
--- a/.github/workflows/clusterfuzzlite.yaml
+++ b/.github/workflows/clusterfuzzlite.yaml
@@ -5,23 +5,31 @@
 
 name: ClusterFuzzLite
 
+# Automatic triggers are disabled until oss-fuzz ships a Python 3.13 base image.
+#
+# ClusterFuzzLite builds in oss-fuzz's `base-builder-python` image, which ships
+# Python 3.11. Probatio requires Python >=3.13, so the package will not install in
+# the container and every fuzz build errors out. atheris is tied to the base
+# image's interpreter, so the container cannot be made to run 3.13.
+#
+# In the meantime the harnesses are fuzzed by the `Fuzz` workflow (fuzz.yaml),
+# which runs atheris directly on Python 3.13. This workflow stays for its
+# coverage-guided, corpus-persisting batch mode (an oss-fuzz feature the plain
+# atheris job lacks); restore the `pull_request` and `schedule` triggers below,
+# verifying with `workflow_dispatch` first, once a 3.13 base image is available.
+#
 # yamllint disable-line rule:truthy
 on:
-  # On pull requests, fuzz only when code that can affect the harnesses actually
-  # changes. Docs, badge, and dependency-only PRs cannot reach the decoder, so
-  # they skip the (slow) Docker build + fuzz run entirely.
-  pull_request:
-    paths:
-      - "src/**"
-      - "fuzz/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".clusterfuzzlite/**"
-      - ".github/workflows/clusterfuzzlite.yaml"
-  # The deep, coverage-guided fuzzing runs on a schedule against an accumulated
-  # corpus, where bugs actually surface; a short per-PR run cannot.
-  schedule:
-    - cron: "0 4 * * *" # daily, 04:00 UTC
+  # pull_request:
+  #   paths:
+  #     - "src/**"
+  #     - "fuzz/**"
+  #     - "pyproject.toml"
+  #     - "uv.lock"
+  #     - ".clusterfuzzlite/**"
+  #     - ".github/workflows/clusterfuzzlite.yaml"
+  # schedule:
+  #   - cron: "0 4 * * *" # daily, 04:00 UTC
   workflow_dispatch:
 
 # Cancel superseded runs for the same ref to save CI minutes.

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,78 @@
+---
+name: Fuzz
+
+# yamllint disable-line rule:truthy
+on:
+  # Fuzz only when code that can reach a harness actually changes; docs and badge
+  # PRs cannot, so they skip the run.
+  pull_request:
+    paths:
+      - "src/**"
+      - "fuzz/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/fuzz.yaml"
+  # A longer nightly sweep, where a regression has more time to surface.
+  schedule:
+    - cron: "0 4 * * *" # daily, 04:00 UTC
+  workflow_dispatch:
+
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Run each atheris harness on a real Python 3.13 interpreter. The oss-fuzz path
+  # (ClusterFuzzLite) cannot: its base image ships Python 3.11, and probatio
+  # requires >=3.13, so the package will not install there. atheris itself runs
+  # fine on 3.13, which is also how the harnesses are fuzzed locally.
+  atheris:
+    name: Fuzz ${{ matrix.harness }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        harness:
+          - fuzz_schema
+          - fuzz_from_json_schema
+          - fuzz_serde
+          - fuzz_is_catastrophic
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up uv and Python 3.13
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+      - name: 🚀 Fuzz ${{ matrix.harness }}
+        # A short run per pull request to catch regressions; a longer one on the
+        # nightly schedule. atheris and the package are installed into an isolated
+        # ephemeral environment, so nothing here depends on the locked dev set. The
+        # workflow-controlled values go through env, not the run string directly.
+        env:
+          HARNESS: ${{ matrix.harness }}
+          MAX_TIME: ${{ github.event_name == 'pull_request' && 60 || 600 }}
+        run: >
+          uv run --no-project --isolated --python 3.13
+          --with 'atheris==3.1.0' --with-editable '.[fast,yaml,toml]'
+          python "fuzz/${HARNESS}.py"
+          -max_total_time="${MAX_TIME}"
+          -artifact_prefix=./
+      - name: ⬆️ Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crash-${{ matrix.harness }}
+          path: |
+            ./crash-*
+            ./oom-*
+            ./timeout-*
+            ./leak-*
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ Desktop.ini
 *.orig
 *.rej
 
+# --- Fuzzing crash artifacts (libFuzzer/atheris) ---
+crash-*
+oom-*
+timeout-*
+leak-*
+
 # voluptuous's own test suite, copied in for the drop-in proof (BSD-licensed,
 # not vendored). See compat/voluptuous/README.md.
 compat/voluptuous/tests.py

--- a/justfile
+++ b/justfile
@@ -64,6 +64,20 @@ codspeed:
 examples:
     uv run --no-sync python docs/verify_examples.py
 
+# Fuzz the atheris harnesses (each for `seconds`, default 30). Runs on an isolated
+# Python 3.13 env: atheris has no 3.14 wheel, and the oss-fuzz CI image is 3.11, so
+# this is the path that actually exercises the harnesses. A crash fails the recipe
+# and leaves a gitignored crash-* file to reproduce.
+fuzz seconds='30':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for harness in fuzz/fuzz_*.py; do
+      echo "=== ${harness} ({{seconds}}s) ==="
+      uv run --no-project --isolated --python 3.13 \
+        --with 'atheris==3.1.0' --with-editable '.[fast,yaml,toml]' \
+        python "${harness}" -max_total_time={{seconds}} -artifact_prefix=./
+    done
+
 # Run Home Assistant's config_validation suite against probatio (set HOME_ASSISTANT_CORE to a core checkout).
 ha-proof:
     #!/usr/bin/env bash

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -443,8 +443,22 @@ def from_openapi(schema: dict[str, Any]) -> Schema:
 
 
 def _decode(schema: dict[str, Any], *, openapi: bool) -> Schema:
-    """Run a decode from the root schema, wrapping the result in a Schema."""
-    node = _from_node(schema, _Decode(root=schema, openapi=openapi))
+    """Run a decode from the root schema, wrapping the result in a Schema.
+
+    The schema is untrusted, and exhaustively type-checking every field of an
+    arbitrary document is impractical, so the decode fails closed: a structural
+    mismatch a specific check did not already catch (a bool where a list was
+    expected, an unhashable ``format``, and the like) is converted to a clean
+    ``SchemaError`` rather than leaking the raw ``TypeError``/``AttributeError``.
+    A ``SchemaError`` a specific check raised keeps its own message.
+    """
+    try:
+        node = _from_node(schema, _Decode(root=schema, openapi=openapi))
+    except SchemaError:
+        raise
+    except (TypeError, AttributeError, KeyError, IndexError, ValueError) as exc:
+        message = f"could not decode the schema; it is malformed: {exc}"
+        raise SchemaError(message) from exc
     return node if isinstance(node, Schema) else Schema(node)
 
 
@@ -964,7 +978,10 @@ def _from_string(node: dict[str, Any]) -> Any:
     ``contentEncoding: base64`` becomes ``Base64`` (so a ``Base64`` round-trips);
     everything else stays a plain string with the length and pattern constraints.
     """
-    base = _FROM_FORMATS.get(node.get("format", ""), str)
+    # ``format`` comes from an untrusted document; a non-string value (a dict, say)
+    # is not a hashable lookup key and is not a known format, so treat it as absent.
+    fmt = node.get("format", "")
+    base = _FROM_FORMATS.get(fmt, str) if isinstance(fmt, str) else str
     if base is str and (
         node.get("contentEncoding") == "base64" or node.get("format") == "byte"
     ):

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -252,7 +252,10 @@ def _oa_callable(node: Any, custom: Any, version: str) -> dict[str, Any]:
             node if isroutine(node) or isinstance(node, type) else node.__call__
         )
         params = list(signature(node).parameters.keys())
-    except (TypeError, NameError):
+    except (TypeError, NameError, ValueError):
+        # ValueError: a builtin type with no introspectable signature (``bytes``,
+        # ``object``, ...). voluptuous-openapi leaks this; probatio falls back to an
+        # open schema rather than crash, keeping the codec leak-free.
         return {}
     hint = hints.get(params[0], Any) if params else Any
     if hint is Any or isinstance(hint, TypeVar):

--- a/src/probatio/validators/network.py
+++ b/src/probatio/validators/network.py
@@ -34,6 +34,15 @@ def _reject_bool(value: typing.Any) -> typing.Any:
     return value
 
 
+# CPython's ``ipaddress`` parsers are fragile on hostile input: besides the
+# expected ValueError/TypeError, a crafted value can reach an IndexError (an empty
+# tuple) or an AttributeError (``'NoneType' object has no attribute 'isascii'`` from
+# the prefix parser). A safe validator may only raise ``Invalid``, so every parse
+# failure is funnelled through this tuple. The wrapped call is a single stdlib
+# function on the value, so this cannot mask a bug in probatio's own code.
+_IP_PARSE_ERRORS = (ValueError, TypeError, IndexError, AttributeError)
+
+
 class IPv4Address(_SafeValidator):
     """Validate an IPv4 address, returning an ``ipaddress.IPv4Address``."""
 
@@ -45,7 +54,7 @@ class IPv4Address(_SafeValidator):
         """Return the parsed address, else raise IpInvalid."""
         try:
             return ipaddress.IPv4Address(_reject_bool(value))
-        except (ValueError, TypeError) as exc:
+        except _IP_PARSE_ERRORS as exc:
             raise IpInvalid(self.msg or "expected an IPv4 address") from exc
 
 
@@ -60,7 +69,7 @@ class IPv6Address(_SafeValidator):
         """Return the parsed address, else raise IpInvalid."""
         try:
             return ipaddress.IPv6Address(_reject_bool(value))
-        except (ValueError, TypeError) as exc:
+        except _IP_PARSE_ERRORS as exc:
             raise IpInvalid(self.msg or "expected an IPv6 address") from exc
 
 
@@ -78,7 +87,7 @@ class IPAddress(_SafeValidator):
         """Return the parsed address (v4 or v6), else raise IpInvalid."""
         try:
             return ipaddress.ip_address(_reject_bool(value))
-        except (ValueError, TypeError) as exc:
+        except _IP_PARSE_ERRORS as exc:
             raise IpInvalid(self.msg or "expected an IP address") from exc
 
 
@@ -100,9 +109,7 @@ class IPNetwork(_SafeValidator):
         """Return the parsed network, else raise IpInvalid."""
         try:
             return ipaddress.ip_network(_reject_bool(value), strict=False)
-        except (ValueError, TypeError, IndexError) as exc:
-            # An empty tuple makes ``ip_network`` raise IndexError; treat it, like
-            # any malformed input, as a clean rejection.
+        except _IP_PARSE_ERRORS as exc:
             raise IpInvalid(self.msg or "expected a CIDR network") from exc
 
 

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -666,3 +666,26 @@ def test_malformed_keyword_values_fail_closed(node: dict[str, object]) -> None:
     """
     with pytest.raises(SchemaError):
         from_json_schema(node)
+
+
+def test_non_string_format_is_ignored_not_a_leak() -> None:
+    """A malformed (non-string) ``format`` is treated as absent, not a TypeError.
+
+    ``_FROM_FORMATS.get(<dict>)`` would raise ``unhashable type``; the decoder
+    treats the bad hint as no format and still decodes a plain string. Found by the
+    atheris fuzz harness.
+    """
+    schema = from_json_schema({"type": "string", "format": {}})
+    assert schema("hello") == "hello"
+
+
+def test_structurally_malformed_schema_fails_closed() -> None:
+    """A malformed untrusted schema raises SchemaError, never a leaked TypeError.
+
+    Exhaustively type-checking every field is impractical, so the decoder fails
+    closed: a structural mismatch a specific check did not catch (a bool where an
+    array is expected) becomes a clean SchemaError. Found by the atheris fuzz
+    harness.
+    """
+    with pytest.raises(SchemaError, match="malformed"):
+        from_json_schema({"type": "array", "items": {"anyOf": True}})

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -140,6 +140,16 @@ def test_unrecognized_value_is_open() -> None:
     assert to_openapi(Schema(object())) == {}
 
 
+def test_signatureless_builtin_type_does_not_leak() -> None:
+    """A builtin type with no introspectable signature falls back, not crashes.
+
+    ``inspect.signature(bytes)`` raises ValueError; voluptuous-openapi leaks it.
+    Probatio must keep the codec leak-free and render an open schema instead. Found
+    by the atheris fuzz harness.
+    """
+    assert to_openapi(Schema(bytes)) == {}
+
+
 def test_merging_enums_with_unhashable_members_does_not_leak() -> None:
     """Same-typed enum branches with list members merge and dedup without a TypeError."""
     schema = Schema(probatio.Any(probatio.In([[1, 2]]), probatio.In([[1, 2], [3, 4]])))

--- a/tests/validators/test_network.py
+++ b/tests/validators/test_network.py
@@ -73,6 +73,22 @@ def test_ip_network_rejects_a_bad_value() -> None:
         Schema(IPNetwork())("nope")
 
 
+@pytest.mark.parametrize(
+    "validator",
+    [IPNetwork, IPAddress, IPv4Address, IPv6Address],
+)
+def test_ip_validators_do_not_leak_on_hostile_input(validator: type) -> None:
+    """A crafted value makes ``ipaddress`` raise odd errors; only Invalid may escape.
+
+    ``ip_network('a/\\x00')`` reaches an ``AttributeError`` ('NoneType' has no
+    attribute 'isascii') deep in CPython's prefix parser. A safe validator must turn
+    that into ``Invalid``, not leak it. Found by the atheris fuzz harness.
+    """
+    for hostile in ("1.2.3.4/\x00", "::/\x00", "a\x00b", "/", "1/2/3"):
+        with pytest.raises(MultipleInvalid):
+            Schema(validator())(hostile)
+
+
 def test_hostname_accepts_a_single_label() -> None:
     """A bare label like localhost is a valid hostname."""
     assert Schema(Hostname())("localhost") == "localhost"


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. The fixes only change how malformed or hostile input is handled: where the codecs and IP validators previously leaked a raw `TypeError`/`AttributeError`/`ValueError`, they now fall back or raise a clean `SchemaError`/`Invalid`. Valid input is unaffected.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

ClusterFuzzLite cannot fuzz this project: oss-fuzz's `base-builder-python` image ships Python 3.11, and probatio requires `>=3.13`, so `pip install .` fails in the container and every fuzz build errors out. atheris itself runs fine on 3.13 (that is how the harnesses are fuzzed locally), so this adds a `Fuzz` workflow that runs the four harnesses directly on Python 3.13, per pull request (short) and nightly (longer), in an isolated ephemeral environment. The clusterfuzzlite auto-triggers are disabled with a note, keeping it dispatchable for its coverage-guided batch mode once a 3.13 base image exists.

Running them immediately surfaced four leaks on the untrusted-input boundary, all fixed here with regression tests:

- `to_openapi(Schema(bytes))` leaked a `ValueError` from `inspect.signature` on a builtin type with no introspectable signature; it now falls back to an open schema (voluptuous-openapi has the same bug).
- `from_json_schema` with a non-string `format` leaked a `TypeError: unhashable type`; the malformed hint is treated as absent.
- The JSON Schema decoder now **fails closed**: a structural mismatch a specific check did not catch (a bool where an array is expected, say) becomes a clean `SchemaError` instead of leaking a raw `TypeError`/`AttributeError`. Exhaustively type-checking every field of an arbitrary document is impractical, so this is the right contract for an untrusted-input decoder.
- The four IP validators leaked an `AttributeError` (`'NoneType' object has no attribute 'isascii'`) from CPython's `ipaddress` prefix parser on crafted input; a shared exception tuple keeps only `Invalid` escaping.

After the fixes every harness fuzzes clean (637k / 215k / 160k / 1.1M runs, no crash). A `just fuzz [seconds]` recipe runs them locally on an isolated 3.13 environment.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: the pytest-probatio PR (#3); this should merge first so #3 runs the new atheris job rather than the broken oss-fuzz one
- Link to a separate documentation pull request: None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->