### PR TITLE
Add configurable normalization to typed string validators

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -201,7 +201,7 @@ from probatio import Schema, Alphanumeric, StartsWith, HexColor
 
 Schema(Alphanumeric())("abc123")     # 'abc123'
 Schema(StartsWith("https://"))("https://example.com")  # 'https://example.com'
-Schema(HexColor())("#ff8800")        # '#ff8800'
+Schema(HexColor())("#FF8800")        # '#ff8800' (normalized; upper=True for uppercase)
 ```
 
 :::tip
@@ -214,14 +214,17 @@ want to reject non-strings, put a `str` check ahead of the transform with `All`.
 A handful of validators check a structured format or a checksum, all pure (no
 network, no extra dependency): `CreditCard` (the Luhn check), `IBAN` (the ISO 13616
 mod-97 check), `DataURI` (an RFC 2397 `data:` URI), and `E164` (a phone number in
-international format). They validate and return the value unchanged.
+international format). By default `CreditCard`, `IBAN`, and `E164` canonicalize the
+input (strip grouping, upper-case the IBAN); pass `normalize=False` to validate and
+return the value unchanged.
 
 ```python
 from probatio import Schema, CreditCard, IBAN, E164
 
-Schema(CreditCard())("4242 4242 4242 4242")     # unchanged
-Schema(IBAN())("DE89 3704 0044 0532 0130 00")   # unchanged
-Schema(E164())("+14155552671")                  # unchanged
+Schema(CreditCard())("4242 4242 4242 4242")     # '4242424242424242'
+Schema(IBAN())("de89 3704 0044 0532 0130 00")   # 'DE89370400440532013000'
+Schema(E164())("+1 (415) 555-2671")             # '+14155552671'
+Schema(E164(normalize=False))("+14155552671")   # '+14155552671' (unchanged)
 ```
 
 These check shape, not existence: `CreditCard` confirms the Luhn checksum, not that
@@ -315,6 +318,18 @@ Schema(UUID())("12345678-1234-5678-1234-567812345678")
 Schema(MacAddress())("AA-BB-CC-DD-EE-FF")  # 'aa:bb:cc:dd:ee:ff'
 Schema(Port())("8080")  # 8080
 Schema(ULID())("01ARZ3NDEKTSV4RRFFQ69G5FAV")  # '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+```
+
+`MacAddress` normalizes to lowercase, colon-separated form by default. Pass
+`upper=True`, a different `separator` (`""` for bare hex), or `normalize=False`
+to validate without rewriting the input:
+
+```python
+from probatio import Schema, MacAddress
+
+Schema(MacAddress(upper=True))("aa-bb-cc-dd-ee-ff")  # 'AA:BB:CC:DD:EE:FF'
+Schema(MacAddress(separator="-"))("aabbccddeeff")  # 'aa-bb-cc-dd-ee-ff'
+Schema(MacAddress(normalize=False))("AA-BB-cc-dd-ee-ff")  # 'AA-BB-cc-dd-ee-ff'
 ```
 
 `IPNetwork` accepts host bits and normalizes to the network; `Hostname` takes a

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -200,7 +200,9 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
   with or ends with a fixed affix.
 - `ByteLength(min=None, max=None, msg=None)`: bound the UTF-8 byte length (not the
   code-point count).
-- `HexColor(msg=None)`: a hex color string (`#rgb` or `#rrggbb`).
+- `HexColor(normalize=True, upper=False, msg=None)`: a hex color string (`#rgb` or
+  `#rrggbb`), lower-cased by default (`upper=True` for uppercase, `normalize=False`
+  to leave it unchanged).
 
 </details>
 
@@ -252,7 +254,10 @@ coerce to their natural Python object; the format checks pass the string through
 - `IPAddress(msg=None)`: an IP address of either version.
 - `IPNetwork(msg=None)`: a CIDR network (host bits allowed), returned as an
   `ipaddress` network.
-- `MacAddress(msg=None)`: a MAC address, normalized to `aa:bb:cc:dd:ee:ff`.
+- `MacAddress(normalize=True, upper=False, separator=":", msg=None)`: a MAC
+  address, normalized to `aa:bb:cc:dd:ee:ff` by default. `upper=True` uppercases,
+  `separator=` sets the separator (`""` for bare hex), and `normalize=False`
+  returns the input unchanged.
 - `UUID(msg=None, version=None)`: a UUID, returned as `uuid.UUID`; `version` pins
   the version.
 - `ULID(msg=None)`: a ULID (26 Crockford base32 characters), normalized to upper
@@ -283,14 +288,18 @@ coerce to their natural Python object; the format checks pass the string through
   backend), optionally validating the decoded value.
 - `Base64(msg=None)`, `Hex(msg=None)`: validate a Base64 or hexadecimal string,
   returning it unchanged.
-- `CreditCard(msg=None)`: a credit card number that passes the Luhn checksum (12 to
-  19 digits, spaces or hyphens allowed).
-- `IBAN(msg=None)`: an IBAN that passes the ISO 13616 mod-97 checksum (spaces
-  allowed; the per-country length is not checked).
+- `CreditCard(normalize=True, msg=None)`: a credit card number that passes the Luhn
+  checksum (12 to 19 digits, spaces or hyphens allowed). Normalized to bare digits
+  by default; `normalize=False` returns the value unchanged.
+- `IBAN(normalize=True, msg=None)`: an IBAN that passes the ISO 13616 mod-97
+  checksum (spaces allowed; the per-country length is not checked). Normalized to
+  the compact, upper-cased form by default; `normalize=False` returns it unchanged.
 - `DataURI(msg=None)`: an RFC 2397 data URI (`data:[<mediatype>][;base64],<data>`),
   validating the Base64 payload when declared.
-- `E164(msg=None)`: a phone number in international E.164 format (`+` then up to 15
-  digits). A format check, not a check that the number is dialable.
+- `E164(normalize=True, msg=None)`: a phone number in international E.164 format
+  (`+` then up to 15 digits). A format check, not a check that the number is
+  dialable. Grouping characters are stripped by default; `normalize=False` rejects
+  them and returns the value unchanged.
 
 </details>
 

--- a/src/probatio/validators/formats.py
+++ b/src/probatio/validators/formats.py
@@ -23,6 +23,8 @@ _CARD_MAX = 19
 _IBAN_MIN = 15
 _IBAN_MAX = 34
 _E164_MAX = 15
+# Grouping characters stripped from a phone number when normalizing.
+_E164_SEPARATORS = str.maketrans("", "", " -.()")
 
 
 def _luhn_ok(digits: str) -> bool:
@@ -42,16 +44,19 @@ class CreditCard(_SafeValidator):
     """Require a credit card number that passes the Luhn checksum.
 
     Accepts a digit string, optionally grouped with spaces or hyphens. The 12 to
-    19 digits (the ISO/IEC 7812 range) must pass the Luhn check. The value is
-    returned unchanged; this is a checksum, not a check that the card exists.
+    19 digits (the ISO/IEC 7812 range) must pass the Luhn check. With ``normalize``
+    (the default) the grouped separators are stripped and the bare digit string is
+    returned; ``normalize=False`` returns the value unchanged. This is a checksum,
+    not a check that the card exists.
     """
 
-    def __init__(self, msg: str | None = None) -> None:
-        """Store an optional custom message."""
+    def __init__(self, normalize: bool = True, *, msg: str | None = None) -> None:
+        """Store the normalization flag and an optional custom message."""
+        self.normalize = normalize
         self.msg = msg
 
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the value if it is a Luhn-valid card number, else raise."""
+        """Return the card number (bare digits when normalizing), else raise."""
         if not isinstance(value, str):
             raise ValueInvalid(
                 self.msg or "expected a credit card number", code="credit_card"
@@ -65,7 +70,7 @@ class CreditCard(_SafeValidator):
             raise ValueInvalid(
                 self.msg or "invalid credit card number", code="credit_card"
             )
-        return value
+        return digits if self.normalize else value
 
 
 def _valid_iban(compact: str) -> bool:
@@ -93,20 +98,24 @@ class IBAN(_SafeValidator):
 
     Accepts an IBAN, optionally grouped with spaces. The structure (two letters,
     two check digits, then alphanumerics) and the mod-97 checksum are validated;
-    the per-country length is not. The value is returned unchanged.
+    the per-country length is not. With ``normalize`` (the default) the result is
+    the compact, upper-cased form (spaces stripped); ``normalize=False`` returns
+    the value unchanged.
     """
 
-    def __init__(self, msg: str | None = None) -> None:
-        """Store an optional custom message."""
+    def __init__(self, normalize: bool = True, *, msg: str | None = None) -> None:
+        """Store the normalization flag and an optional custom message."""
+        self.normalize = normalize
         self.msg = msg
 
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the value if it is a checksum-valid IBAN, else raise."""
+        """Return the IBAN (compact and upper-cased when normalizing), else raise."""
         if not isinstance(value, str):
             raise ValueInvalid(self.msg or "expected an IBAN", code="iban")
-        if not _valid_iban(value.replace(" ", "").upper()):
+        compact = value.replace(" ", "").upper()
+        if not _valid_iban(compact):
             raise ValueInvalid(self.msg or "invalid IBAN", code="iban")
-        return value
+        return compact if self.normalize else value
 
 
 class DataURI(_SafeValidator):
@@ -147,24 +156,28 @@ class E164(_SafeValidator):
 
     A leading ``+``, a first digit 1 to 9, then up to 14 more digits (15 digits
     total at most). This is a format check, not a guarantee the number is assigned
-    or dialable, which needs a phone-number database. The value is returned
-    unchanged.
+    or dialable, which needs a phone-number database. With ``normalize`` (the
+    default) common grouping characters (spaces, hyphens, dots, parentheses) are
+    stripped and the compact ``+<digits>`` form is returned; ``normalize=False``
+    rejects those characters and returns the value unchanged.
     """
 
-    def __init__(self, msg: str | None = None) -> None:
-        """Store an optional custom message."""
+    def __init__(self, normalize: bool = True, *, msg: str | None = None) -> None:
+        """Store the normalization flag and an optional custom message."""
+        self.normalize = normalize
         self.msg = msg
 
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the value if it is a valid E.164 number, else raise."""
+        """Return the E.164 number (compact when normalizing), else raise."""
         if not isinstance(value, str):
             raise ValueInvalid(self.msg or "expected a phone number", code="e164")
-        digits = value[1:]
+        candidate = value.translate(_E164_SEPARATORS) if self.normalize else value
+        digits = candidate[1:]
         if (
-            not value.startswith("+")
+            not candidate.startswith("+")
             or not 2 <= len(digits) <= _E164_MAX
             or digits[0] not in _NONZERO
             or not _DIGITS.issuperset(digits)
         ):
             raise ValueInvalid(self.msg or "invalid phone number", code="e164")
-        return value
+        return candidate

--- a/src/probatio/validators/identifiers.py
+++ b/src/probatio/validators/identifiers.py
@@ -72,23 +72,40 @@ class UUID(_SafeValidator):
 
 
 class MacAddress(_SafeValidator):
-    """Validate a MAC address, returning a normalized ``aa:bb:cc:dd:ee:ff`` string.
+    """Validate a MAC address, normalized to ``aa:bb:cc:dd:ee:ff`` by default.
 
-    Accepts the common separators (colon, hyphen, dot) and bare hex, and
-    normalizes to lowercase colon-separated form.
+    Accepts the common separators (colon, hyphen, dot) and bare hex. By default
+    the result is canonicalized to lowercase, colon-separated form. Pass
+    ``upper=True`` for uppercase, and ``separator=`` to change the separator (for
+    example ``"-"``, or ``""`` for bare hex). Pass ``normalize=False`` to validate
+    only and return the input unchanged; ``upper`` and ``separator`` then have no
+    effect.
     """
 
-    def __init__(self, msg: str | None = None) -> None:
-        """Store an optional custom message."""
+    def __init__(
+        self,
+        normalize: bool = True,
+        *,
+        upper: bool = False,
+        separator: str = ":",
+        msg: str | None = None,
+    ) -> None:
+        """Store the normalization options and an optional message."""
+        self.normalize = normalize
+        self.upper = upper
+        self.separator = separator
         self.msg = msg
 
     def __call__(self, value: typing.Any) -> str:
-        """Return the normalized MAC address, else raise MacAddressInvalid."""
+        """Return the MAC address, normalized unless ``normalize`` is False."""
         if not isinstance(value, str):
             raise MacAddressInvalid(self.msg or "expected a MAC address")
         cleaned = value.replace(":", "").replace("-", "").replace(".", "").lower()
         if len(cleaned) != _MAC_LENGTH or not _HEX_CHARS.issuperset(cleaned):
             raise MacAddressInvalid(self.msg or "expected a MAC address")
-        return ":".join(
-            cleaned[index : index + 2] for index in range(0, _MAC_LENGTH, 2)
+        if not self.normalize:
+            return value
+        octets = cleaned.upper() if self.upper else cleaned
+        return self.separator.join(
+            octets[index : index + 2] for index in range(0, _MAC_LENGTH, 2)
         )

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -163,16 +163,31 @@ class ByteLength(_SafeValidator):
 
 
 class HexColor(_SafeValidator):
-    """Require a hex color string (``#rgb`` or ``#rrggbb``)."""
+    """Require a hex color string (``#rgb`` or ``#rrggbb``).
 
-    def __init__(self, msg: str | None = None) -> None:
-        """Store an optional custom message."""
+    With ``normalize`` (the default) the value is lower-cased, or upper-cased with
+    ``upper=True``, keeping the leading ``#``; ``normalize=False`` returns it
+    unchanged.
+    """
+
+    def __init__(
+        self,
+        normalize: bool = True,
+        *,
+        upper: bool = False,
+        msg: str | None = None,
+    ) -> None:
+        """Store the normalization options and an optional custom message."""
+        self.normalize = normalize
+        self.upper = upper
         self.msg = msg
 
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the value if it is a hex color, else MatchInvalid."""
+        """Return the hex color (cased when normalizing), else MatchInvalid."""
         if isinstance(value, str) and _HEX_COLOR.match(value):
-            return value
+            if not self.normalize:
+                return value
+            return value.upper() if self.upper else value.lower()
         raise MatchInvalid(self.msg or "expected a hex color like #rrggbb")
 
 

--- a/tests/validators/test_formats.py
+++ b/tests/validators/test_formats.py
@@ -17,11 +17,11 @@ from probatio.error import MultipleInvalid
 
 
 def test_credit_card_accepts_a_luhn_valid_number() -> None:
-    """A Luhn-valid number passes, with or without grouping separators."""
+    """A Luhn-valid number passes; grouping separators are stripped by default."""
     schema = Schema(CreditCard())
     assert schema("4242424242424242") == "4242424242424242"
-    assert schema("4242 4242 4242 4242") == "4242 4242 4242 4242"
-    assert schema("5555-5555-5555-4444") == "5555-5555-5555-4444"
+    assert schema("4242 4242 4242 4242") == "4242424242424242"
+    assert schema("5555-5555-5555-4444") == "5555555555554444"
 
 
 @pytest.mark.parametrize(
@@ -42,10 +42,11 @@ def test_credit_card_rejects_invalid(value: object) -> None:
 
 
 def test_iban_accepts_a_checksum_valid_value() -> None:
-    """A mod-97-valid IBAN passes, with or without spaces."""
+    """A mod-97-valid IBAN passes; spaces are stripped and it is upper-cased."""
     schema = Schema(IBAN())
     assert schema("DE89370400440532013000") == "DE89370400440532013000"
-    assert schema("GB82 WEST 1234 5698 7654 32") == "GB82 WEST 1234 5698 7654 32"
+    assert schema("GB82 WEST 1234 5698 7654 32") == "GB82WEST12345698765432"
+    assert schema("gb82 west 1234 5698 7654 32") == "GB82WEST12345698765432"
 
 
 @pytest.mark.parametrize(
@@ -98,10 +99,11 @@ def test_data_uri_rejects_invalid(value: object) -> None:
 
 
 def test_e164_accepts_valid_numbers() -> None:
-    """A leading + and 2 to 15 digits with no leading zero validates."""
+    """A leading + and 2 to 15 digits validates; grouping is stripped by default."""
     schema = Schema(E164())
     assert schema("+14155552671") == "+14155552671"
     assert schema("+442071838750") == "+442071838750"
+    assert schema("+1 (415) 555-2671") == "+14155552671"
 
 
 @pytest.mark.parametrize(
@@ -119,6 +121,26 @@ def test_e164_rejects_invalid(value: object) -> None:
     """A leading zero, missing plus, wrong length, non-digit, or type is rejected."""
     with pytest.raises(MultipleInvalid) as caught:
         Schema(E164())(value)
+    assert caught.value.errors[0].code == "e164"
+
+
+def test_normalize_false_returns_input_unchanged() -> None:
+    """normalize=False validates but returns the original string verbatim."""
+    assert (
+        Schema(CreditCard(normalize=False))("4242 4242 4242 4242")
+        == "4242 4242 4242 4242"
+    )
+    assert (
+        Schema(IBAN(normalize=False))("gb82 west 1234 5698 7654 32")
+        == "gb82 west 1234 5698 7654 32"
+    )
+    assert Schema(E164(normalize=False))("+14155552671") == "+14155552671"
+
+
+def test_e164_normalize_false_rejects_grouped_input() -> None:
+    """normalize=False keeps E164 strict: grouping characters are rejected."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(E164(normalize=False))("+1 (415) 555-2671")
     assert caught.value.errors[0].code == "e164"
 
 

--- a/tests/validators/test_identifiers.py
+++ b/tests/validators/test_identifiers.py
@@ -71,7 +71,9 @@ def test_mac_address_upper_and_separator() -> None:
 
 def test_mac_address_normalize_false_returns_input_unchanged() -> None:
     """normalize=False validates but returns the original string verbatim."""
-    assert Schema(MacAddress(normalize=False))("AA-bb-CC-dd-EE-ff") == "AA-bb-CC-dd-EE-ff"
+    assert (
+        Schema(MacAddress(normalize=False))("AA-bb-CC-dd-EE-ff") == "AA-bb-CC-dd-EE-ff"
+    )
 
 
 def test_mac_address_normalize_false_still_validates() -> None:

--- a/tests/validators/test_identifiers.py
+++ b/tests/validators/test_identifiers.py
@@ -58,6 +58,29 @@ def test_mac_address_rejects_invalid(value: object) -> None:
     assert isinstance(caught.value.errors[0], MacAddressInvalid)
 
 
+def test_mac_address_upper_and_separator() -> None:
+    """upper and separator control the normalized output."""
+    assert Schema(MacAddress(upper=True))("aa-bb-cc-dd-ee-ff") == "AA:BB:CC:DD:EE:FF"
+    assert Schema(MacAddress(separator="-"))("aabbccddeeff") == "aa-bb-cc-dd-ee-ff"
+    assert Schema(MacAddress(separator=""))("AA:BB:CC:DD:EE:FF") == "aabbccddeeff"
+    assert (
+        Schema(MacAddress(upper=True, separator="-"))("aabbccddeeff")
+        == "AA-BB-CC-DD-EE-FF"
+    )
+
+
+def test_mac_address_normalize_false_returns_input_unchanged() -> None:
+    """normalize=False validates but returns the original string verbatim."""
+    assert Schema(MacAddress(normalize=False))("AA-bb-CC-dd-EE-ff") == "AA-bb-CC-dd-EE-ff"
+
+
+def test_mac_address_normalize_false_still_validates() -> None:
+    """normalize=False still rejects a malformed MAC."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(MacAddress(normalize=False))("nope")
+    assert isinstance(caught.value.errors[0], MacAddressInvalid)
+
+
 def test_custom_messages() -> None:
     """A custom message replaces the default on failure."""
     with pytest.raises(MultipleInvalid) as caught:

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -218,6 +218,13 @@ def test_hex_color_accepts(value: str) -> None:
     assert Schema(HexColor())(value) == value
 
 
+def test_hex_color_normalizes_case() -> None:
+    """HexColor lower-cases by default, upper-cases with upper=True, keeps the #."""
+    assert Schema(HexColor())("#FF8800") == "#ff8800"
+    assert Schema(HexColor(upper=True))("#ff8800") == "#FF8800"
+    assert Schema(HexColor(normalize=False))("#FF8800") == "#FF8800"
+
+
 @pytest.mark.parametrize("value", ["red", "#xyz", "ff8800", 5])
 def test_hex_color_rejects(value: object) -> None:
     """A non-hex-color value raises MatchInvalid."""


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

`E164`, `HexColor`, `CreditCard`, and `IBAN` previously returned the input unchanged. They now normalize by default, so their default output changes:

- `E164` strips grouping characters and returns the compact `+<digits>` form. It also now accepts formatted numbers like `+1 (415) 555-2671`, which it rejected before.
- `HexColor` lower-cases the value (keeping the `#`).
- `CreditCard` returns the bare digit string (grouping stripped).
- `IBAN` returns the compact, upper-cased form (spaces stripped).

To keep the old pass-through behavior, pass `normalize=False`. For `E164`, `normalize=False` also restores the stricter input rules (grouping characters rejected). The default is worth changing because canonical output is what most callers want from these validators, and the opt-out is one keyword.

`MacAddress` is not a behavior change: it already normalized to lowercase colon form, and that default is unchanged.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Gives the typed string validators a consistent, configurable normalization story.

- `MacAddress(normalize=True, upper=False, separator=":", msg=None)`: `normalize=False` validates without rewriting; `upper=True` and `separator=` (for example `"-"`, or `""` for bare hex) control the canonical output.
- `E164(normalize=True, msg=None)`, `CreditCard(normalize=True, msg=None)`, `IBAN(normalize=True, msg=None)`: normalize by default, `normalize=False` to return the value unchanged.
- `HexColor(normalize=True, upper=False, msg=None)`: lower-case by default, `upper=True` for uppercase, `normalize=False` to leave it unchanged.

The new keyword arguments are keyword-only (except `normalize`), so call sites stay readable. The codecs are unaffected: these still render as a plain string / the same `format`.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [x] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
