### PR TITLE
Propagate a schema's extra policy into combinator branches

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -539,6 +539,14 @@ class Schema:
         if isinstance(schema, list | tuple | set | frozenset):
             return self._compile_sequence(schema)
         if callable(schema):
+            # A combinator compiles its branches at construction with the strict
+            # default extra. When this schema sets a different policy, rebind the
+            # combinator so the policy reaches dict schemas nested inside it
+            # (matching voluptuous), on a copy so the shared instance is untouched.
+            if self.extra != PREVENT_EXTRA:
+                rebind = getattr(schema, "__probatio_with_extra__", None)
+                if rebind is not None:
+                    schema = rebind(self.extra)
             # probatio's own validators always raise Invalid (never leak a
             # ValueError), so they can be called directly. Arbitrary callables go
             # through the guard that turns a ValueError into an Invalid.
@@ -756,7 +764,11 @@ class Schema:
         return validate
 
 
-def compile_schema(schema: Any, required: bool = False) -> CompiledSchema:  # noqa: FBT001, FBT002
+def compile_schema(
+    schema: Any,
+    required: bool = False,  # noqa: FBT001, FBT002
+    extra: int = PREVENT_EXTRA,
+) -> CompiledSchema:
     """Compile a schemable into its raw validating callable.
 
     The compiler service the combinators use to compile their sub-schemas without
@@ -765,12 +777,15 @@ def compile_schema(schema: Any, required: bool = False) -> CompiledSchema:  # no
     (that is ``Schema.__call__``'s job, which the structural validators compose).
 
     ``required`` propagates into mapping sub-schemas, the way voluptuous applies a
-    combinator's ``required`` to the schemas it wraps.
+    combinator's ``required`` to the schemas it wraps. ``extra`` is the enclosing
+    schema's extra-key policy, propagated into dict schemas nested in the
+    combinator (also matching voluptuous); it defaults to ``PREVENT_EXTRA``, so a
+    combinator built on its own keeps the strict default.
     """
     # Flag the compile so a ``Self`` wrapped here (``Any(Self, ...)``) is deferred
     # to validation time rather than rejected as a bare ``Schema(Self)`` would be.
     token = _COMPILING_FOR_COMBINATOR.set(True)
     try:
-        return Schema(schema, required=required)._compiled  # noqa: SLF001
+        return Schema(schema, required=required, extra=extra)._compiled  # noqa: SLF001
     finally:
         _COMPILING_FOR_COMBINATOR.reset(token)

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -10,6 +10,7 @@ typing one is referred to as ``typing.Any`` throughout.
 
 from __future__ import annotations
 
+import copy
 import typing
 
 from probatio.error import (
@@ -20,8 +21,38 @@ from probatio.error import (
     NotEnoughValid,
     TooManyValid,
 )
-from probatio.schema import compile_schema
+from probatio.schema import PREVENT_EXTRA, compile_schema
 from probatio.validators._base import _SafeValidator
+
+
+class _Combinator(_SafeValidator):
+    """Base for the combinators, threading an enclosing schema's extra policy in.
+
+    A combinator compiles its branches at construction with the strict default
+    extra policy. When a ``Schema`` wraps it with a different ``extra``, the schema
+    rebinds it through ``__probatio_with_extra__``, which recompiles the branches
+    under that policy on a copy. That carries the policy into dict schemas nested
+    in the combinator, the way voluptuous compiles them, without mutating the
+    shared combinator instance.
+    """
+
+    _extra: int
+
+    def _compile_branches(self) -> None:  # pragma: no cover - each combinator overrides
+        """Recompile ``self.validators`` into ``self._compiled`` under ``self._extra``."""
+        raise NotImplementedError
+
+    def __probatio_with_extra__(self, extra: int) -> _Combinator:
+        """Return a copy of this combinator recompiled under ``extra``.
+
+        The enclosing ``Schema`` only rebinds when its policy differs from the
+        combinator's strict default, so this recompiles on a fresh copy and never
+        touches the shared instance.
+        """
+        clone = copy.copy(self)
+        clone._extra = extra  # noqa: SLF001
+        clone._compile_branches()  # noqa: SLF001
+        return clone
 
 
 def _branch_label(branch: typing.Any) -> str | None:
@@ -105,7 +136,7 @@ def _combinator_repr(combinator: typing.Any) -> str:
     return f"{type(combinator).__name__}({body}, msg={combinator.msg!r})"
 
 
-class All(_SafeValidator):
+class All(_Combinator):
     """Apply every validator in turn; all must pass, the output chains forward."""
 
     def __init__(
@@ -124,8 +155,14 @@ class All(_SafeValidator):
         self.validators = list(validators)
         self.msg = msg
         self.required = required
+        self._extra = PREVENT_EXTRA
+        self._compile_branches()
+
+    def _compile_branches(self) -> None:
+        """Compile each validator under the current extra policy."""
         self._compiled = [
-            compile_schema(validator, required=required) for validator in validators
+            compile_schema(validator, required=self.required, extra=self._extra)
+            for validator in self.validators
         ]
 
     def __call__(self, value: typing.Any) -> typing.Any:
@@ -194,7 +231,7 @@ def _run_typed_any(
     raise AnyInvalid(message)
 
 
-class Any(_SafeValidator):
+class Any(_Combinator):
     """Return the first validator that accepts the value; fail if none do."""
 
     # Marks Any as a "complex" mapping key: ``Required(Any("a", "b"))`` requires
@@ -218,8 +255,14 @@ class Any(_SafeValidator):
         self.validators = list(validators)
         self.msg = msg
         self.required = required
+        self._extra = PREVENT_EXTRA
+        self._compile_branches()
+
+    def _compile_branches(self) -> None:
+        """Compile each branch under the current extra policy."""
         self._compiled = [
-            compile_schema(validator, required=required) for validator in validators
+            compile_schema(validator, required=self.required, extra=self._extra)
+            for validator in self.validators
         ]
         self._types = _type_tuple(self._compiled)
         self._expected = _expected_label(self.validators)
@@ -236,7 +279,7 @@ class Any(_SafeValidator):
         return _combinator_repr(self)
 
 
-class Union(_SafeValidator):
+class Union(_Combinator):
     """Like ``Any``, but an optional discriminant narrows which validators to try.
 
     Without a discriminant it behaves like ``Any``. With one, the discriminant is
@@ -263,8 +306,14 @@ class Union(_SafeValidator):
         self.msg = msg
         self.required = required
         self.discriminant = discriminant
+        self._extra = PREVENT_EXTRA
+        self._compile_branches()
+
+    def _compile_branches(self) -> None:
+        """Compile each branch under the current extra policy, indexing by id."""
         self._compiled = [
-            compile_schema(validator, required=required) for validator in validators
+            compile_schema(validator, required=self.required, extra=self._extra)
+            for validator in self.validators
         ]
         # Map each raw validator to its compiled form by identity, so a
         # discriminant's chosen subset resolves in one lookup per choice instead
@@ -273,7 +322,7 @@ class Union(_SafeValidator):
             id(raw): compiled
             for raw, compiled in zip(self.validators, self._compiled, strict=True)
         }
-        self._types = _type_tuple(self._compiled) if discriminant is None else None
+        self._types = _type_tuple(self._compiled) if self.discriminant is None else None
         self._expected = _expected_label(self.validators)
 
     def __call__(self, value: typing.Any) -> typing.Any:
@@ -286,7 +335,8 @@ class Union(_SafeValidator):
         # its compiled form, compiling any object it returns that was not among
         # the originals (matching voluptuous, which recompiles the chosen set).
         candidates = [
-            self._compiled_by_id.get(id(option)) or compile_schema(option)
+            self._compiled_by_id.get(id(option))
+            or compile_schema(option, extra=self._extra)
             for option in self.discriminant(value, self.validators)
         ]
         # The discriminant chose a subset, so the all-branches label would not
@@ -298,7 +348,7 @@ class Union(_SafeValidator):
         return _combinator_repr(self)
 
 
-class SomeOf(_SafeValidator):
+class SomeOf(_Combinator):
     """Require the value to pass a bounded number of the given validators.
 
     The output of each passing validator feeds the next, like ``All``. At least
@@ -328,8 +378,13 @@ class SomeOf(_SafeValidator):
         self.max_valid = max_valid if max_valid is not None else len(self.validators)
         self.msg = msg
         self.required = required
+        self._extra = PREVENT_EXTRA
+        self._compile_branches()
+
+    def _compile_branches(self) -> None:
+        """Compile each validator under the current extra policy."""
         self._compiled = [
-            compile_schema(validator, required=required)
+            compile_schema(validator, required=self.required, extra=self._extra)
             for validator in self.validators
         ]
 

--- a/tests/validators/test_combinators.py
+++ b/tests/validators/test_combinators.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import pytest
 
 from probatio import (
+    ALLOW_EXTRA,
+    PREVENT_EXTRA,
+    REMOVE_EXTRA,
     All,
     And,
     Any,
     Coerce,
+    Invalid,
     MultipleInvalid,
     Or,
     Range,
+    Required,
     Schema,
     SomeOf,
     Switch,
@@ -220,3 +225,53 @@ def test_any_of_literals_lists_the_values() -> None:
     error = caught.value.errors[0]
     assert isinstance(error, AnyInvalid)
     assert error.error_message == "expected 'a' or 'b'"
+
+
+def test_allow_extra_propagates_into_any_branch_dicts() -> None:
+    """A Schema's ALLOW_EXTRA reaches dict branches nested in Any (voluptuous parity)."""
+    schema = Schema(
+        Any(
+            {Required("write"): int},
+            {Required("state"): int},
+            msg="at least one",
+        ),
+        extra=ALLOW_EXTRA,
+    )
+    data = {"write": 1, "state": 2, "passive": []}
+    assert schema(data) == data
+
+
+def test_allow_extra_propagates_into_all_branch_dicts() -> None:
+    """ALLOW_EXTRA reaches dict schemas nested in All too."""
+    schema = Schema(All({Required("a"): int}), extra=ALLOW_EXTRA)
+    assert schema({"a": 1, "extra": 9}) == {"a": 1, "extra": 9}
+
+
+def test_allow_extra_propagates_into_someof_and_union() -> None:
+    """ALLOW_EXTRA reaches dict schemas nested in SomeOf and Union."""
+    some = Schema(SomeOf([{Required("a"): int}], min_valid=1), extra=ALLOW_EXTRA)
+    assert some({"a": 1, "x": 2}) == {"a": 1, "x": 2}
+    union = Schema(Union({"kind": "a", "v": int}), extra=ALLOW_EXTRA)
+    assert union({"kind": "a", "v": 1, "x": 2}) == {"kind": "a", "v": 1, "x": 2}
+
+
+def test_remove_extra_propagates_into_any_branch_dicts() -> None:
+    """REMOVE_EXTRA reaches dict branches nested in Any, dropping unknown keys."""
+    schema = Schema(Any({Required("a"): int}), extra=REMOVE_EXTRA)
+    assert schema({"a": 1, "junk": 9}) == {"a": 1}
+
+
+def test_default_still_rejects_extra_in_a_combinator_branch() -> None:
+    """With the default PREVENT_EXTRA, an unknown key in an Any branch still rejects."""
+    schema = Schema(Any({Required("a"): int}))
+    with pytest.raises(MultipleInvalid):
+        schema({"a": 1, "junk": 9})
+
+
+def test_extra_rebind_does_not_mutate_a_shared_combinator() -> None:
+    """Wrapping a combinator with ALLOW_EXTRA must not change it for another schema."""
+    shared = Any({Required("a"): int})
+    assert Schema(shared, extra=ALLOW_EXTRA)({"a": 1, "x": 2}) == {"a": 1, "x": 2}
+    # The same instance, used strictly elsewhere, still rejects the extra key.
+    with pytest.raises(Invalid):
+        Schema(shared, extra=PREVENT_EXTRA)({"a": 1, "x": 2})


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None in the strict default. With `extra=ALLOW_EXTRA`/`REMOVE_EXTRA`, a dict nested in a combinator now applies that policy where it previously rejected extra keys, which is a correctness fix toward voluptuous parity, not a regression.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`Schema(Any({...}, {...}), extra=ALLOW_EXTRA)` did not push the outer extra-key policy into the dict schemas nested in the `Any` (or `All`/`Union`/`SomeOf`). The branches stayed `PREVENT_EXTRA`, so any extra key in the data made every branch fail:

```python
schema = Schema(
    Any({Required("write"): IsTrue()}, {Required("state"): IsTrue()}, msg="at least one"),
    extra=ALLOW_EXTRA,
)
schema({"write": "1/2/3", "state": None, "passive": []})
# before: Invalid("at least one")
# voluptuous: {"write": "1/2/3", "state": None, "passive": []}
```

voluptuous compiles those nested dicts with the enclosing schema's `extra`, so this was a compatibility gap. A directly-nested dict value already inherited the policy in probatio; combinators were the hole, because they compile their branches at construction (before the enclosing `Schema` exists) and were then used as-is.

The fix: a combinator still compiles its branches with the strict default at construction, but when a `Schema` wraps it with a different `extra`, the schema rebinds it through a new `__probatio_with_extra__` hook, which recompiles the branches under that policy **on a copy**. So the policy reaches dict schemas nested in the combinator (matching voluptuous), the shared combinator instance is never mutated (a combinator reused in another `Schema` keeps its own policy), and the strict-default path pays nothing (no rebind unless the policy differs).

Surfaced migrating Home Assistant off voluptuous (KNX `GASelector.build_schema`, "at least one group address is set, extra keys allowed").

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue:
- This PR is related to: voluptuous compatibility (Home Assistant migration)
- Link to a separate documentation pull request:

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
