### PR TITLE
Accept a numeric string as seconds in Duration

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -248,9 +248,9 @@ Schema(Date(format="%d/%m/%Y"))("25/06/2026")       # '25/06/2026'
 
 `Time` is the time-of-day sibling, defaulting to `%H:%M:%S`. `Duration` and
 `TimeZone` are Probatio additions that coerce to a Python object: `Duration`
-parses a `timedelta`, a number of seconds, a `H:MM[:SS]` string, or a mapping
-into a `datetime.timedelta`; `TimeZone` resolves an IANA name to a
-`zoneinfo.ZoneInfo`.
+parses a `timedelta`, a number of seconds (an `int`, `float`, or numeric string),
+a `H:MM[:SS]` string, or a mapping into a `datetime.timedelta`; `TimeZone`
+resolves an IANA name to a `zoneinfo.ZoneInfo`.
 
 ```python
 from probatio import Schema, Time, Duration, TimeZone
@@ -258,6 +258,7 @@ from probatio import Schema, Time, Duration, TimeZone
 Schema(Time())("14:30:00")             # '14:30:00'
 Schema(Duration())("1:30:00")          # datetime.timedelta(seconds=5400)
 Schema(Duration())(90)                 # datetime.timedelta(seconds=90)
+Schema(Duration())("90")               # datetime.timedelta(seconds=90)
 Schema(TimeZone())("Europe/Amsterdam")  # zoneinfo.ZoneInfo(key='Europe/Amsterdam')
 ```
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -221,8 +221,8 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
   default, or a `strptime` `format=`).
 - `AsTime(format=None, msg=None)`: parse a string to a `datetime.time` (ISO 8601 by
   default, or a `strptime` `format=`).
-- `Duration(msg=None)`: parse a duration (timedelta, seconds, `H:MM[:SS]`, or a
-  mapping) to a `timedelta`.
+- `Duration(msg=None)`: parse a duration (timedelta, seconds as an int/float/string,
+  `H:MM[:SS]`, or a mapping) to a `timedelta`.
 - `TimeZone(msg=None)`: validate an IANA zone name, returned as
   `zoneinfo.ZoneInfo`.
 - `Epoch(unit="seconds", msg=None)`: parse a Unix timestamp (`int` or `float`,

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -29,6 +29,7 @@ from probatio.validators._base import _SafeValidator
 
 # A colon duration has hours:minutes or hours:minutes:seconds.
 _DURATION_PARTS = (2, 3)
+_DURATION_MSG = "expected a duration like H:MM, H:MM:SS, or a number of seconds"
 
 # How many epoch sub-units make one second, per accepted ``Epoch`` unit.
 _EPOCH_DIVISORS = {"seconds": 1, "milliseconds": 1000}
@@ -209,9 +210,10 @@ class AsTime(_SafeValidator):
 class Duration(_SafeValidator):
     """Validate a duration, returning a ``datetime.timedelta``.
 
-    Accepts a ``timedelta`` (passed through), a number of seconds, a colon string
-    (``"H:MM"`` or ``"H:MM:SS"``, optionally negative), or a mapping of
-    ``timedelta`` keyword arguments (``{"hours": 1, "minutes": 30}``).
+    Accepts a ``timedelta`` (passed through), a number of seconds (an ``int``,
+    ``float``, or numeric string like ``"90"``), a colon string (``"H:MM"`` or
+    ``"H:MM:SS"``, optionally negative), or a mapping of ``timedelta`` keyword
+    arguments (``{"hours": 1, "minutes": 30}``).
     """
 
     def __init__(self, msg: str | None = None) -> None:
@@ -241,15 +243,21 @@ class Duration(_SafeValidator):
         raise DurationInvalid(self.msg or "expected a duration")
 
     def _parse_string(self, value: str) -> datetime.timedelta:
-        """Parse a ``H:MM`` / ``H:MM:SS`` colon string into a timedelta."""
+        """Parse a ``H:MM`` / ``H:MM:SS`` colon string or a number of seconds.
+
+        A bare numeric string (``"90"``, ``"90.5"``) is read as seconds, matching
+        an ``int``/``float`` input, so ``Duration`` covers the whole time-period
+        family rather than only the colon form.
+        """
         text = value.strip()
         sign = 1
         if text.startswith("-"):
             sign, text = -1, text[1:]
+        if ":" not in text:
+            return sign * self._seconds(text)
         parts = text.split(":")
         if len(parts) not in _DURATION_PARTS or not all(p.isdigit() for p in parts):
-            message = self.msg or "expected a duration like H:MM or H:MM:SS"
-            raise DurationInvalid(message)
+            raise DurationInvalid(self.msg or _DURATION_MSG)
         hours, minutes, *rest = (int(part) for part in parts)
         seconds = rest[0] if rest else 0
         try:
@@ -259,8 +267,16 @@ class Duration(_SafeValidator):
                 seconds=seconds,
             )
         except OverflowError as exc:
-            message = self.msg or "expected a duration like H:MM or H:MM:SS"
-            raise DurationInvalid(message) from exc
+            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
+
+    def _seconds(self, text: str) -> datetime.timedelta:
+        """Read a bare number of seconds (``"90"``, ``"90.5"``) as a timedelta."""
+        try:
+            return datetime.timedelta(seconds=float(text))
+        except (ValueError, OverflowError) as exc:
+            # ``float("abc")`` and an empty string raise ValueError; ``"inf"`` or a
+            # huge value overflows timedelta; ``"nan"`` raises ValueError there.
+            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
 
 
 class TimeZone(_SafeValidator):

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -179,9 +179,28 @@ def test_duration_from_mapping() -> None:
     )
 
 
-@pytest.mark.parametrize("value", [True, "x:y", "nonsense", {"bogus": 1}, [1]])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("90", datetime.timedelta(seconds=90)),
+        ("90.5", datetime.timedelta(seconds=90.5)),
+        ("-30", -datetime.timedelta(seconds=30)),
+        (" 90 ", datetime.timedelta(seconds=90)),
+    ],
+)
+def test_duration_from_numeric_string(value: str, expected: datetime.timedelta) -> None:
+    """A bare numeric string is read as seconds, like an int or float."""
+    assert Schema(Duration())(value) == expected
+
+
+def test_duration_numeric_string_matches_int() -> None:
+    """The numeric string "90" gives the same result as the int 90."""
+    assert Schema(Duration())("90") == Schema(Duration())(90)
+
+
+@pytest.mark.parametrize("value", [True, "x:y", "nonsense", "", {"bogus": 1}, [1]])
 def test_duration_rejects_invalid(value: object) -> None:
-    """A bool, a malformed string, bad mapping keys, or a wrong type all reject."""
+    """A bool, a malformed/empty string, bad mapping keys, or a wrong type reject."""
     with pytest.raises(MultipleInvalid) as caught:
         Schema(Duration())(value)
     assert isinstance(caught.value.errors[0], DurationInvalid)
@@ -189,7 +208,7 @@ def test_duration_rejects_invalid(value: object) -> None:
 
 @pytest.mark.parametrize(
     "value",
-    [10**20, "100000000000000:0:0", {"days": 10**20}],
+    [10**20, "100000000000000:0:0", "inf", "1e400", {"days": 10**20}],
 )
 def test_duration_rejects_overflow(value: object) -> None:
     """A duration too large for timedelta is rejected, not a leaked OverflowError."""


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. This only accepts more input: a numeric string like `"90"` that `Duration` rejected before. Everything previously valid is unchanged, and the previously-rejected case now succeeds.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`Duration()` reads an `int` or `float` as a count of seconds, but rejected the numeric string `"90"`, even though `"90"` and `90` mean the same thing. A bare numeric string (one without a colon) is now read as seconds, so `Duration()("90") == Duration()(90)`.

This closes Home Assistant's whole time-period family onto `Duration`: `time_period_str` and `positive_timedelta` already mapped to the colon and int forms, and the numeric-string case was the last gap.

Colon strings (`"1:30"`, `"1:30:00"`), mappings, timedeltas, and ints/floats are all unchanged. A malformed, empty, NaN, or infinite string still rejects cleanly as `DurationInvalid` (the safe-validator contract holds; it is covered by the fuzzer).

```python
Schema(Duration())("90")     # datetime.timedelta(seconds=90)
Schema(Duration())("90.5")   # datetime.timedelta(seconds=90.5)
Schema(Duration())("1:30")   # datetime.timedelta(seconds=5400)  (unchanged)
```

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to: Home Assistant's `time_period_str` / `positive_timedelta`
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
