### PR TITLE
Split the codec guide into JSON Schema, OpenAPI, and Field lists

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,6 +7,10 @@ import rehypeProbatio from "./src/plugins/rehype-probatio.mjs";
 // https://astro.build/config
 export default defineConfig({
   site: "https://probatio.frenck.dev",
+  // The combined "JSON Schema and OpenAPI" guide was split into three pages.
+  redirects: {
+    "/guides/json-schema-and-openapi/": "/guides/json-schema/",
+  },
   markdown: {
     rehypePlugins: [rehypeProbatio],
   },
@@ -101,10 +105,9 @@ export default defineConfig({
             { label: "Custom validators", slug: "guides/custom-validators" },
             { label: "Recursive schemas", slug: "guides/recursive-schemas" },
             { label: "Schemas from dataclasses", slug: "guides/dataclasses" },
-            {
-              label: "JSON Schema and OpenAPI",
-              slug: "guides/json-schema-and-openapi",
-            },
+            { label: "JSON Schema", slug: "guides/json-schema" },
+            { label: "OpenAPI", slug: "guides/openapi" },
+            { label: "Field lists", slug: "guides/field-lists" },
             {
               label: "Testing with pytest-probatio",
               slug: "guides/testing-with-pytest",

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -15,7 +15,7 @@ import Default from "@astrojs/starlight/components/Footer.astro";
     <a href="https://github.com/frenck/probatio/blob/main/LICENSE">License (MIT)</a>
   </nav>
   <p class="pb-footer-copy">
-    Released under the <a href="https://github.com/frenck/probatio/blob/main/LICENSE">MIT License</a>. Copyright © 2026
+    Released under the <a href="https://github.com/frenck/probatio/blob/main/LICENSE">MIT License</a>. Copyright © 2026{" "}
     <a href="https://github.com/frenck">Franck Nijhof</a>.
   </p>
 </div>

--- a/docs/src/content/docs/guides/field-lists.md
+++ b/docs/src/content/docs/guides/field-lists.md
@@ -1,0 +1,53 @@
+---
+title: Field lists
+description: Render a Probatio schema as the flat field list config frontends and tool exporters consume.
+---
+
+Some tools do not want a schema document, they want a flat list of fields to
+render as a form. `serialize(schema)` produces exactly that. It is exported from
+the top level: `from probatio import serialize`.
+
+Unlike [JSON Schema](/guides/json-schema/) and [OpenAPI](/guides/openapi/), this is
+not a published standard. It is the shape
+[voluptuous-serialize](https://github.com/home-assistant-libs/voluptuous-serialize)
+emits, an internal format from the Home Assistant ecosystem, where the config-flow
+frontend turns a schema into a form. Probatio matches it byte for byte so anything
+built against voluptuous-serialize keeps working on a Probatio schema. That is who
+this codec is for: Home Assistant and the libraries around it. If you are not in
+that world, reach for JSON Schema or OpenAPI instead.
+
+## The field list
+
+A mapping becomes a list of field dicts, one per key, carrying the type, the name,
+and whether it is required:
+
+```python
+from probatio import Schema, Required, Optional, serialize
+
+schema = Schema({Required("name"): str, Optional("port", default=8080): int})
+serialize(schema)
+# [{'type': 'string', 'name': 'name', 'required': True}, {'type': 'integer', 'name': 'port', 'required': False, 'optional': True, 'default': 8080}]
+```
+
+Each field carries what the frontend needs to render it: the `type`, the `name`,
+`required`, an `optional` flag and a `default` when present, and bounds (such as
+`valueMin`/`valueMax` for a `Range`) where the validator implies them.
+
+## A custom-serializer hook
+
+`serialize` and `to_openapi` take a `custom_serializer` hook, called first for
+each node. It returns a dict to override that node, or the `UNSUPPORTED` sentinel
+to defer to the default handling. `UNSUPPORTED` is exported from the top level and
+prints as itself:
+
+```python
+from probatio import UNSUPPORTED
+
+UNSUPPORTED  # UNSUPPORTED
+```
+
+:::tip
+Return `UNSUPPORTED` from your hook for the nodes you do not care about. That
+keeps your custom logic small: handle the one or two constructs you need, defer
+everything else.
+:::

--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -1,15 +1,18 @@
 ---
-title: JSON Schema and OpenAPI
-description: Render a Probatio schema as JSON Schema or OpenAPI, build one back, and stay safe doing it.
+title: JSON Schema
+description: Render a Probatio schema as JSON Schema, build one back, and stay safe doing it.
 ---
 
-A Probatio schema is Python data. Other tools speak JSON Schema, OpenAPI, or the
-flat field list that config frontends and tool exporters consume. The codecs
-translate between them, for the constructs that map cleanly. They are exported
-from the top level, so `from probatio import to_json_schema, from_json_schema`
-is all you need.
+A Probatio schema is Python data. JSON Schema is the lingua franca other tools
+speak. The two codecs translate between them, for the constructs that map
+cleanly. They are exported from the top level, so
+`from probatio import to_json_schema, from_json_schema` is all you need.
 
-## JSON Schema, both directions
+The same decoder backs OpenAPI (see [OpenAPI](/guides/openapi/)), and a third
+codec renders the flat shape config frontends consume (see [Field
+lists](/guides/field-lists/)).
+
+## Both directions
 
 `to_json_schema(schema)` renders a schema as a JSON Schema dictionary.
 `from_json_schema(dict)` is the inverse: it builds a `Schema` back. Together they
@@ -60,20 +63,20 @@ identical".
 
 `from_json_schema` understands the keywords below. A purely descriptive keyword
 it does not read (`title`, `description`, `examples`) is ignored, so a partial
-schema still yields a usable validator. A *restrictive* keyword it cannot honor
+schema still yields a usable validator. A _restrictive_ keyword it cannot honor
 (`if`/`then`/`else`, `propertyNames`, `patternProperties`, `dependentRequired`,
 `dependentSchemas`) is refused with a `SchemaError` rather than silently dropped,
 so an untrusted schema is never quietly widened to accept what its author meant
 to forbid. `to_json_schema` emits the same constructs in the other direction.
 
-| Area    | Keywords                                                             |
-| ------- | ------------------------------------------------------------------- |
-| Objects | `properties`, `required`, `additionalProperties`, `minProperties`, `maxProperties` |
-| Arrays  | `items`, `minItems`, `maxItems`, `prefixItems`, `uniqueItems`, `contains`, `minContains`, `maxContains` |
+| Area    | Keywords                                                                                                                                                                           |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Objects | `properties`, `required`, `additionalProperties`, `minProperties`, `maxProperties`                                                                                                 |
+| Arrays  | `items`, `minItems`, `maxItems`, `prefixItems`, `uniqueItems`, `contains`, `minContains`, `maxContains`                                                                            |
 | Strings | `minLength`, `maxLength`, `pattern`, `format` (`date`, `date-time`, `time`, `email`, `uri`, `ipv4`, `ipv6`, `uuid`, `hostname`, `byte`), `writeOnly`, `contentEncoding` (`Base64`) |
-| Numbers | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf` |
-| Values  | `enum`, `const`, `not`, `type` (including a type array like `["string", "null"]`) |
-| Compose | `anyOf`, `oneOf`, `allOf`, `$ref` (resolved against `$defs`/`definitions`) |
+| Numbers | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`                                                                                                         |
+| Values  | `enum`, `const`, `not`, `type` (including a type array like `["string", "null"]`)                                                                                                  |
+| Compose | `anyOf`, `oneOf`, `allOf`, `$ref` (resolved against `$defs`/`definitions`)                                                                                                         |
 
 `ExactSequence` exports as `prefixItems` (with `items: false` and matching
 `minItems`/`maxItems`), `Unique` as `uniqueItems`, `Contains` as `contains`,
@@ -94,79 +97,14 @@ check if the distinction matters. `oneOf` decodes with its exact semantics (a
 value must match exactly one branch, so one matching two or more is rejected),
 unlike the looser `anyOf`.
 
-`from_openapi` adds the OpenAPI `nullable` keyword, covered next.
+`from_openapi` adds the OpenAPI `nullable` keyword, covered in
+[OpenAPI](/guides/openapi/).
 
 :::note[Integers and booleans]
 A decoded `{"type": "integer"}` validates with Python's `int`, and in Python
 `bool` is a subclass of `int`. So a decoded integer schema accepts `True` as an
 integer, where a strict JSON Schema validator would not. If that distinction
 matters for your data, add an explicit check.
-:::
-
-## OpenAPI and the nullable keyword
-
-`to_openapi(schema)` and `from_openapi(dict)` are the OpenAPI pair. The decoder
-is the same one `from_json_schema` uses, plus the OpenAPI 3.0 `nullable` keyword.
-That keyword is the visible difference. A value that also accepts `None` renders
-as two branches in JSON Schema, but as a single `nullable: True` in OpenAPI:
-
-```python
-from probatio import Schema, Maybe, to_json_schema, to_openapi
-
-schema = Schema({"nickname": Maybe(str)})
-to_json_schema(schema)["properties"]["nickname"]
-# {'anyOf': [{'type': 'null'}, {'type': 'string'}]}
-to_openapi(schema)["properties"]["nickname"]
-# {'type': 'string', 'nullable': True}
-```
-
-`to_openapi` defaults to OpenAPI 3.0 (the `nullable` keyword above). Pass
-`openapi_version="3.1.0"` for 3.1, which drops `nullable` and expresses
-nullability the JSON Schema way instead, as an `anyOf` with a `{"type": "null"}`
-branch.
-
-`from_openapi` reads `nullable` back the way you would expect. A nullable field
-accepts both `None` and a real value:
-
-```python
-from probatio import from_openapi
-
-schema = from_openapi(
-    {"type": "object", "properties": {"nickname": {"type": "string", "nullable": True}}}
-)
-schema({"nickname": None})   # {'nickname': None}
-schema({"nickname": "ada"})  # {'nickname': 'ada'}
-```
-
-## The field list
-
-`serialize(schema)` renders a schema as a plain field list, the shape
-voluptuous-serialize produces. Config frontends and tool exporters consume it. A
-mapping becomes a list of field dicts:
-
-```python
-from probatio import Schema, Required, Optional, serialize
-
-schema = Schema({Required("name"): str, Optional("port", default=8080): int})
-serialize(schema)
-# [{'type': 'string', 'name': 'name', 'required': True}, {'type': 'integer', 'name': 'port', 'required': False, 'optional': True, 'default': 8080}]
-```
-
-`serialize` and `to_openapi` take a `custom_serializer` hook, called first for
-each node. It returns a dict to override that node, or the `UNSUPPORTED` sentinel
-to defer to the default handling. `UNSUPPORTED` is exported from the top level
-and prints as itself:
-
-```python
-from probatio import UNSUPPORTED
-
-UNSUPPORTED  # UNSUPPORTED
-```
-
-:::tip
-Return `UNSUPPORTED` from your hook for the nodes you do not care about. That
-keeps your custom logic small: handle the one or two constructs you need, defer
-everything else.
 :::
 
 ## Untrusted input is the default assumption
@@ -181,6 +119,7 @@ A nested unbounded quantifier like `(a+)+` is the classic catastrophic regular
 expression. Probatio refuses to compile it:
 
 <!-- verify: raises SchemaError -->
+
 ```python
 from probatio import from_json_schema
 

--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -1,0 +1,83 @@
+---
+title: OpenAPI
+description: Render a Probatio schema as an OpenAPI Schema object, build one back, and handle nullable.
+---
+
+OpenAPI Schema objects are JSON Schema with a few of their own rules. `to_openapi`
+and `from_openapi` are the OpenAPI pair, exported from the top level. They share
+the JSON Schema codec, so most of the behavior, the supported keywords, the
+round-trip caveats, and the untrusted-input guards, is the same. Read [JSON
+Schema](/guides/json-schema/) first; this page covers what OpenAPI adds.
+
+## Both directions
+
+`to_openapi(schema)` renders a schema as an OpenAPI Schema object.
+`from_openapi(dict)` is the inverse: it builds a `Schema` back. This is handy for
+LLM tool calling and MCP, which describe tool parameters as OpenAPI, so a Probatio
+schema can become a tool signature and a tool's declared parameters can become a
+validator.
+
+```python
+from probatio import Schema, Required, Optional, to_openapi
+
+schema = Schema({Required("name"): str, Optional("port", default=8080): int})
+to_openapi(schema)
+# {'type': 'object', 'properties': {'name': {'type': 'string'}, 'port': {'type': 'integer', 'default': 8080}}, 'required': ['name']}
+```
+
+Going the other way, an OpenAPI Schema object becomes a working validator.
+`nullable` is read back too, so a nullable field accepts both `None` and a real
+value:
+
+```python
+from probatio import from_openapi
+
+document = {
+    "type": "object",
+    "properties": {"name": {"type": "string"}, "age": {"type": "integer", "nullable": True}},
+    "required": ["name"],
+}
+schema = from_openapi(document)
+schema({"name": "Ada", "age": None})  # {'name': 'Ada', 'age': None}
+schema({"name": "Ada", "age": 37})    # {'name': 'Ada', 'age': 37}
+```
+
+## The nullable keyword
+
+`nullable` is the visible difference from JSON Schema. A value that also accepts
+`None` renders as two branches in JSON Schema, but as a single `nullable: True` in
+OpenAPI:
+
+```python
+from probatio import Schema, Maybe, to_json_schema, to_openapi
+
+schema = Schema({"nickname": Maybe(str)})
+to_json_schema(schema)["properties"]["nickname"]
+# {'anyOf': [{'type': 'null'}, {'type': 'string'}]}
+to_openapi(schema)["properties"]["nickname"]
+# {'type': 'string', 'nullable': True}
+```
+
+`to_openapi` defaults to OpenAPI 3.0 (the `nullable` keyword above). Pass
+`openapi_version="3.1.0"` for 3.1, which drops `nullable` and expresses
+nullability the JSON Schema way instead, as an `anyOf` with a `{"type": "null"}`
+branch.
+
+## Customizing the output
+
+`to_openapi` takes a `custom_serializer` hook, the same one `serialize` uses, to
+override how individual nodes render. It is documented with the field-list codec
+in [Field lists](/guides/field-lists/#a-custom-serializer-hook), since both codecs
+share it.
+
+## Shared with JSON Schema
+
+Everything else is the JSON Schema codec:
+
+- The [supported keywords](/guides/json-schema/#supported-keywords) and how each
+  validator maps to them.
+- The round trip is [not lossless](/guides/json-schema/#both-directions); treat it
+  as "the validatable shape survives".
+- `from_openapi` treats its input as [untrusted](/guides/json-schema/#untrusted-input-is-the-default-assumption):
+  a catastrophic `pattern` or a pathologically deep document is refused with
+  `SchemaError`, not a hang or a crash.

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -79,8 +79,8 @@ read a JSON Schema into a Probatio schema and write one back out, for the
 constructs that map cleanly between the two.
 
 :::tip
-See [JSON Schema and OpenAPI](/guides/json-schema-and-openapi/) for
-`from_json_schema` and `to_json_schema`, and for which constructs round-trip.
+See [JSON Schema](/guides/json-schema/) for `from_json_schema` and
+`to_json_schema`, and for which constructs round-trip.
 :::
 
 ## attrs and cattrs

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -379,7 +379,8 @@ In `probatio.humanize`:
 
 Probatio converts schemas to and from JSON Schema and OpenAPI, for the
 constructs that map cleanly (see the [JSON Schema
-guide](/guides/json-schema-and-openapi/) for the supported keywords):
+guide](/guides/json-schema/) for the supported keywords, and [Field
+lists](/guides/field-lists/) for the `serialize` shape):
 
 - `to_json_schema(schema)` / `from_json_schema(dict)`
 - `to_openapi(schema, *, custom_serializer=None, openapi_version="3.0")` / `from_openapi(dict)`


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Documentation only. The old `/guides/json-schema-and-openapi/` URL keeps working through a redirect.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The single "JSON Schema and OpenAPI" guide bundled three codecs, which buried the field-list codec (`serialize`): it was a subsection of an unrelated page, so it was easy to miss that it exists at all. This splits it into three focused pages:

- **JSON Schema**: both directions, the supported-keywords table, and the untrusted-input guards (they back both decoders, so they live here).
- **OpenAPI**: `to_openapi`/`from_openapi` with examples for each, the `nullable` keyword and the 3.0/3.1 split, and cross-links back to the shared JSON Schema behavior.
- **Field lists**: `serialize()` and the `custom_serializer` hook. The intro now states plainly that this is the voluptuous-serialize shape from the Home Assistant ecosystem, an internal format rather than a published standard, so readers know who it is for.

The sidebar gains the three entries, a redirect keeps the old slug alive, and the two inbound documentation links are repointed.

Also fixes a small unrelated bug: the site footer rendered `Copyright © 2026Franck Nijhof` with no space, because the compiler trimmed the newline between the year and the name link. An explicit space expression fixes it.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
