### PR TITLE
Fix dropped and mis-decoded constraints in the JSON Schema decoder

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -223,8 +223,31 @@ def _convert_validator(node: Any) -> dict[str, Any] | None:
         merged: dict[str, Any] = {}
         for validator in node.validators:
             merged.update(_child(validator))
-        return merged
+        return _retarget_length(merged)
     return _convert_constraint(node)
+
+
+# JSON Schema spells "length" three ways depending on the type: minLength for a
+# string, minItems for an array, minProperties for an object. A Length validator
+# always renders the string form, so an All that pins an array or object length
+# has to move the bounds onto the matching keyword.
+_LENGTH_KEYS_BY_TYPE: dict[str, tuple[str, str]] = {
+    "array": ("minItems", "maxItems"),
+    "object": ("minProperties", "maxProperties"),
+}
+
+
+def _retarget_length(merged: dict[str, Any]) -> dict[str, Any]:
+    """Move a merged Length's string-length keys onto the array/object keyword."""
+    keys = _LENGTH_KEYS_BY_TYPE.get(merged.get("type", ""))
+    if keys is None:
+        return merged
+    min_key, max_key = keys
+    if "minLength" in merged:
+        merged[min_key] = merged.pop("minLength")
+    if "maxLength" in merged:
+        merged[max_key] = merged.pop("maxLength")
+    return merged
 
 
 def _convert_equality(node: Any) -> dict[str, Any] | None:
@@ -516,31 +539,60 @@ def _build_node(node: Any, ctx: _Decode) -> Any:
         )
         raise SchemaError(message)
     _reject_unsupported(node)
-    # The core dispatch is kept inline (not a helper) so a deeply nested schema
-    # does not spend an extra stack frame per level, which would let Python's
-    # recursion limit fire before the explicit depth guard in _from_node.
-    if "$ref" in node:
-        result = _from_ref(node["$ref"], ctx)
-    elif "const" in node:
-        result = _from_const(node["const"])
-    elif "enum" in node:
-        result = _from_enum(node["enum"])
-    elif "not" in node:
-        result = _Not(_from_node(node["not"], ctx))
-    elif "anyOf" in node:
-        result = _from_combinator(node["anyOf"], "anyOf", AnyValidator, ctx)
-    elif "oneOf" in node:
-        result = _from_oneof(node["oneOf"], ctx)
-    elif "allOf" in node:
-        result = _from_combinator(node["allOf"], "allOf", All, ctx)
+    facets = _collect_facets(node, ctx)
+    if not facets:
+        result: Any = object
+    elif len(facets) == 1:
+        result = facets[0]
     else:
-        result = _from_typed(node, ctx)
+        result = All(*facets)
     if node.get("writeOnly") is True:
         # JSON Schema's secret marker round-trips back into a Secret.
         result = Secret(result)
     if ctx.openapi and node.get("nullable") is True:
         result = Maybe(result)
     return result
+
+
+def _collect_facets(node: dict[str, Any], ctx: _Decode) -> list[Any]:
+    """Collect every facet of a node, to be ANDed together.
+
+    A JSON Schema object's keywords are conjunctive: a value must satisfy every
+    facet present (a combinator AND a sibling ``type`` AND any constraint). The
+    old decoder picked a single branch and silently dropped the rest, which would
+    widen an untrusted schema (accept data the author meant to forbid).
+    """
+    facets: list[Any] = []
+    if "$ref" in node:
+        facets.append(_from_ref(node["$ref"], ctx))
+    if "const" in node:
+        facets.append(_from_const(node["const"]))
+    elif "enum" in node:
+        facets.append(_from_enum(node["enum"]))
+    if "not" in node:
+        facets.append(_Not(_from_node(node["not"], ctx)))
+    if "allOf" in node:
+        facets.append(_from_combinator(node["allOf"], "allOf", All, ctx))
+    if "anyOf" in node:
+        facets.append(_from_combinator(node["anyOf"], "anyOf", AnyValidator, ctx))
+    if "oneOf" in node:
+        facets.append(_from_oneof(node["oneOf"], ctx))
+    typed = _typed_facet(node, ctx)
+    if typed is not None:
+        facets.append(typed)
+    return facets
+
+
+def _typed_facet(node: dict[str, Any], ctx: _Decode) -> Any:
+    """Return the ``type``-based or standalone-constraint facet of a node, or None.
+
+    None means a node carries neither a ``type`` nor a recognized constraint
+    keyword, so a node that is only a combinator (an ``allOf`` with no sibling
+    assertions) does not pick up a redundant accept-anything facet.
+    """
+    if "type" in node:
+        return _from_typed(node, ctx)
+    return _combine_constraints(node, ctx)
 
 
 # Restrictive keywords probatio does not implement. Silently ignoring one would
@@ -708,10 +760,11 @@ def _from_typed(node: dict[str, Any], ctx: _Decode) -> Any:
     if json_type in ("integer", "number"):
         base = int if json_type == "integer" else AnyValidator(int, float)
         return _from_number(node, base=base)
-    # No recognized type keyword: honor any constraint keywords on their own, so a
-    # typeless schema like {"minimum": 1} or {"uniqueItems": true} round-trips back
-    # into the matching validator instead of dropping the constraint.
-    return _from_typeless(node, ctx)
+    # An unrecognized type keyword: ignore it and honor any constraint keywords on
+    # their own, so the type does not swallow the rest of the schema. A node with
+    # no constraint accepts any value.
+    combined = _combine_constraints(node, ctx)
+    return object if combined is None else combined
 
 
 def _from_type_list(node: dict[str, Any], types: list[str], ctx: _Decode) -> Any:
@@ -728,18 +781,18 @@ _NUMERIC_BOUND_KEYS = frozenset(
 )
 
 
-def _from_typeless(node: dict[str, Any], ctx: _Decode) -> Any:
-    """Build a validator from a typeless schema's standalone constraint keywords.
+def _combine_constraints(node: dict[str, Any], ctx: _Decode) -> Any:
+    """Combine a node's standalone constraint keywords into one validator, or None.
 
     With no ``type``, a JSON Schema still carries meaning through keywords like
     ``minimum``, ``minLength``, ``multipleOf``, ``uniqueItems``, and ``contains``.
     Each becomes its matching validator so the encoder's typeless output (a bare
-    ``Range``, ``Length``, ``MultipleOf``, ``Unique``, or ``Contains``) round-trips.
-    A schema with no recognized keyword accepts any value.
+    ``Range``, ``Length``, ``MultipleOf``, ``Unique``, or ``ContainsCount``) round
+    trips. None means the node carries no recognized constraint.
     """
     constraints = _from_constraints(node, ctx)
     if not constraints:
-        return object
+        return None
     if len(constraints) == 1:
         return constraints[0]
     return All(*constraints)
@@ -859,10 +912,12 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     max_items = _item_count(node, "maxItems")
     bounded = min_items is not None or max_items is not None
     has_contains = "contains" in node
+    has_unique = node.get("uniqueItems") is True
     if items is None:
-        # No item schema: any list. Length and contains still apply, so a
-        # constrained array accepts any element ([object]) but must satisfy them.
-        if not bounded and not has_contains:
+        # No item schema: any list. Length, uniqueItems, and contains still apply,
+        # so a constrained array accepts any element ([object]) but must satisfy
+        # them.
+        if not bounded and not has_contains and not has_unique:
             return list
         sequence: Any = [object]
     elif isinstance(items, dict) and "anyOf" in items:
@@ -872,6 +927,8 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     constraints: list[Any] = []
     if bounded:
         constraints.append(Length(min=min_items, max=max_items))
+    if has_unique:
+        constraints.append(Unique())
     if has_contains:
         constraints.append(_from_contains(node, ctx))
     if constraints:
@@ -882,15 +939,15 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
 def _from_contains(node: dict[str, Any], ctx: _Decode) -> Any:
     """Build a contains check, honoring ``minContains``/``maxContains`` counts.
 
-    Plain ``contains`` requires at least one matching item (the spec default of
-    ``minContains: 1``). When a count bound is present, a counting validator
-    enforces how many items must match.
+    JSON Schema ``contains`` requires at least one element to match a subschema
+    (the spec default of ``minContains: 1``); a count bound sets how many. This
+    is schema-matching, not membership, so it must not decode to probatio's
+    ``Contains`` (which tests whether a literal value is an element). The
+    counting validator carries the right semantics for the plain case too.
     """
     item = _from_node(node["contains"], ctx)
     min_count = _item_count(node, "minContains")
     max_count = _item_count(node, "maxContains")
-    if min_count is None and max_count is None:
-        return Contains(item)
     return _ContainsCount(item, 1 if min_count is None else min_count, max_count)
 
 

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -19,6 +19,7 @@ from probatio import (
 from probatio.error import SchemaError
 from probatio.markers import Forbidden
 from probatio.validators import (
+    All,
     Base64,
     Contains,
     ExactSequence,
@@ -689,3 +690,91 @@ def test_structurally_malformed_schema_fails_closed() -> None:
     """
     with pytest.raises(SchemaError, match="malformed"):
         from_json_schema({"type": "array", "items": {"anyOf": True}})
+
+
+def test_plain_contains_matches_a_subschema_not_membership() -> None:
+    """Plain ``contains`` requires an element matching the subschema, not equality.
+
+    JSON Schema ``contains`` is satisfied when at least one element validates
+    against the subschema, so ``{"contains": {"type": "integer"}}`` accepts a list
+    that holds any integer. Decoding it to probatio's ``Contains`` (a literal
+    membership test) would wrongly reject such a list.
+    """
+    schema = from_json_schema({"contains": {"type": "integer"}})
+    assert schema(["a", 1]) == ["a", 1]
+    with pytest.raises(Invalid):
+        schema(["a", "b"])
+
+
+def test_allof_keeps_a_sibling_constraint() -> None:
+    """A keyword beside ``allOf`` is enforced too, not dropped (fail closed)."""
+    schema = from_json_schema({"allOf": [{"type": "integer"}], "minimum": 5})
+    assert schema(7) == 7
+    with pytest.raises(Invalid):
+        schema(3)  # below the sibling minimum
+
+
+def test_not_keeps_a_sibling_constraint() -> None:
+    """A keyword beside ``not`` is enforced too, not dropped (fail closed)."""
+    schema = from_json_schema({"not": {"type": "string"}, "minimum": 5})
+    assert schema(7) == 7
+    with pytest.raises(Invalid):
+        schema(3)  # below the sibling minimum
+
+
+def test_anyof_keeps_a_sibling_type() -> None:
+    """A ``type`` beside ``anyOf`` is enforced too, not dropped (fail closed)."""
+    schema = from_json_schema(
+        {"anyOf": [{"minimum": 0}, {"minimum": 100}], "type": "integer"},
+    )
+    assert schema(5) == 5
+    with pytest.raises(Invalid):
+        schema("5")  # the sibling type rejects a string
+
+
+def test_unique_items_under_array_type() -> None:
+    """uniqueItems is honored under an explicit array type, not only typeless."""
+    schema = from_json_schema({"type": "array", "uniqueItems": True})
+    assert schema([1, 2]) == [1, 2]
+    with pytest.raises(Invalid):
+        schema([1, 1])
+
+
+def test_unique_array_round_trips_through_the_codec() -> None:
+    """All([int], Unique()) survives encode then decode and still rejects duplicates."""
+    schema = from_json_schema(to_json_schema(Schema(All([int], Unique()))))
+    assert schema([1, 2]) == [1, 2]
+    with pytest.raises(Invalid):
+        schema([1, 1])
+
+
+def test_array_length_round_trips_as_item_count() -> None:
+    """An array length encodes as minItems/maxItems and decodes back enforcing it."""
+    schema = from_json_schema(to_json_schema(Schema(All([int], Length(min=2)))))
+    assert schema([1, 2]) == [1, 2]
+    with pytest.raises(Invalid):
+        schema([1])  # below the array length
+
+
+def test_unrecognized_type_accepts_anything() -> None:
+    """An unknown ``type`` value is ignored, leaving an accept-anything schema."""
+    schema = from_json_schema({"type": "nonsense"})
+    assert schema("x") == "x"
+    assert schema(5) == 5
+
+
+def test_unrecognized_type_still_honors_a_constraint() -> None:
+    """An unknown ``type`` does not swallow a sibling constraint keyword."""
+    schema = from_json_schema({"type": "nonsense", "minimum": 5})
+    assert schema(7) == 7
+    with pytest.raises(Invalid):
+        schema(3)  # the sibling minimum still applies
+
+
+def test_object_length_round_trips_as_property_count() -> None:
+    """An object length encodes as min/maxProperties and decodes back enforcing it."""
+    source = {"type": "object", "additionalProperties": True, "minProperties": 2}
+    schema = from_json_schema(to_json_schema(from_json_schema(source)))
+    assert schema({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    with pytest.raises(Invalid):
+        schema({"a": 1})  # below the property count

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -270,6 +270,36 @@ def test_contains_exports_contains() -> None:
     assert to_json_schema(Schema(Contains(5))) == {"contains": {"const": 5}}
 
 
+def test_array_length_exports_item_count() -> None:
+    """A Length guarding an array exports minItems/maxItems, not the string form."""
+    assert to_json_schema(Schema(All([int], Length(min=1, max=2)))) == {
+        "type": "array",
+        "items": {"type": "integer"},
+        "minItems": 1,
+        "maxItems": 2,
+    }
+
+
+def test_object_length_exports_property_count() -> None:
+    """A Length guarding an object exports minProperties/maxProperties."""
+    assert to_json_schema(Schema(All({Required("a"): int}, Length(min=2)))) == {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}},
+        "additionalProperties": False,
+        "required": ["a"],
+        "minProperties": 2,
+    }
+
+
+def test_string_length_keeps_the_string_form() -> None:
+    """A Length guarding a string still exports minLength/maxLength."""
+    assert to_json_schema(Schema(All(str, Length(min=1, max=5)))) == {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 5,
+    }
+
+
 def test_date_exports_date_format() -> None:
     """Date with the default ISO format exports format date."""
     assert to_json_schema(Schema(Date())) == {"type": "string", "format": "date"}


### PR DESCRIPTION
## Breaking change

A JSON Schema with a `not`/`anyOf`/`oneOf`/`allOf` keyword alongside a sibling `type` or constraint now enforces both, and an array's `uniqueItems` is honored under an explicit `type: array`. A document that round-trips through `from_json_schema` may therefore produce a stricter validator than before. This is the intended fix (the decoder must not drop a constraint), but a caller relying on the old, looser behavior would notice.

## Proposed change

The JSON Schema codec mishandled several array, `contains`, and combinator constructs. Each either dropped a constraint (widening an untrusted schema, against the decoder's fail-closed contract) or decoded to the wrong semantics. The audit that found these is the same codec parity pass behind the field-list and OpenAPI pull requests; this is the third and last of the three.

- Plain `contains` decoded to probatio's `Contains`, which is a literal membership test ("is this value an element"), where JSON Schema `contains` means "at least one element matches the subschema". The old decode rejected `["a", 1]` for `{"contains": {"type": "integer"}}`. It now uses the schema-matching counting validator, which already backed the `minContains`/`maxContains` case.
- A combinator (`not`/`anyOf`/`oneOf`/`allOf`) silently dropped any sibling `type` or constraint keyword. JSON Schema keywords are conjunctive, so the decoder now collects every facet present and combines them with `All`. A single-facet node keeps its exact previous shape, so only the multi-facet case changes.
- `uniqueItems` was ignored under an explicit `type: array` (it only worked on a typeless schema), dropping the constraint. It now builds a `Unique()`, which also closes the `All([T], Unique())` round-trip.
- A `Length` merged into an `All` always rendered the string-length keywords (`minLength`/`maxLength`), even when it guarded an array or object, so the length was lost on re-decode. The encoder now retargets the bounds to `minItems`/`maxItems` or `minProperties`/`maxProperties` based on the merged type.

The old `_from_typeless` becomes `_combine_constraints` (it returns `None` for "no constraint present"), so the new facet collector and the unrecognized-type fallback share one combiner. The decoder's depth guard and fail-closed handling are preserved; the worst-case recursion path (a typeless `contains` chain) is unchanged in stack depth.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
