### PR TITLE
Suggest close enum values on a Coerce miss

### DIFF
--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -94,13 +94,15 @@ Each entry shows the class, its meaning, and its `default_code` in parentheses.
 - `ValueInvalid` (`value`): a validator rejected the value.
 - `ScalarInvalid` (`not_valid`): the value does not match a scalar literal.
 - `LiteralInvalid` (`not_valid`): the value does not match a `Literal`.
-- `CoerceInvalid` (`coerce`): a value could not be coerced to the requested type.
+- `CoerceInvalid` (`coerce`): a value could not be coerced to the requested type;
+  for an `Enum` with string values, carries `candidates`, the close matches.
 - `AnyInvalid` (`no_match`): the value matched none of the candidates.
 - `AllInvalid` (`all`): the value failed one of a chain of validators.
 - `MatchInvalid` (`match`): the value does not match the expected pattern.
 - `RangeInvalid` (`range`): the value falls outside the allowed range.
 - `LengthInvalid` (`length`): the value's length falls outside the allowed bounds.
-- `InInvalid` (`not_in_list`): the value is not a member of the allowed set.
+- `InInvalid` (`not_in_list`): the value is not a member of the allowed set;
+  carries `candidates`, the close matches among string members.
 - `NotInInvalid` (`in_list`): the value is a member of a disallowed set.
 - `ContainsInvalid` (`contains`): the collection does not contain the required
   element.

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -343,9 +343,43 @@ class ScalarInvalid(Invalid):
 
 
 class CoerceInvalid(Invalid):
-    """A value could not be coerced to the requested type."""
+    """A value could not be coerced to the requested type.
+
+    Carries ``candidates``: when the target is an ``Enum`` with string values, the
+    close matches among them, so a caller can render (or has already rendered) a
+    "did you mean ...?" hint. The list is empty for any other coercion.
+    """
 
     default_code = "coerce"
+
+    def __init__(
+        self,
+        message: str,
+        path: list[Any] | None = None,
+        error_message: str | None = None,
+        error_type: str | None = None,
+        *,
+        candidates: list[str] | None = None,
+        code: str | None = None,
+        context: dict[str, Any] | None = None,
+        translation_key: str | None = None,
+        placeholders: dict[str, Any] | None = None,
+    ) -> None:
+        """Create the error, recording any close-match suggestions."""
+        self.candidates: list[str] = list(candidates) if candidates else []
+        merged = dict(context) if context else {}
+        if self.candidates:
+            merged.setdefault("candidates", self.candidates)
+        super().__init__(
+            message,
+            path,
+            error_message,
+            error_type,
+            code=code,
+            context=merged or None,
+            translation_key=translation_key,
+            placeholders=placeholders,
+        )
 
 
 class EnumInvalid(Invalid):

--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import enum
 import typing
 from decimal import Decimal, InvalidOperation
+from difflib import get_close_matches
 
-from probatio.error import BooleanInvalid, CoerceInvalid, Invalid
+from probatio.error import BooleanInvalid, CoerceInvalid, Invalid, _format_candidates
 from probatio.validators._base import _SafeValidator
 from probatio.validators.decorators import message
 
@@ -38,7 +39,14 @@ class Coerce(_SafeValidator):
         try:
             return self.type(value)
         except (ValueError, TypeError, ArithmeticError) as exc:
-            raise CoerceInvalid(self.msg or self._default_message()) from exc
+            candidates = self._suggest(value)
+            if self.msg is not None:
+                message = self.msg
+            else:
+                message = self._default_message()
+                if candidates:
+                    message += f", did you mean {_format_candidates(candidates)}?"
+            raise CoerceInvalid(message, candidates=candidates) from exc
 
     def _default_message(self) -> str:
         """Build the failure message, listing an enum's values (like voluptuous)."""
@@ -47,6 +55,20 @@ class Coerce(_SafeValidator):
             values = ", ".join(repr(member.value) for member in self.type)
             message = f"{message} or one of {values}"
         return message
+
+    def _suggest(self, value: typing.Any) -> list[str]:
+        """Close string enum values for a string input, for a 'did you mean ...?' hint.
+
+        Matches the member values (what ``Coerce(enum)`` actually accepts, since it
+        coerces with ``enum(value)``), not the names, so a suggestion always names a
+        value that would validate. Only string values are eligible.
+        """
+        if not isinstance(value, str):
+            return []
+        if not (isinstance(self.type, type) and issubclass(self.type, enum.Enum)):
+            return []
+        pool = [member.value for member in self.type if isinstance(member.value, str)]
+        return get_close_matches(value, pool)
 
 
 @message("expected boolean", cls=BooleanInvalid)

--- a/tests/validators/test_coerce.py
+++ b/tests/validators/test_coerce.py
@@ -134,6 +134,51 @@ def test_coerce_enum_custom_message_does_not_append_values() -> None:
     assert str(caught.value.errors[0]) == "bad color"
 
 
+def test_coerce_enum_suggests_a_close_value() -> None:
+    """A near-miss against an enum's string values gets a 'did you mean ...?' hint."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Color))("gren")
+    error = caught.value.errors[0]
+    assert isinstance(error, CoerceInvalid)
+    assert error.candidates == ["green"]
+    assert "did you mean 'green'?" in error.error_message
+
+
+def test_coerce_enum_no_suggestion_when_nothing_is_close() -> None:
+    """A far-off value gets no hint and no candidates, matching the value listing."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Color))("purple")
+    error = caught.value.errors[0]
+    assert error.candidates == []
+    assert "did you mean" not in error.error_message
+
+
+def test_coerce_enum_custom_message_keeps_candidates() -> None:
+    """A custom message wins the text, yet the close matches are still recorded."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Color, msg="bad color"))("gren")
+    assert caught.value.errors[0].candidates == ["green"]
+
+
+def test_coerce_int_enum_has_no_suggestions() -> None:
+    """An IntEnum has non-string values, so difflib offers nothing."""
+
+    class _Size(enum.IntEnum):
+        SMALL = 1
+        LARGE = 2
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(_Size))("small")
+    assert caught.value.errors[0].candidates == []
+
+
+def test_coerce_non_enum_failure_has_no_candidates() -> None:
+    """A plain coercion failure carries an empty candidates list."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Coerce(int))("abc")
+    assert caught.value.errors[0].candidates == []
+
+
 def test_boolean_truthy_and_falsy_strings() -> None:
     """Boolean reads common truthy and falsy strings."""
     assert Schema(Boolean())("yes") is True


### PR DESCRIPTION
## Breaking change

None. The suggestion is additive (a richer message when there is a close match, and a new `candidates` attribute on `CoerceInvalid`). A miss with no close match, a custom `msg=`, and a non-enum coercion are all unchanged, so the voluptuous-parity behavior holds.

## Proposed change

Extend the "did you mean ...?" hint to enum coercion, completing the set: a value can miss an allowed set in three places, and all three now suggest the closest member the same way.

`Coerce` to an enum already lists the valid values on failure (`expected Color or one of 'red', 'green', 'blue'`). It now also suggests the closest one when the input is a near miss:

```python
Schema(Coerce(Color))("gren")
# CoerceInvalid: expected Color or one of 'red', 'green', 'blue', did you mean 'green'?
```

- The match is against the member **values**, not names, because `Coerce(enum)` coerces with `enum(value)`. Suggesting a name that would not validate is worse than no suggestion. Only string values are eligible, so an `IntEnum` offers nothing.
- A non-string input and a plain (non-enum) coercion offer nothing.
- A custom `msg=` still wins the message text, while `candidates` stays populated.

`CoerceInvalid` gains the `candidates` attribute in the same shape as `InInvalid` and `ExtraKeysInvalid`, so the three miss points (an unknown mapping key, an `In` miss, an enum coerce miss) all carry their close matches identically. The errors reference is corrected to note `candidates` on both `CoerceInvalid` and `InInvalid`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
