### PR TITLE
Upload test results to Codecov for test analytics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,9 @@ jobs:
       - name: 🏗 Install dependencies
         run: uv sync --locked --all-packages --group test
       - name: 🚀 Run pytest
-        run: uv run --no-sync pytest --cov probatio tests
+        run: >
+          uv run --no-sync pytest --cov probatio tests
+          --junitxml=junit.xml -o junit_family=legacy
       - name: 🧩 Run workspace package tests
         run: uv run --no-sync pytest packages/pytest-probatio/tests -o addopts=""
       - name: 📝 Verify documentation examples
@@ -48,6 +50,13 @@ jobs:
           name: coverage-${{ matrix.python }}
           include-hidden-files: true
           path: .coverage
+      - name: 🧪 Upload test results to Codecov
+        # Runs even when the suite failed, so the failed and flaky tests reach
+        # Codecov's test analytics.
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
     name: Coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,9 @@ jobs:
           uv run --no-sync pytest --cov probatio tests
           --junitxml=junit.xml -o junit_family=legacy
       - name: 🧩 Run workspace package tests
-        run: uv run --no-sync pytest packages/pytest-probatio/tests -o addopts=""
+        run: >
+          uv run --no-sync pytest packages/pytest-probatio/tests
+          -o addopts="" -o junit_family=legacy --junitxml=junit-packages.xml
       - name: 📝 Verify documentation examples
         run: uv run --no-sync python docs/verify_examples.py
       - name: ⬆️ Upload coverage artifact


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Wires up Codecov Test Analytics. The `pytest` job now writes a JUnit XML (`--junitxml=junit.xml -o junit_family=legacy`) and uploads it with `codecov/test-results-action`, so Codecov gets test run times, failure rates, and flaky-test detection, and can annotate pull requests with failed tests.

The upload step uses `if: ${{ !cancelled() }}`, so it runs even when the suite fails, which is the point: failed and flaky tests have to be uploaded to be reported. The action is pinned to a commit SHA (v1.2.1), matching the rest of the workflows.

**Prerequisite:** add a `CODECOV_TOKEN` repository secret (Settings -> Secrets and variables -> Actions). `test-results-action` needs it to upload reliably. The existing coverage upload is tokenless, but adding the token there too is worth doing in a follow-up for stability.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to: the Codecov coverage badge PR
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
