### PR TITLE
Suggest close members and normalize matches in In

### DIFF
--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -116,7 +116,11 @@ name is importable straight from `probatio`.
   `Boolean()`.
 - `Literal(lit)`: require the value to equal a literal, returning the literal.
 - `Equal(target, msg=None)`: require the value to equal `target`.
-- `In(container, msg=None)`: the value must be a member of `container`.
+- `In(container, msg=None, *, fold_case=False, space=None)`: the value must be a
+  member of `container`. `fold_case` matches case-insensitively; `space` collapses
+  each whitespace run in a string to the given character; either returns the
+  normalized value. A missed string value suggests the closest members (`did you
+  mean ...?`) and records them on the error's `candidates`.
 - `NotIn(container, msg=None)`: the value must not be a member of `container`.
 - `Contains(item, msg=None)`: the value (a collection) must contain `item`.
 - `Match(pattern, msg=None)`: the value must match a regular expression.

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -25,6 +25,7 @@ from probatio.error import (
     SchemaError,
     SequenceTypeInvalid,
     TypeInvalid,
+    _format_candidates,
 )
 from probatio.markers import UNDEFINED, Undefined, VirtualPathComponent
 
@@ -34,14 +35,6 @@ ALLOW_EXTRA = 1  # keep them as-is
 REMOVE_EXTRA = 2  # drop them from the result
 
 type CompiledSchema = Callable[[Any], Any]
-
-
-def _format_candidates(names: list[str]) -> str:
-    """Render close-match key names: ``'a'``, ``'a' or 'b'``, ``'a', 'b' or 'c'``."""
-    quoted = [repr(name) for name in names]
-    if len(quoted) == 1:
-        return quoted[0]
-    return f"{', '.join(quoted[:-1])} or {quoted[-1]}"
 
 
 def _type_error(expected: str, path: list[Any], error_type: str | None) -> TypeInvalid:

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -26,6 +26,14 @@ from typing import Any, cast
 _MAX_PATH_SEGMENT_LENGTH = 500
 
 
+def _format_candidates(names: list[str]) -> str:
+    """Render close-match names: ``'a'``, ``'a' or 'b'``, ``'a', 'b' or 'c'``."""
+    quoted = [repr(name) for name in names]
+    if len(quoted) == 1:
+        return quoted[0]
+    return f"{', '.join(quoted[:-1])} or {quoted[-1]}"
+
+
 @dataclass(frozen=True)
 class Location:
     """A source location for a value: its line, column, and file when known.
@@ -383,9 +391,44 @@ class LengthInvalid(Invalid):
 
 
 class InInvalid(Invalid):
-    """The value is not a member of the allowed set."""
+    """The value is not a member of the allowed set.
+
+    Carries ``candidates``: the close matches among the allowed string members, so
+    a caller can render (or has already rendered) a "did you mean ...?" hint
+    without recomputing it. The list is empty when nothing was close enough or the
+    members are not strings.
+    """
 
     default_code = "not_in_list"
+
+    def __init__(
+        self,
+        message: str,
+        path: list[Any] | None = None,
+        error_message: str | None = None,
+        error_type: str | None = None,
+        *,
+        candidates: list[str] | None = None,
+        code: str | None = None,
+        context: dict[str, Any] | None = None,
+        translation_key: str | None = None,
+        placeholders: dict[str, Any] | None = None,
+    ) -> None:
+        """Create the error, recording any close-match suggestions."""
+        self.candidates: list[str] = list(candidates) if candidates else []
+        merged = dict(context) if context else {}
+        if self.candidates:
+            merged.setdefault("candidates", self.candidates)
+        super().__init__(
+            message,
+            path,
+            error_message,
+            error_type,
+            code=code,
+            context=merged or None,
+            translation_key=translation_key,
+            placeholders=placeholders,
+        )
 
 
 class NotInInvalid(Invalid):

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import re
 import typing
+from difflib import get_close_matches
 
 from probatio.error import (
     ContainsInvalid,
@@ -14,8 +16,12 @@ from probatio.error import (
     NotInInvalid,
     RangeInvalid,
     SchemaError,
+    _format_candidates,
 )
 from probatio.validators._base import _SafeValidator
+
+# Collapses each run of whitespace to a single normalization character.
+_WHITESPACE = re.compile(r"\s+")
 
 # A percentage runs from 0 to 100.
 _MIN_PERCENT = 0
@@ -400,31 +406,78 @@ class Length(_SafeValidator):
 
 
 class In(_SafeValidator):
-    """Require the value to be a member of a container."""
+    """Require the value to be a member of a container.
 
-    def __init__(self, container: typing.Any, msg: str | None = None) -> None:
-        """Store the container (read as ``.container``) and an optional message."""
+    ``fold_case=True`` matches case-insensitively, and ``space`` collapses each run
+    of whitespace in a string value to the given character (``space=" "`` to
+    normalize spacing, ``space="_"`` so ``"front door"`` matches ``"front_door"``).
+    When either normalizes the value, the normalized value is returned, the way
+    a coercing membership check does; otherwise the value is returned unchanged.
+
+    On a miss the error suggests the closest allowed members (``did you mean ...?``)
+    when both the value and the members are strings, and carries them on the error's
+    ``candidates``, mirroring the unknown-key hint a mapping schema gives.
+    """
+
+    def __init__(
+        self,
+        container: typing.Any,
+        msg: str | None = None,
+        *,
+        fold_case: bool = False,
+        space: str | None = None,
+    ) -> None:
+        """Store the container (read as ``.container``), message, and normalization."""
         self.container = container
         self.msg = msg
+        self.fold_case = fold_case
+        self.space = space
 
     def __repr__(self) -> str:
         """Render as a constructor call, matching voluptuous."""
         return f"In({self.container!r})"
 
+    def _normalize(self, value: typing.Any) -> typing.Any:
+        """Apply the space and case normalization to a string, else pass through."""
+        if not isinstance(value, str):
+            return value
+        if self.space is not None:
+            value = _WHITESPACE.sub(self.space, value)
+        if self.fold_case:
+            value = value.casefold()
+        return value
+
+    def _contains(self, candidate: typing.Any) -> bool:
+        """Whether the normalized candidate is a member, normalizing members to match."""
+        if not self.fold_case and self.space is None:
+            return candidate in self.container
+        return any(candidate == self._normalize(member) for member in self.container)
+
+    def _suggest(self, value: typing.Any) -> list[str]:
+        """Close string members for a string value, for a 'did you mean ...?' hint."""
+        if not isinstance(value, str):
+            return []
+        pool = [member for member in self.container if isinstance(member, str)]
+        return get_close_matches(value, pool)
+
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the value if it is in the container, else raise InInvalid."""
+        """Return the (normalized) value if it is in the container, else raise."""
+        candidate = self._normalize(value)
         try:
-            present = value in self.container
+            present = self._contains(candidate)
         except (TypeError, ArithmeticError) as exc:
             message = self.msg or "value is not allowed"
             raise InInvalid(message) from exc
         if not present:
-            message = (
-                self.msg
-                or f"value must be one of {_sorted_for_message(self.container)}"
-            )
-            raise InInvalid(message)
-        return value
+            candidates = self._suggest(value)
+            if self.msg is not None:
+                message = self.msg
+            else:
+                message = f"value must be one of {_sorted_for_message(self.container)}"
+                if candidates:
+                    message += f", did you mean {_format_candidates(candidates)}?"
+            raise InInvalid(message, candidates=candidates)
+        return candidate
 
 
 class NotIn(_SafeValidator):

--- a/tests/validators/test_comparison.py
+++ b/tests/validators/test_comparison.py
@@ -164,6 +164,61 @@ def test_in_exposes_its_container() -> None:
     assert In([1, 2]).container == [1, 2]
 
 
+def test_in_suggests_close_members_on_a_miss() -> None:
+    """A missed string value suggests the closest members and carries candidates."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(In(["auto", "manual"]))("atuo")
+    error = caught.value.errors[0]
+    assert isinstance(error, InInvalid)
+    assert error.candidates == ["auto"]
+    assert "did you mean 'auto'?" in error.error_message
+
+
+def test_in_offers_no_suggestion_when_nothing_is_close() -> None:
+    """A miss with no close member has empty candidates and no hint."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(In(["auto", "manual"]))("zzzzz")
+    error = caught.value.errors[0]
+    assert error.candidates == []
+    assert "did you mean" not in error.error_message
+
+
+def test_in_has_no_suggestions_for_non_string_members() -> None:
+    """A non-string container yields no suggestions (difflib is string-only)."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(In([1, 2, 3]))(9)
+    assert caught.value.errors[0].candidates == []
+
+
+def test_in_custom_message_wins_but_keeps_candidates() -> None:
+    """A custom message replaces the text, yet the candidates are still recorded."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(In(["auto"], msg="bad mode"))("atuo")
+    error = caught.value.errors[0]
+    assert error.error_message == "bad mode"
+    assert error.candidates == ["auto"]
+
+
+def test_in_fold_case_matches_and_returns_the_normalized_value() -> None:
+    """fold_case matches case-insensitively and returns the folded value."""
+    schema = Schema(In(["Auto", "Manual"], fold_case=True))
+    assert schema("auto") == "auto"
+    assert schema("MANUAL") == "manual"
+    with pytest.raises(MultipleInvalid):
+        schema("nope")
+
+
+def test_in_space_normalizes_whitespace_runs() -> None:
+    """space collapses each whitespace run to the given character before matching."""
+    assert Schema(In(["a b"], space=" "))("a   b") == "a b"
+    assert Schema(In(["front_door"], space="_"))("front door") == "front_door"
+
+
+def test_in_normalization_leaves_a_non_string_value_alone() -> None:
+    """A non-string value is matched as-is even with normalization enabled."""
+    assert Schema(In([1, 2, 3], fold_case=True, space="_"))(2) == 2
+
+
 def test_not_in_membership() -> None:
     """NotIn rejects values that are in the container."""
     assert Schema(NotIn(["a"]))("b") == "b"


### PR DESCRIPTION
## Breaking change

None. The suggestions are additive (a richer message and a new `candidates` attribute on `InInvalid`), and `fold_case`/`space` are opt-in keyword arguments that default off. A plain `In(container)` behaves exactly as before, including its repr and its fast `value in container` path.

## Proposed change

Enrich `In` so it can stand in for ESPHome's `one_of` (ESPHome recently migrated to Probatio), while keeping `In` focused on membership.

- **Suggestions, always on.** On a miss against string members, the error suggests the closest ones (`..., did you mean 'auto'?`) and records them on `InInvalid.candidates`. This mirrors exactly what a mapping schema already does for an unknown key (`ExtraKeysInvalid`), so it is the same behavior applied to the same kind of failure. It is empty when the value or the members are not strings. A custom `msg=` still wins the message text, and `candidates` is populated regardless.
- **`fold_case=True`** matches case-insensitively and returns the folded value.
- **`space=`** collapses each whitespace run in a string value to the given character (`" "` to normalize spacing, `"_"` so `"front door"` matches `"front_door"`) and returns the normalized value.

When `fold_case`/`space` normalize the value, the normalized value is returned, the way a coercing membership check does. Type coercion is deliberately left to composition (`All(Coerce(int), In([1, 2, 3]))`), so `In` does not absorb `Coerce`'s job; ESPHome's `one_of` collapses to a thin helper that builds `All(<normalizers>, In(..., fold_case=..., space=...))`.

The candidate-formatting helper moves to `error.py` (the leaf both the engine and the validators import) so the unknown-key hint and the `In` hint share one renderer, and `InInvalid` gains the `candidates` attribute in the same shape as `ExtraKeysInvalid`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
