### PR TITLE
Give TypedDict schemas their own guide page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -106,6 +106,7 @@ export default defineConfig({
             { label: "Custom validators", slug: "guides/custom-validators" },
             { label: "Recursive schemas", slug: "guides/recursive-schemas" },
             { label: "Schemas from dataclasses", slug: "guides/dataclasses" },
+            { label: "Schemas from TypedDicts", slug: "guides/typeddict" },
             { label: "JSON Schema", slug: "guides/json-schema" },
             { label: "OpenAPI", slug: "guides/openapi" },
             { label: "Field lists", slug: "guides/field-lists" },

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -1,6 +1,6 @@
 ---
-title: Schemas from dataclasses and TypedDicts
-description: Generate a validating schema straight from a dataclass or a TypedDict, with the field annotations driving the validators.
+title: Schemas from dataclasses
+description: Generate a validating schema straight from a dataclass, with the field annotations driving the validators.
 ---
 
 If your data already has a dataclass, you should not have to write the schema
@@ -9,6 +9,10 @@ annotations: it validates a plain mapping and hands you back a constructed
 instance. This is the same idea as voluptuous [PR #533](https://github.com/alecthomas/voluptuous/pull/533), with a richer type
 mapping (Probatio descends into element types instead of stopping at the
 container).
+
+The same engine reads a `TypedDict`. If your shape is a dict rather than a
+constructed object, see [Schemas from TypedDicts](/guides/typeddict/); this page is
+about dataclasses.
 
 ## The basics
 
@@ -281,34 +285,9 @@ trying every member, so it still fails cleanly rather than silently.
 
 ## From a TypedDict
 
-`TypedDictSchema` does the same for a `TypedDict`, sharing the annotation mapping
-above. The difference is the output: a `TypedDict` is a plain dict at runtime, so
-the validated mapping comes back unchanged, with nothing constructed. The schema
-is generic in the `TypedDict`, so the result is typed as that `TypedDict`: your
-type checker sees the real keys, at no runtime cost.
-
-```python
-from typing import TypedDict
-
-from probatio import TypedDictSchema
-
-
-class Config(TypedDict):
-    port: int
-    host: str
-
-
-schema = TypedDictSchema(Config)
-schema({"port": 8080, "host": "nas"})  # {'port': 8080, 'host': 'nas'}, typed as Config
-```
-
-A field in the TypedDict's required keys is required, the rest optional;
-`total=False` and `Required`/`NotRequired` are honored, and the keys are closed
-(an unknown key is rejected, like the default dict schema). Nested TypedDicts,
-recursive ones, `additional_constraints`, and `Annotated` inline validators all
-work the same as for a dataclass. Since the result is just the validated dict,
-`result["port"]` access keeps working, so it layers types onto dict-shaped data
-without changing how that data is used.
+The same engine builds a schema from a `TypedDict`. Because that is a different
+tool with a different result (the validated dict, not a constructed instance), it
+has its own page: [Schemas from TypedDicts](/guides/typeddict/).
 
 ## Limits
 

--- a/docs/src/content/docs/guides/typeddict.md
+++ b/docs/src/content/docs/guides/typeddict.md
@@ -1,0 +1,188 @@
+---
+title: Schemas from TypedDicts
+description: Generate a validating schema straight from a TypedDict, with the field annotations driving the validators and the typed dict coming back out.
+---
+
+A `TypedDict` describes the shape of a plain dict: which keys it has and what
+each value is typed as. `TypedDictSchema` reads that shape and builds a schema
+from it, so you validate against the keys you already declared instead of writing
+the schema twice.
+
+The annotation engine is shared with [dataclasses](/guides/dataclasses/), but the
+two are different tools for different jobs. A dataclass schema validates a mapping
+and hands you back a constructed instance. A TypedDict is a plain dict at runtime,
+so a TypedDict schema validates the mapping and returns it unchanged, just typed.
+Dict in, dict out, at no construction cost.
+
+## The basics
+
+Pass a `TypedDict` type to `TypedDictSchema`. The validated mapping comes back as
+is, and your type checker sees it as the `TypedDict`, so `result["port"]` is an
+`int` to the type checker with nothing extra at runtime.
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema
+
+
+class Config(TypedDict):
+    port: int
+    host: str
+
+
+schema = TypedDictSchema(Config)
+schema({"port": 8080, "host": "nas"})  # {'port': 8080, 'host': 'nas'}
+```
+
+By default every key is required, and a missing one is reported like any other
+validation error:
+
+<!-- verify: raises MultipleInvalid -->
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema
+
+
+class Config(TypedDict):
+    port: int
+    host: str
+
+
+TypedDictSchema(Config)({"port": 8080})  # required key not provided @ data['host']
+```
+
+The keys are closed: an unknown key is rejected, the same as the default dict
+schema. Pass `extra=ALLOW_EXTRA` (keyword-only) to keep unknown keys instead.
+
+## Required and optional keys
+
+A `TypedDict` carries its own notion of which keys are required, and the schema
+honors it. A `total=False` class makes every key optional; `Required` and
+`NotRequired` set it per key. An optional key that is absent is simply left out of
+the result, no default is invented.
+
+```python
+from typing import TypedDict, NotRequired
+
+from probatio import TypedDictSchema
+
+
+class Server(TypedDict):
+    name: str
+    port: NotRequired[int]
+
+
+schema = TypedDictSchema(Server)
+schema({"name": "nas", "port": 22})  # {'name': 'nas', 'port': 22}
+schema({"name": "nas"})              # {'name': 'nas'}
+```
+
+A `total=False` class flips the default, so nothing is required:
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema
+
+
+class Partial(TypedDict, total=False):
+    a: int
+    b: str
+
+
+TypedDictSchema(Partial)({})  # {}
+```
+
+## Annotations drive the validators
+
+Each field's annotation becomes a validator. The mapping is deep, not just the
+container type: a parameterized generic keeps its element types, a union with
+`None` becomes `Maybe`, and a nested `TypedDict` (or dataclass) recurses into its
+own schema. The full table is the same one
+[dataclasses use](/guides/dataclasses/#annotations-drive-the-validators).
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema
+
+
+class Config(TypedDict):
+    port: int
+    host: str
+
+
+class Service(TypedDict):
+    name: str
+    config: Config
+
+
+TypedDictSchema(Service)({"name": "web", "config": {"port": 80, "host": "nas"}})
+# {'name': 'web', 'config': {'port': 80, 'host': 'nas'}}
+```
+
+For anything beyond the type check (a length, a range, a pattern), the same two
+options as dataclasses apply: pass `additional_constraints`, a map from key to a
+validator that runs after the type check, or put the rule on the field with
+`Annotated`.
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema, Length
+
+
+class Config(TypedDict):
+    port: int
+    host: str
+
+
+schema = TypedDictSchema(Config, {"host": Length(min=2)})
+schema({"port": 8080, "host": "nas"})  # {'port': 8080, 'host': 'nas'}
+```
+
+## The functional form
+
+`create_typeddict_schema(typeddict_type, additional_constraints=None)` builds the
+same schema without the class wrapper. It returns a plain `Schema`, so it does not
+carry the `TypedDict` type for the type checker the way `TypedDictSchema` does.
+
+```python
+from typing import TypedDict
+
+from probatio import create_typeddict_schema
+
+
+class Config(TypedDict):
+    port: int
+    host: str
+
+
+create_typeddict_schema(Config)({"port": 8080, "host": "nas"})
+# {'port': 8080, 'host': 'nas'}
+```
+
+## What carries over from dataclasses
+
+The two share the annotation engine, so the [dataclasses
+guide](/guides/dataclasses/) covers the rest, and it all behaves the same with a
+`TypedDict`:
+
+- The [annotation mapping table](/guides/dataclasses/#annotations-drive-the-validators).
+- [Coercing a type wherever it appears](/guides/dataclasses/#coercing-a-type-wherever-it-appears)
+  with `register_type` / `type_registry`.
+- [Recursive](/guides/dataclasses/#recursive-dataclasses) and mutually recursive
+  types, with the same depth guard.
+- [Discriminated unions](/guides/dataclasses/#discriminated-unions) over a shared
+  literal tag.
+
+The one difference is the result: a dataclass schema constructs an instance, a
+TypedDict schema returns the validated dict.
+
+## Limits
+
+The value is not coerced between container types: a list stays a list even where
+the annotation says `tuple`.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -406,8 +406,9 @@ overflowing the stack.
 
 ## Dataclasses
 
-Probatio builds a schema from a dataclass, driven by its field annotations (see
-the [dataclasses guide](/guides/dataclasses/)):
+Probatio builds a schema from a dataclass or a `TypedDict`, driven by its field
+annotations (see the [dataclasses guide](/guides/dataclasses/) and the [TypedDicts
+guide](/guides/typeddict/)):
 
 - `DataclassSchema(dataclass_type, additional_constraints=None, *, required=False, extra=PREVENT_EXTRA)`: a `Schema` that validates a mapping and constructs an instance of `dataclass_type`.
 - `create_dataclass_schema(dataclass_type, additional_constraints=None, *, required=False, extra=PREVENT_EXTRA)`: the functional form, returning the same `Schema`.


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Documentation only.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The "Schemas from dataclasses" guide also documented `TypedDictSchema`, tucked into a short section near the end. They share the annotation engine in the codebase, but from a user's point of view they are different tools for different jobs: a dataclass schema validates a mapping and constructs an instance, a TypedDict schema validates a dict and returns it unchanged, typed. The TypedDict story was easy to miss where it was.

This gives TypedDicts their own page:

- **New `guides/typeddict.md`**: the basics, required vs optional keys (`total=False`, `Required`/`NotRequired`), annotations driving the validators with a nested example, `additional_constraints`/`Annotated`, and the functional `create_typeddict_schema`. A "what carries over from dataclasses" section links back rather than duplicating the shared mapping table, `register_type` coercion, recursion, and discriminated unions. The framing throughout: dict in, dict out, nothing constructed.
- **`guides/dataclasses.md`**: title back to "Schemas from dataclasses"; the buried TypedDict section becomes a short pointer to the new page.
- Sidebar gains the new entry, and the reference's Dataclasses section links both guides.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
