### PR TITLE
Fix OpenAPI encoder emitting date-time for Date()

### DIFF
--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -29,6 +29,7 @@ from probatio.validators import (
     Capitalize,
     Clamp,
     Coerce,
+    Date,
     Datetime,
     Email,
     FqdnUrl,
@@ -279,9 +280,11 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
         return _oa_range(node)
     if isinstance(node, Length):
         return _oa_length(node)
-    # Time subclasses Datetime, so it must be matched before the Datetime branch.
+    # Date and Time subclass Datetime, so they must be matched before it.
     if isinstance(node, Time):
         return {"type": "string", "format": "time"}
+    if isinstance(node, Date):
+        return {"type": "string", "format": "date"}
     if isinstance(node, Datetime):
         return {"type": "string", "format": "date-time"}
     if isinstance(node, Match):

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -22,6 +22,7 @@ from probatio import (
     UUID,
     Alpha,
     Base64,
+    Date,
     Fqdn,
     Hostname,
     IPAddress,
@@ -293,6 +294,11 @@ def test_bare_callable_with_unresolvable_annotation_is_open_schema() -> None:
 def test_new_validators_to_openapi(validator: object, expected: dict) -> None:
     """The probatio-only validators render their OpenAPI fragment (no oracle)."""
     assert to_openapi(Schema(validator)) == expected
+
+
+def test_date_is_not_exported_as_datetime() -> None:
+    """Date (a Datetime subclass) exports format date, not date-time."""
+    assert to_openapi(Schema(Date())) == {"type": "string", "format": "date"}
 
 
 def test_new_string_validators_to_openapi() -> None:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. The OpenAPI output for `Date()` changes, but only from an incorrect value (`date-time`) to the correct one (`date`). Nothing depended on the wrong output.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`to_openapi` rendered a plain `Date()` as `{"type": "string", "format": "date-time"}` instead of `date`. The encoder matched `Time` then `Datetime`, but had no `Date` branch, and `Date` subclasses `Datetime`, so a date fell through to the datetime branch. The JSON Schema encoder already handled this correctly, so the two had drifted.

This adds the missing `Date` branch (before `Datetime`, like `Time`) and a regression test.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
