### PR TITLE
Allow a default factory to decline by returning UNDEFINED

### DIFF
--- a/docs/src/content/docs/guides/dict-schemas-and-markers.md
+++ b/docs/src/content/docs/guides/dict-schemas-and-markers.md
@@ -61,6 +61,31 @@ schema = Schema(
 schema({})  # {'port': 8080, 'tags': []}
 ```
 
+A callable default may return `UNDEFINED` to decline: the key is then left absent,
+exactly as if it had no default. This is useful for a default that depends on
+runtime context (the active platform, which plugins are loaded), where sometimes
+no value should be supplied:
+
+```python
+from probatio import Schema, Optional, UNDEFINED
+
+context = {"fast": True}
+
+
+def speed_default():
+    return 80 if context["fast"] else UNDEFINED
+
+
+schema = Schema({Optional("speed", default=speed_default): int})
+
+print(schema({}))  # {'speed': 80}
+context["fast"] = False
+print(schema({}))  # {}
+```
+
+For a `Required` key a declining default leaves the key missing, so it is reported
+as a missing required key.
+
 ## The extra-key policy
 
 What happens to a key the schema does not mention is controlled by the `extra`
@@ -132,7 +157,7 @@ schema({"keep": 1, "drop": "gone"})  # {'keep': 1}
 
 ## Forbidding keys
 
-`Forbidden` is the inverse of `Required`: the key must *not* be present. If it
+`Forbidden` is the inverse of `Required`: the key must _not_ be present. If it
 appears, validation fails with "key not allowed". The mapped value is never
 looked at, so the idiom is to map it to `object`.
 
@@ -147,6 +172,7 @@ schema({"id": 1})  # {'id': 1}
 A present forbidden key fails:
 
 <!-- verify: raises MultipleInvalid -->
+
 ```python
 from probatio import Schema, Forbidden
 
@@ -197,7 +223,7 @@ an ambiguous schema fails fast rather than at validation.
 
 ## Type and callable keys
 
-A key does not have to be a literal. A type key validates *every* key of that
+A key does not have to be a literal. A type key validates _every_ key of that
 type, which is how you describe an open mapping like "string keys, integer
 values":
 
@@ -266,6 +292,7 @@ change what an empty group does. `required=True` makes the group demand exactly
 one key:
 
 <!-- verify: raises MultipleInvalid -->
+
 ```python
 from probatio import Schema, Exclusive
 

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -481,18 +481,27 @@ class _MappingValidator:
             if seen[index]:
                 continue
             if not isinstance(candidate.default, Undefined):
-                # The default is validated through the value schema, the way
-                # voluptuous does: a default is coerced (``default="1"`` through
-                # ``Coerce(int)`` yields ``1``) and a default that fails its
-                # schema is reported, not stored raw.
-                self._store(
-                    candidate.key_schema,
-                    candidate.default(),
-                    candidate.check_value,
-                    out,
-                    errors,
-                )
-            elif candidate.complex_keys is not None:
+                default = candidate.default()
+                if not isinstance(default, Undefined):
+                    # The default is validated through the value schema, the way
+                    # voluptuous does: a default is coerced (``default="1"``
+                    # through ``Coerce(int)`` yields ``1``) and a default that
+                    # fails its schema is reported, not stored raw.
+                    self._store(
+                        candidate.key_schema,
+                        default,
+                        candidate.check_value,
+                        out,
+                        errors,
+                    )
+                    continue
+                # A default callable may return ``UNDEFINED`` to decline at
+                # validation time, meaning "no default this run". The key is then
+                # treated as if it had no default: an Optional is left absent, a
+                # Required still reports the missing key below.
+                if not candidate.required:
+                    continue
+            if candidate.complex_keys is not None:
                 # Required(Any("a", "b")): at least one of the listed keys must be
                 # present (voluptuous 0.16.0). A custom marker msg still wins.
                 message = (
@@ -503,8 +512,9 @@ class _MappingValidator:
                     RequiredFieldInvalid(message, path=[candidate.key_schema]),
                 )
             else:
-                # A finalizer with no default is, by construction, a required key.
-                # A Required marker's own ``msg`` wins, matching voluptuous.
+                # A finalizer reaching here is required and unfilled: it had no
+                # default, or its default callable declined. A Required marker's
+                # own ``msg`` wins, matching voluptuous.
                 errors.append(
                     RequiredFieldInvalid(
                         candidate.msg or "required key not provided",
@@ -528,14 +538,19 @@ class _MappingValidator:
         for index in members:
             candidate = self._candidates[index]
             if not isinstance(candidate.default, Undefined):
-                self._store(
-                    candidate.key_schema,
-                    candidate.default(),
-                    candidate.check_value,
-                    out,
-                    errors,
-                )
-                return
+                default = candidate.default()
+                if not isinstance(default, Undefined):
+                    self._store(
+                        candidate.key_schema,
+                        default,
+                        candidate.check_value,
+                        out,
+                        errors,
+                    )
+                    return
+                # This member's default declined (returned ``UNDEFINED``): it does
+                # not fill the group, so try the next member, then the
+                # ``required`` check below.
         if any(self._candidates[index].exclusive_required for index in members):
             keys = [self._candidates[index].key_schema for index in members]
             message = f"exactly one of {keys} is required"

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -9,8 +9,10 @@ import pytest
 from probatio import (
     ALLOW_EXTRA,
     REMOVE_EXTRA,
+    UNDEFINED,
     Any,
     Coerce,
+    Exclusive,
     Extra,
     ExtraKeysInvalid,
     Invalid,
@@ -106,6 +108,43 @@ def test_required_default_is_applied_without_error() -> None:
     """A Required key with a default fills in rather than failing."""
     schema = Schema({Required("port", default=80): int})
     assert schema({}) == {"port": 80}
+
+
+def test_default_factory_returning_undefined_leaves_key_absent() -> None:
+    """A default callable returning UNDEFINED declines, so the key stays absent."""
+    schema = Schema({Optional("speed", default=lambda: UNDEFINED): int})
+    assert schema({}) == {}
+
+
+def test_default_factory_returning_value_still_applies() -> None:
+    """A default callable returning a value still fills that value in."""
+    schema = Schema({Optional("speed", default=lambda: 80): int})
+    assert schema({}) == {"speed": 80}
+
+
+def test_default_factory_decline_does_not_affect_a_provided_value() -> None:
+    """A provided value is validated normally, even when the default would decline."""
+    schema = Schema({Optional("speed", default=lambda: UNDEFINED): int})
+    assert schema({"speed": 5}) == {"speed": 5}
+
+
+def test_required_default_factory_that_declines_reports_missing() -> None:
+    """A Required default that declines leaves the key missing, so it is reported."""
+    schema = Schema({Required("speed", default=lambda: UNDEFINED): int})
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({})
+    assert caught.value.errors[0].path == ["speed"]
+
+
+def test_exclusive_group_default_factory_that_declines_falls_through() -> None:
+    """An exclusive member whose default declines lets the next member's apply."""
+    schema = Schema(
+        {
+            Exclusive("a", "group", default=lambda: UNDEFINED): int,
+            Exclusive("b", "group", default=lambda: 7): int,
+        },
+    )
+    assert schema({}) == {"b": 7}
 
 
 def test_prevent_extra_is_the_default() -> None:


### PR DESCRIPTION
When an `Optional`/`Required` default is a callable factory, that factory may now return `UNDEFINED` at validation time to mean "no default this run", leaving the key absent instead of injecting the sentinel as a value. This makes a default able to decline, which is needed for defaults whose presence depends on runtime state (the active platform, which plugins are loaded).

## Problem

Probatio resolves a marker default once, at compile time, and stores it on the immutable candidate. At finalize it calls the factory and stores the result. There was no way for the factory to say "actually, no default applies here": returning `UNDEFINED` injected the sentinel as a literal value, which then failed the value schema.

```python
from probatio import Schema, Optional, UNDEFINED

Schema({Optional("speed", default=lambda: UNDEFINED): int})({})
# before: MultipleInvalid: expected int for dictionary value @ data['speed']
# after:  {}   (key absent, because the factory declined)
```

## Behavior

A default callable that returns an `Undefined` instance at finalize is treated as "no default this run". A normal default never returns `Undefined`, so existing behavior is unchanged.

- An `Optional` whose default declines leaves the key absent.
- A `Required` whose default declines leaves the key missing, so it is reported as a missing required key.
- An `Exclusive` group member whose default declines does not fill the group: the next member is tried, then the group's `required` check.

## Implementation

Both default-application sites in `src/probatio/_engine.py` (`_finalize` and `_empty_exclusive_group`) resolve `candidate.default()` once and skip storing when the result is `Undefined`, letting the existing required/optional and group logic decide what happens next.

## Compatibility

Backward compatible: no built-in validator returns `UNDEFINED` from a default, so no existing behavior changes. This restores the dynamic "sometimes no default" that voluptuous expressed by having a marker's `default` property return `Undefined`.

## Tests

Added to `tests/test_mapping.py`: Optional declines to absent, value default still applies, a provided value is unaffected by a declining default, a Required that declines is reported missing, and an exclusive group member that declines falls through.

## Verification

`just check` passes: 100% line and branch coverage, the voluptuous conformance suite, the Home Assistant compatibility suite, snapshots, and the documentation examples (the markers guide gained a runnable example of a declining default).