### PR TITLE
Serialize a literal mapping value as a constant field

### DIFF
--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -168,6 +168,12 @@ def _serialize_value(node: Any, custom: Any) -> dict[str, Any]:
     converted = _serialize_validator(node, custom)
     if converted is not None:
         return converted
+    if isinstance(node, str | int | float):
+        # A literal mapping value (``{"mode": 5}``) is a constant the value must
+        # equal. voluptuous-serialize renders it as a ``constant`` field; ``bool``
+        # is an ``int`` subclass, so it is covered. ``None`` is not a constant
+        # there, so it falls through to the error, matching the oracle.
+        return {"type": "constant", "value": node}
     message = f"unable to serialize schema: {node!r}"
     raise ValueError(message)
 

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -114,6 +114,19 @@ def test_coerce_of_non_type_is_open() -> None:
     assert serialize(Schema(probatio.Coerce(str.strip))) == {}
 
 
+@pytest.mark.parametrize("value", [5, "abc", 3.14, True])
+def test_literal_value_serializes_as_a_constant(value: object) -> None:
+    """A literal mapping value renders as a constant field, like the oracle."""
+    assert serialize(Schema({Required("n"): value})) == voluptuous_serialize.convert(
+        voluptuous.Schema({voluptuous.Required("n"): value}),
+    )
+
+
+def test_bare_literal_serializes_as_a_constant() -> None:
+    """A bare literal schema renders as a constant value, like the oracle."""
+    assert serialize(Schema(5)) == voluptuous_serialize.convert(voluptuous.Schema(5))
+
+
 def test_unsupported_value_raises() -> None:
     """An un-serializable value raises, matching voluptuous-serialize."""
     with pytest.raises(ValueError, match="unable to serialize"):


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. Previously this raised; now it produces output. Nothing that worked before changes.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`probatio.serialize` raised on a literal mapping value instead of emitting a constant field, breaking the byte-for-byte parity the field-list codec promises with voluptuous-serialize.

```python
serialize(Schema({Required("n"): 5}))
# before: ValueError("unable to serialize schema: 5")
# voluptuous-serialize: [{"type": "constant", "value": 5, "name": "n", "required": True}]
```

A literal mapping value (`{"mode": 5}` means "the value must equal 5") is a constant the value must match. This serializes a bare `str`/`int`/`float`/`bool` as `{"type": "constant", "value": <value>}`, matching voluptuous-serialize exactly. `bool` is an `int` subclass, so it is covered. `None` is not a constant in voluptuous-serialize (it raises there), so it still raises here, keeping parity.

Surfaced migrating Home Assistant off voluptuous (Insteon read-only properties serialize a constant value).

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to: voluptuous-serialize parity (Home Assistant migration)
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
