### PR TITLE
Match voluptuous-serialize output across more validators

### DIFF
--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -11,6 +11,8 @@ this codec.
 
 from __future__ import annotations
 
+import enum
+from collections.abc import Hashable, Mapping
 from typing import Any, cast
 
 from probatio.codecs._shared import UNSUPPORTED
@@ -30,16 +32,19 @@ from probatio.validators import (
     AsTime,
     Base64,
     ByteLength,
+    Capitalize,
     Clamp,
     Coerce,
     CreditCard,
     DataURI,
     Datetime,
     Duration,
+    Email,
     EndsWith,
     EnsureList,
     Epoch,
     Fqdn,
+    FqdnUrl,
     Hex,
     HexColor,
     Hostname,
@@ -50,7 +55,9 @@ from probatio.validators import (
     IPv6Address,
     IsRegex,
     Length,
+    Lower,
     MacAddress,
+    Maybe,
     MultipleOf,
     NonEmpty,
     NoWhitespace,
@@ -62,7 +69,11 @@ from probatio.validators import (
     Slug,
     Sorted,
     StartsWith,
+    Strip,
     TimeZone,
+    Title,
+    Upper,
+    Url,
 )
 from probatio.validators import Any as AnyValidator
 
@@ -110,6 +121,49 @@ _SERIALIZE_TYPES: dict[type, str] = {
     str: "string",
 }
 
+# The format validators, rendered as a ``format`` field by voluptuous-serialize.
+# These are the bare functions a voluptuous schema uses (``vol.Email``), so they
+# arrive uncalled under the shim.
+_SERIALIZE_FORMATS: dict[Any, str] = {Email: "email", Url: "url", FqdnUrl: "fqdnurl"}
+
+# The string transforms, rendered as a boolean flag (``{"lower": True}``).
+_SERIALIZE_TRANSFORMS: dict[Any, str] = {
+    Lower: "lower",
+    Upper: "upper",
+    Capitalize: "capitalize",
+    Title: "title",
+    Strip: "strip",
+}
+
+
+def _enum_select(enum_cls: type[enum.Enum]) -> dict[str, Any]:
+    """Render an Enum class as a select of its member values, like the oracle."""
+    return {
+        "type": "select",
+        "options": [(member.value, member.value) for member in enum_cls],
+    }
+
+
+def _serialize_callable(node: Any) -> dict[str, Any] | None:
+    """Render a bare format validator or string transform, or None if neither."""
+    if not isinstance(node, Hashable):
+        # The format/transform tables are keyed by identity, so an unhashable
+        # callable cannot be one. Bail before the dict lookup hashes it, leaving
+        # it to fall through to the ValueError like the oracle does.
+        return None
+    fmt = _SERIALIZE_FORMATS.get(node)
+    if fmt is not None:
+        return {"format": fmt}
+    flag = _SERIALIZE_TRANSFORMS.get(node)
+    if flag is not None:
+        return {flag: True}
+    return None
+
+
+def _allow_none(field: dict[str, Any]) -> dict[str, Any]:
+    """Mark a serialized value field as nullable, matching ``Maybe``'s oracle output."""
+    return {**field, "allow_none": True}
+
 
 def serialize(schema: Any, *, custom_serializer: Any = None) -> Any:
     """Render a schema as the field-list shape voluptuous-serialize produces.
@@ -142,7 +196,7 @@ def _serialize_field(key: Any, value: Any, custom: Any) -> dict[str, Any]:
     marker = key if isinstance(key, Marker) else None
     field = dict(_serialize_value(value, custom))
     field["name"] = marker.schema if marker is not None else key
-    if marker is not None and marker.description:
+    if marker is not None and marker.description is not None:
         field["description"] = marker.description
     field["required"] = isinstance(marker, Required)
     if isinstance(marker, Optional):
@@ -165,6 +219,14 @@ def _serialize_value(node: Any, custom: Any) -> dict[str, Any]:
         name = _SERIALIZE_TYPES.get(node)
         if name is not None:
             return {"type": name}
+        if issubclass(node, enum.Enum):
+            return _enum_select(node)
+    if callable(node):
+        # The format validators and string transforms are bare functions, so they
+        # are matched by identity before the validator dispatch below.
+        func_field = _serialize_callable(node)
+        if func_field is not None:
+            return func_field
     converted = _serialize_validator(node, custom)
     if converted is not None:
         return converted
@@ -181,8 +243,22 @@ def _serialize_value(node: Any, custom: Any) -> dict[str, Any]:
 def _serialize_validator(node: Any, custom: Any) -> dict[str, Any] | None:  # noqa: PLR0911
     """Render a known validator, or None if it is not recognized."""
     if isinstance(node, In):
-        return {"type": "select", "options": [(item, item) for item in node.container]}
+        # A mapping container carries a label per value, so its items become the
+        # (value, label) options; a list/tuple uses each item as its own label.
+        container = node.container
+        options = (
+            list(container.items())
+            if isinstance(container, Mapping)
+            else [(item, item) for item in container]
+        )
+        return {"type": "select", "options": options}
+    if isinstance(node, Maybe):
+        return _allow_none(_serialize_value(node.validator, custom))
     if isinstance(node, AnyValidator):
+        # ``Maybe(X)`` compiles to ``Any(None, X)``: voluptuous-serialize strips a
+        # leading None and marks the single remaining member allow_none.
+        if len(node.validators) == 2 and node.validators[0] is None:
+            return _allow_none(_serialize_value(node.validators[1], custom))
         for validator in node.validators:
             converted = _serialize_value(validator, custom)
             if converted:
@@ -195,7 +271,13 @@ def _serialize_validator(node: Any, custom: Any) -> dict[str, Any] | None:  # no
         return merged
     if isinstance(node, Coerce):
         name = _SERIALIZE_TYPES.get(node.type)
-        return {"type": name} if name is not None else {}
+        if name is not None:
+            return {"type": name}
+        if isinstance(node.type, type) and issubclass(node.type, enum.Enum):
+            return _enum_select(node.type)
+        # An unmapped coerce target (a function, a custom type) carries no field
+        # hint, so it serializes to an open dict rather than raising.
+        return {}
     typed = _serialize_typed(node, custom)
     if typed is not None:
         return typed

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -8,6 +8,7 @@ probatio schemas unchanged.
 
 from __future__ import annotations
 
+import enum
 from typing import Any
 
 import pytest
@@ -133,6 +134,19 @@ def test_unsupported_value_raises() -> None:
         serialize(Schema([str]))
 
 
+def test_unhashable_callable_value_raises_cleanly() -> None:
+    """An unhashable callable value raises ValueError, not a leaked TypeError."""
+
+    class _Unhashable:
+        __hash__ = None
+
+        def __call__(self, value: Any) -> Any:
+            return value
+
+    with pytest.raises(ValueError, match="unable to serialize"):
+        serialize(Schema({Required("k"): _Unhashable()}))
+
+
 def test_custom_serializer_overrides_and_defers() -> None:
     """A custom serializer can override a node or defer with UNSUPPORTED."""
     sentinel = object()
@@ -242,3 +256,48 @@ def test_string_and_no_shape_validators_serialize() -> None:
     assert by_name["a"]["type"] == "string"
     assert by_name["b"]["type"] == "string"
     assert "type" not in by_name["c"]
+
+
+class _Color(enum.Enum):
+    """A small enum shared by both libraries in the parity cases.
+
+    The member values differ from the lowercased names on purpose, so the select
+    options pin ``member.value`` and not ``member.name.lower()``.
+    """
+
+    RED = "r"
+    GREEN = "green"
+
+
+def _parity_build(lib: Any) -> dict[str, Any]:
+    """Schemas exercising the constructs serialize must match the oracle on."""
+    req, opt = lib.Required, lib.Optional
+    return {
+        "in_dict": {req("k"): lib.In({"x": "X", "y": "Y"})},
+        "in_list": {req("k"): lib.In(["a", "b"])},
+        "email": {req("k"): lib.Email},
+        "url": {req("k"): lib.Url},
+        "fqdnurl": {req("k"): lib.FqdnUrl},
+        "lower": {req("k"): lib.Lower},
+        "upper": {req("k"): lib.Upper},
+        "capitalize": {req("k"): lib.Capitalize},
+        "title": {req("k"): lib.Title},
+        "strip": {req("k"): lib.Strip},
+        "maybe": {req("k"): lib.Maybe(int)},
+        "any_none_first": {req("k"): lib.Any(None, str)},
+        "enum_class": {req("k"): _Color},
+        "coerce_enum": {req("k"): lib.Coerce(_Color)},
+        "coerce_int": {req("k"): lib.Coerce(int)},
+        "empty_description": {opt("k", description=""): int},
+        "none_description": {opt("k", description=None): int},
+    }
+
+
+@pytest.mark.parametrize("case", list(_parity_build(voluptuous)))
+def test_serialize_matches_voluptuous_serialize(case: str) -> None:
+    """serialize matches voluptuous-serialize byte for byte across these constructs."""
+    got = serialize(Schema(_parity_build(probatio)[case]))
+    want = voluptuous_serialize.convert(
+        voluptuous.Schema(_parity_build(voluptuous)[case])
+    )
+    assert got == want


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The field-list codec (`serialize`, the voluptuous-serialize shape that config-flow frontends and tool exporters consume) diverged from the voluptuous-serialize oracle on several common constructs. This brings them back into byte-for-byte agreement:

- `In` over a mapping renders `(value, label)` options from its items; a list or tuple keeps each item as its own label.
- The bare format validators (`Email`, `Url`, `FqdnUrl`) render as a `format` field.
- The bare string transforms (`Lower`, `Upper`, `Capitalize`, `Title`, `Strip`) render as a boolean flag like `{"lower": true}`.
- `Maybe(X)` and a None-first two-member `Any(None, X)` strip the None and mark the remainder `allow_none`, exactly as the oracle does (it only special-cases the None-first form, so this matches that and nothing wider).
- An `Enum` class renders as a `select` of its member values; `Coerce(Enum)` renders the same select.
- A marker with an empty-string description now emits that description, matching the oracle's identity check rather than a truthiness check.

Each construct is pinned by a differential parity table that builds the same schema in both libraries and compares `serialize` against `voluptuous_serialize.convert` byte for byte.

While adding the bare-callable dispatch, an unhashable callable value would have leaked a `TypeError` from the identity-keyed table lookup. It now falls through to the same `ValueError` the oracle raises, so the reject path stays clean.

The pre-existing intentional deviations (a `Coerce` of an unmapped non-type serializing to an open dict, and a multi-member `Any` picking its first usable member) are left as they were; both are deliberate leniency for the frontend use case and are covered by their own tests.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
