### PR TITLE
Widen extend and marker description types for the drop-in promise

### DIFF
--- a/src/probatio/markers.py
+++ b/src/probatio/markers.py
@@ -127,7 +127,7 @@ class Marker:
         self,
         schema: Any,
         msg: str | None = None,
-        description: str | None = None,
+        description: Any | None = None,
     ) -> None:
         """Wrap ``schema`` (the key), with an optional message and description."""
         self.schema = schema
@@ -169,7 +169,7 @@ class Required(Marker):
         schema: Any,
         msg: str | None = None,
         default: Any = UNDEFINED,
-        description: str | None = None,
+        description: Any | None = None,
     ) -> None:
         """Mark ``schema`` required, with an optional default and metadata."""
         super().__init__(schema, msg, description)
@@ -184,7 +184,7 @@ class Optional(Marker):
         schema: Any,
         msg: str | None = None,
         default: Any = UNDEFINED,
-        description: str | None = None,
+        description: Any | None = None,
     ) -> None:
         """Mark ``schema`` optional, with an optional default and metadata."""
         super().__init__(schema, msg, description)
@@ -214,7 +214,7 @@ class Alias(Marker):
         required: bool = False,
         default: Any = UNDEFINED,
         msg: str | None = None,
-        description: str | None = None,
+        description: Any | None = None,
     ) -> None:
         """Wrap ``schema`` (the canonical name) with extra accepted ``aliases``."""
         if not aliases:
@@ -244,7 +244,7 @@ class Inclusive(Optional):
         group_of_inclusion: str,
         msg: str | None = None,
         default: Any = UNDEFINED,
-        description: str | None = None,
+        description: Any | None = None,
     ) -> None:
         """Mark ``schema`` co-dependent on the other keys in its group."""
         super().__init__(schema, msg, default, description)
@@ -267,7 +267,7 @@ class Exclusive(Optional):
         schema: Any,
         group_of_exclusion: str,
         msg: str | None = None,
-        description: str | None = None,
+        description: Any | None = None,
         *,
         required: bool = False,
         default: Any = UNDEFINED,

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -410,7 +410,7 @@ class Schema:
 
     def extend(
         self,
-        schema: dict[Any, Any] | Schema,
+        schema: Schemable,
         required: bool | None = None,  # noqa: FBT001
         extra: int | None = None,
     ) -> Schema:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -51,6 +51,18 @@ def test_description_is_writable() -> None:
     assert marker.description == "the friendly name"
 
 
+def test_description_holds_structured_data() -> None:
+    """description may hold any value, not only a string (voluptuous parity).
+
+    Home Assistant stuffs a dict like ``{"suggested_value": ...}`` into a marker's
+    description, so the type must stay as permissive as voluptuous left it.
+    """
+    marker = Optional("name", description={"suggested_value": 42})
+    assert marker.description == {"suggested_value": 42}
+    marker.description = {"suggested_value": "later"}
+    assert marker.description["suggested_value"] == "later"
+
+
 def test_copy_yields_an_independent_marker() -> None:
     """copy.copy gives an equal but separate marker that can be mutated."""
     marker = Optional("name")


### PR DESCRIPTION
## Breaking change

None. Both changes widen a public type, so every call that type-checked before still does; no runtime behavior changes.

## Proposed change

voluptuous left two public types permissive that probatio had narrowed. The narrowing breaks the drop-in promise: switching the import from `voluptuous` to `probatio` introduces new type-check errors for callers (Home Assistant) that relied on the looser types. Both are widened to match what voluptuous declared.

- `Schema.extend` typed its argument `dict | Schema`, but voluptuous accepts the broad `Schemable`. Home Assistant passes an `All` built from a dict (`BASE_COMMAND_MESSAGE_SCHEMA.extend(schema)` where `schema: dict | All`). The argument is now typed `Schemable` (probatio's existing exported alias), matching voluptuous. The runtime already rejects a genuine non-mapping with a clean `SchemaError`, exactly as voluptuous asserts, so only the static type changes.
- `Marker.description` was typed `str | None`, but voluptuous left it `Any`. Home Assistant stores a dict there (`{"suggested_value": ...}`, a long-standing pattern for suggested values), so the type is widened to `Any | None` across `Marker` and its subclasses. The codecs already treat the description as an opaque value (a truthiness check, then pass-through), so nothing downstream assumes a string.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
