### PR TITLE
List an enum's values in the Coerce error message

### DIFF
--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 import typing
 from decimal import Decimal, InvalidOperation
 
@@ -37,8 +38,15 @@ class Coerce(_SafeValidator):
         try:
             return self.type(value)
         except (ValueError, TypeError, ArithmeticError) as exc:
-            message = self.msg or f"expected {self.type_name}"
-            raise CoerceInvalid(message) from exc
+            raise CoerceInvalid(self.msg or self._default_message()) from exc
+
+    def _default_message(self) -> str:
+        """Build the failure message, listing an enum's values (like voluptuous)."""
+        message = f"expected {self.type_name}"
+        if isinstance(self.type, type) and issubclass(self.type, enum.Enum):
+            values = ", ".join(repr(member.value) for member in self.type)
+            message = f"{message} or one of {values}"
+        return message
 
 
 @message("expected boolean", cls=BooleanInvalid)

--- a/tests/validators/test_coerce.py
+++ b/tests/validators/test_coerce.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 from decimal import Decimal
 
 import pytest
@@ -103,6 +104,34 @@ def test_coerce_failure_is_reported() -> None:
 def test_coerce_exposes_its_type() -> None:
     """Coerce keeps its target type for introspection."""
     assert Coerce(int).type is int
+
+
+class _Color(enum.Enum):
+    """A small enum for the Coerce-of-enum message tests."""
+
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+def test_coerce_enum_message_lists_the_values() -> None:
+    """Coercing to an enum names the valid values, matching voluptuous."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Color))("purple")
+    with pytest.raises(voluptuous.MultipleInvalid) as oracle:
+        voluptuous.Schema(voluptuous.Coerce(_Color))("purple")
+    assert (
+        str(caught.value.errors[0])
+        == "expected _Color or one of 'red', 'green', 'blue'"
+    )
+    assert str(caught.value.errors[0]) == str(oracle.value.errors[0])
+
+
+def test_coerce_enum_custom_message_does_not_append_values() -> None:
+    """A custom message replaces the default; the values are not appended."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Color, msg="bad color"))("purple")
+    assert str(caught.value.errors[0]) == "bad color"
 
 
 def test_boolean_truthy_and_falsy_strings() -> None:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. The accept/reject behavior is unchanged; only the failure message for `Coerce` of an enum gains the list of valid values (it now matches voluptuous).

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

voluptuous's `Coerce` lists an enum's values in its default error message, so a failed coercion tells you what was allowed:

```
expected Color or one of 'red', 'green', 'blue'
```

probatio dropped the values and said only `expected Color`. That is a divergence from voluptuous (the primary correctness target, ADR-001), and Home Assistant relies on the richer message for useful enum errors.

This matches voluptuous: when the `Coerce` target is an `enum.Enum` subclass and no custom message is set, the default message appends ` or one of <values>`. A custom `msg=` still wins (no values appended), and non-enum types are unchanged.

The conformance suite did not catch this because voluptuous's own test suite does not assert that message, so the new test pins it differentially against the voluptuous oracle to stop it drifting again.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to: voluptuous compatibility (Coerce of an enum)
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
