### PR TITLE
Speed up schema construction

### DIFF
--- a/bench/test_benchmarks.py
+++ b/bench/test_benchmarks.py
@@ -115,15 +115,18 @@ def test_validate_config_reject(benchmark: Any) -> None:
     assert benchmark(run) == 2
 
 
-LEAF_HEAVY = probatio.Schema(
-    {
+def _leaf_heavy_schema() -> dict[Any, Any]:
+    """A wide mapping of built-in leaf validators, fresh each call."""
+    return {
         probatio.Required("email"): probatio.Email(),
         probatio.Required("ip"): probatio.IPv4Address(),
         probatio.Required("host"): probatio.Hostname(),
         probatio.Required("code"): probatio.Match(r"^[A-Z]{3}$"),
         probatio.Required("slug"): probatio.Slug(),
-    },
-)
+    }
+
+
+LEAF_HEAVY = probatio.Schema(_leaf_heavy_schema())
 LEAF_HEAVY_PAYLOAD = {
     "email": "user@example.com",
     "ip": "192.168.1.1",
@@ -139,8 +142,9 @@ def test_validate_leaf_heavy(benchmark: Any) -> None:
     assert result["email"] == "user@example.com"
 
 
-NESTED = probatio.Schema(
-    {
+def _nested_schema() -> dict[Any, Any]:
+    """A nested mapping (sub-mapping and a list), fresh each call."""
+    return {
         probatio.Required("entity_id"): str,
         probatio.Optional("data", default=dict): {
             probatio.Optional("brightness"): probatio.All(
@@ -151,8 +155,10 @@ NESTED = probatio.Schema(
                 probatio.All(probatio.Coerce(int), probatio.Range(min=0, max=255)),
             ],
         },
-    },
-)
+    }
+
+
+NESTED = probatio.Schema(_nested_schema())
 NESTED_PAYLOAD = {
     "entity_id": "light.kitchen",
     "data": {"brightness": "200", "rgb": [255, 0, 0]},
@@ -163,3 +169,55 @@ def test_validate_nested(benchmark: Any) -> None:
     """Validate a nested mapping (recursing into a sub-mapping and a list)."""
     result = benchmark(NESTED, NESTED_PAYLOAD)
     assert result["data"]["brightness"] == 200
+
+
+def _combinator_schema() -> dict[Any, Any]:
+    """A combinator-heavy mapping (All/Any/Union nesting), fresh each call."""
+    return {
+        probatio.Required("mode"): probatio.Any("auto", "manual", "off"),
+        probatio.Required("level"): probatio.All(
+            probatio.Coerce(int), probatio.Range(min=0, max=10)
+        ),
+        probatio.Optional("value"): probatio.Any(
+            probatio.All(str, probatio.Length(min=1)),
+            probatio.All(probatio.Coerce(int), probatio.Range(min=0)),
+            None,
+        ),
+        probatio.Optional("kind"): probatio.Union(int, str, float),
+    }
+
+
+def _deep_schema(depth: int) -> dict[Any, Any]:
+    """A mapping nested ``depth`` levels deep, fresh each call.
+
+    Construction cost grows with depth and tree size, so a deep schema is where
+    the compile walk actually shows up; a flat schema barely exercises it.
+    """
+    node: dict[Any, Any] = {probatio.Required("leaf"): int}
+    for _ in range(depth):
+        node = {probatio.Required("value"): int, probatio.Optional("child"): node}
+    return node
+
+
+def test_compile_nested(benchmark: Any) -> None:
+    """Compile a nested schema from scratch (recursive compile over a sub-mapping)."""
+    result = benchmark(lambda: probatio.Schema(_nested_schema()))
+    assert isinstance(result, probatio.Schema)
+
+
+def test_compile_leaf_heavy(benchmark: Any) -> None:
+    """Compile a wide, many-key mapping from scratch."""
+    result = benchmark(lambda: probatio.Schema(_leaf_heavy_schema()))
+    assert isinstance(result, probatio.Schema)
+
+
+def test_compile_combinators(benchmark: Any) -> None:
+    """Compile a combinator-heavy schema (All/Any/Union nesting) from scratch."""
+    result = benchmark(lambda: probatio.Schema(_combinator_schema()))
+    assert isinstance(result, probatio.Schema)
+
+
+def test_compile_deep(benchmark: Any) -> None:
+    """Compile a deeply nested schema, where construction cost actually lives."""
+    result = benchmark(lambda: probatio.Schema(_deep_schema(16)))
+    assert isinstance(result, probatio.Schema)

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -160,13 +160,19 @@ class _MappingValidator:
         self._inclusive_groups = list(inclusive.items())
         self._has_groups = bool(self._exclusive_groups or self._inclusive_groups)
         self._track_seen = bool(self._finalizers) or self._has_groups
-        # Alias keys (rare) rename each accepted input name to the candidate's
-        # canonical key in a pre-pass, so the candidate machinery never sees them.
-        # ``_alias_lookup`` maps an input name to its canonical and rank (declaration
-        # order, first-present-wins); ``_alias_claimed`` is every name an alias spec
-        # owns, so a leftover one (a superseded alias, or a canonical under
-        # accept_canonical=False) is dropped rather than passed through as unknown.
-        # The collision checks need the full ``_literal`` map, so they run here.
+        self._build_alias_index(alias_candidates)
+
+    def _build_alias_index(self, alias_candidates: list[_Candidate]) -> None:
+        """Map each alias input name to its canonical key (rare; needs the literals).
+
+        An accepted input name is renamed to the candidate's canonical key in a
+        pre-pass, so the candidate machinery never sees the aliases.
+        ``_alias_lookup`` maps an input name to its canonical and rank (declaration
+        order, first-present-wins); ``_alias_claimed`` is every name an alias spec
+        owns, so a leftover one (a superseded alias, or a canonical under
+        ``accept_canonical=False``) is dropped rather than passed through as an
+        unknown key. The collision checks need the full ``_literal`` map.
+        """
         self._alias_lookup: dict[Any, tuple[Any, int]] = {}
         self._alias_claimed: set[Any] = set()
         for candidate in alias_candidates:

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -100,57 +100,76 @@ class _MappingValidator:
         self._candidates = candidates
         self._extra = extra
         self._invalid_msg = invalid_msg
-        # Literal keys are matched by an exact dict lookup (the common, fast
-        # path); only keys not found that way fall back to the validator keys
-        # (types and callables), which must be tried one by one. A literal lookup
-        # also naturally gives literal keys precedence over validator keys.
+        # Everything the validator needs is derived from the candidate list in one
+        # pass; the structures below were six separate walks, but each candidate's
+        # attributes are read once here instead. What each piece is:
+        #
+        # ``_literal``: literal keys matched by an exact dict lookup (the common,
+        #   fast path); a key not found there falls back to the validator keys
+        #   (types and callables) tried one by one, so literals take precedence.
+        # ``_literal_fast``: a flat tuple per literal key that is neither Forbidden
+        #   nor Remove (the overwhelming case), holding exactly what the per-key
+        #   validation loop reads (position, inlined value type, value check) so it
+        #   skips the forbidden/remove branches.
+        # ``_key_names``: the literal string keys a caller could legitimately give,
+        #   the pool for "did you mean ...?" on an unknown key (Remove/Forbidden
+        #   excluded; suggesting a dropped or must-be-absent key would be wrong).
+        # ``_finalizers``: the candidates that can apply a default or report a
+        #   missing required key; a mapping of purely optional keys needs none, so
+        #   it skips seen-tracking and finalization entirely.
+        # ``exclusive``/``inclusive``: group member lists, built once so a grouped
+        #   validation does not rebuild them per call.
         self._literal: dict[Any, tuple[int, _Candidate]] = {}
         self._validators: list[tuple[int, _Candidate]] = []
+        self._literal_fast: dict[Any, tuple[int, type | None, CompiledSchema]] = {}
+        self._key_names: list[Any] = []
+        self._finalizers: list[tuple[int, _Candidate]] = []
+        exclusive: dict[str, list[int]] = defaultdict(list)
+        inclusive: dict[str, list[int]] = defaultdict(list)
+        alias_candidates: list[_Candidate] = []
         for index, candidate in enumerate(candidates):
+            key = candidate.key_schema
             if candidate.is_literal:
-                self._literal[candidate.key_schema] = (index, candidate)
+                self._literal[key] = (index, candidate)
+                if not candidate.forbidden and not candidate.remove:
+                    self._literal_fast[key] = (
+                        index,
+                        candidate.value_type,
+                        candidate.check_value,
+                    )
+                    if isinstance(key, str):
+                        self._key_names.append(key)
             else:
                 self._validators.append((index, candidate))
-        # A derived index for the hot path. A literal key that is neither
-        # Forbidden nor Remove (the overwhelming common case) maps to a flat
-        # tuple of exactly what the per-key loop needs: its position (for the
-        # seen flags), the inlined value type if any, and its value check. The
-        # loop reads that tuple instead of a ``_Candidate`` property and skips
-        # the forbidden/remove branches entirely. Forbidden and Remove literal
-        # keys are absent here and take the slower branch via ``_literal``.
-        self._literal_fast: dict[Any, tuple[int, type | None, CompiledSchema]] = {
-            candidate.key_schema: (
-                index,
-                candidate.value_type,
-                candidate.check_value,
-            )
-            for index, candidate in enumerate(candidates)
-            if candidate.is_literal and not candidate.forbidden and not candidate.remove
-        }
-        # The pool for "did you mean ...?" suggestions on an unknown key: the
-        # literal string keys a caller could legitimately provide. Remove and
-        # Forbidden keys are excluded; suggesting a key that gets dropped, or one
-        # that must be absent, would be wrong.
-        self._key_names = [
-            candidate.key_schema
-            for candidate in candidates
-            if candidate.is_literal
-            and isinstance(candidate.key_schema, str)
-            and not candidate.remove
-            and not candidate.forbidden
-        ]
-        # Alias keys (rare) are resolved in a pre-pass that renames each accepted
-        # input name to the candidate's canonical key, so the candidate machinery
-        # below never sees the aliases. ``_alias_lookup`` maps an input name to its
-        # canonical and its rank (declaration order, for first-present-wins);
-        # ``_alias_claimed`` is every name an alias spec owns, so a leftover one
-        # (a superseded alias, or a canonical under accept_canonical=False) is
-        # dropped rather than passed through as an unknown key.
+            if candidate.exclusive_group is not None:
+                exclusive[candidate.exclusive_group].append(index)
+            if candidate.inclusive_group is not None:
+                inclusive[candidate.inclusive_group].append(index)
+            if candidate.required or (
+                candidate.is_literal
+                and not isinstance(candidate.default, Undefined)
+                # An Exclusive member's default is group-level: it fills in only
+                # when the whole group is empty, applied in the group pass, not
+                # here where it would fire whenever this one key is absent.
+                and candidate.exclusive_group is None
+            ):
+                self._finalizers.append((index, candidate))
+            if candidate.alias_input_names:
+                alias_candidates.append(candidate)
+        self._exclusive_groups = list(exclusive.items())
+        self._inclusive_groups = list(inclusive.items())
+        self._has_groups = bool(self._exclusive_groups or self._inclusive_groups)
+        self._track_seen = bool(self._finalizers) or self._has_groups
+        # Alias keys (rare) rename each accepted input name to the candidate's
+        # canonical key in a pre-pass, so the candidate machinery never sees them.
+        # ``_alias_lookup`` maps an input name to its canonical and rank (declaration
+        # order, first-present-wins); ``_alias_claimed`` is every name an alias spec
+        # owns, so a leftover one (a superseded alias, or a canonical under
+        # accept_canonical=False) is dropped rather than passed through as unknown.
+        # The collision checks need the full ``_literal`` map, so they run here.
         self._alias_lookup: dict[Any, tuple[Any, int]] = {}
         self._alias_claimed: set[Any] = set()
-        for candidate in candidates:
-            if not candidate.alias_input_names:
-                continue
+        for candidate in alias_candidates:
             canonical = candidate.key_schema
             self._alias_claimed.add(canonical)
             for rank, name in enumerate(candidate.alias_input_names):
@@ -162,37 +181,6 @@ class _MappingValidator:
                     raise SchemaError(message)
                 self._alias_lookup[name] = (canonical, rank)
                 self._alias_claimed.add(name)
-        # Group checking is only needed when Exclusive/Inclusive markers are
-        # present, which is rare. The member lists are built once here, so a
-        # validation with groups does not rebuild them every call.
-        exclusive: dict[str, list[int]] = defaultdict(list)
-        inclusive: dict[str, list[int]] = defaultdict(list)
-        for index, candidate in enumerate(candidates):
-            if candidate.exclusive_group is not None:
-                exclusive[candidate.exclusive_group].append(index)
-            if candidate.inclusive_group is not None:
-                inclusive[candidate.inclusive_group].append(index)
-        self._exclusive_groups = list(exclusive.items())
-        self._inclusive_groups = list(inclusive.items())
-        self._has_groups = bool(self._exclusive_groups or self._inclusive_groups)
-        # The only candidates that need a post-pass are those that can apply a
-        # default or report a missing required key. Mappings of purely optional
-        # keys (common for nested option dicts) need none of it, so they skip
-        # tracking which keys were seen and the finalization pass altogether.
-        self._finalizers = [
-            (index, candidate)
-            for index, candidate in enumerate(candidates)
-            if candidate.required
-            or (
-                candidate.is_literal
-                and not isinstance(candidate.default, Undefined)
-                # An Exclusive member's default is group-level: it fills in only
-                # when the whole group is empty, applied in the group pass, not
-                # here where it would fire whenever this one key is absent.
-                and candidate.exclusive_group is None
-            )
-        ]
-        self._track_seen = bool(self._finalizers) or self._has_groups
 
     def __call__(self, data: Any) -> dict[Any, Any]:  # noqa: PLR0912
         """Validate the mapping, gathering every error into one MultipleInvalid."""

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -295,10 +295,13 @@ class Schema:
         self.schema = schema
         self.required = required
         self.extra = extra
-        # Whether ``Self`` appears anywhere in the definition. Only then does
-        # validation record an active root (a contextvar that is not free), so a
-        # non-recursive schema, the common case, skips that cost entirely.
-        self._uses_self = _schema_uses_self(schema)
+        # Whether ``Self`` appears anywhere in the definition. This is discovered
+        # during the compile walk below (set on the first ``Self`` reached, and on
+        # a combinator/wrapper branch that holds one), so the tree is walked once,
+        # not a second time by a standalone pre-pass. Only a recursive schema then
+        # records an active root when validated, a contextvar that is not free, so
+        # a non-recursive schema, the common case, skips that cost entirely.
+        self._uses_self = False
         # Mark self as the root while compiling, so a ``Self`` inside this schema
         # resolves here. Tokens nest correctly, so a nested Schema restores the
         # outer root on exit.
@@ -528,6 +531,7 @@ class Schema:
     def _compile(self, schema: Any) -> CompiledSchema:  # noqa: PLR0911
         """Dispatch a schema node to the right compiler for its kind."""
         if schema is Self:
+            self._uses_self = True
             return self._compile_self()
         if isinstance(schema, type):
             return self._compile_type(schema)
@@ -547,6 +551,12 @@ class Schema:
                 rebind = getattr(schema, "__probatio_with_extra__", None)
                 if rebind is not None:
                     schema = rebind(self.extra)
+            # A combinator or wrapper compiled its own branches at construction, so
+            # the compile walk never descends into them; detect a ``Self`` nested in
+            # one on the branch node itself. Cheap for a plain callable (it has no
+            # ``validators``/``validator`` to walk) and skipped once a Self is found.
+            if not self._uses_self:
+                self._uses_self = _schema_uses_self(schema)
             # probatio's own validators always raise Invalid (never leak a
             # ValueError), so they can be called directly. Arbitrary callables go
             # through the guard that turns a ValueError into an Invalid.
@@ -615,24 +625,37 @@ class Schema:
                 remove=False,
                 is_literal=False,
             )
-        if isinstance(key, Marker):
+        is_marker = isinstance(key, Marker)
+        if is_marker:
+            # Classify the marker's kind once, then reuse the flags below rather
+            # than re-running overlapping isinstance checks per attribute. Subtypes
+            # are honored (Inclusive and Exclusive are Optional), so the dispatch
+            # stays correct for a custom marker subclass too.
+            is_required = isinstance(key, Required)
+            is_optional = isinstance(key, Optional)
+            is_alias = isinstance(key, Alias)
+            is_remove = isinstance(key, Remove)
+            is_forbidden = isinstance(key, Forbidden)
+            is_exclusive = isinstance(key, Exclusive)
+            is_inclusive = isinstance(key, Inclusive)
             key_schema = key.schema
             default = (
-                key.default
-                if isinstance(key, Required | Optional | Alias)
-                else UNDEFINED
+                key.default if (is_required or is_optional or is_alias) else UNDEFINED
             )
             # An Alias carries its own required flag and is self-contained, so a
             # schema-wide ``required`` does not force it (like Optional).
             required = (
-                isinstance(key, Required)
-                or (isinstance(key, Alias) and key.required)
+                is_required
+                or (is_alias and key.required)
                 or (
                     self.required
-                    and not isinstance(key, Optional | Remove | Forbidden | Alias)
+                    and not (is_optional or is_remove or is_forbidden or is_alias)
                 )
             )
         else:
+            # A literal key is none of the marker kinds, so skip those checks.
+            is_required = is_optional = is_alias = is_remove = False
+            is_forbidden = is_exclusive = is_inclusive = False
             key_schema = key
             default = UNDEFINED
             required = self.required
@@ -645,19 +668,13 @@ class Schema:
             check_value=check_value,
             required=required,
             default=default,
-            remove=isinstance(key, Remove),
-            forbidden=isinstance(key, Forbidden),
+            remove=is_remove,
+            forbidden=is_forbidden,
             is_literal=is_literal,
-            exclusive_group=(
-                key.group_of_exclusion if isinstance(key, Exclusive) else None
-            ),
-            exclusive_required=(
-                key.group_required if isinstance(key, Exclusive) else False
-            ),
-            inclusive_group=(
-                key.group_of_inclusion if isinstance(key, Inclusive) else None
-            ),
-            msg=key.msg if isinstance(key, Marker) else None,
+            exclusive_group=(key.group_of_exclusion if is_exclusive else None),
+            exclusive_required=(key.group_required if is_exclusive else False),
+            inclusive_group=(key.group_of_inclusion if is_inclusive else None),
+            msg=key.msg if is_marker else None,
             value_type=getattr(check_value, "checked_type", None),
             key_type=getattr(check_key, "checked_type", None),
             complex_keys=(
@@ -665,11 +682,10 @@ class Schema:
                 # failure can report "at least one of [...] is required". Read by
                 # attribute to avoid importing Any (circular with combinators).
                 list(key_schema.validators)
-                if isinstance(key, Required)
-                and getattr(key_schema, "is_complex_key", False)
+                if is_required and getattr(key_schema, "is_complex_key", False)
                 else None
             ),
-            alias_input_names=key.input_names if isinstance(key, Alias) else (),
+            alias_input_names=key.input_names if is_alias else (),
         )
 
     def _compile_self(self) -> CompiledSchema:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -90,6 +90,20 @@ def test_self_inside_all_chains_recursion_with_another_schema() -> None:
         schema({"follow": {"number": 1, "extra": "no"}})
 
 
+def test_self_detection_short_circuits_for_a_trailing_callable() -> None:
+    """Once Self is found, a callable value compiled afterwards skips the re-check.
+
+    The Self in the first branch flips the recursive flag during compile, so a
+    later callable value (``str.strip``) does not re-walk for Self.
+    """
+    schema = Schema({"next": Any(Self, None), "tag": str.strip})
+    assert schema._uses_self is True
+    assert schema({"next": {"next": None, "tag": " a "}, "tag": " b "}) == {
+        "next": {"next": None, "tag": "a"},
+        "tag": "b",
+    }
+
+
 def test_self_in_a_combinator_called_outside_a_schema_is_an_error() -> None:
     """A combinator holding Self, called on its own, has no schema to resolve to."""
     with pytest.raises(SchemaError):


### PR DESCRIPTION
## Breaking change

None. All three changes are internal to compilation and preserve behavior exactly: the same `_uses_self` result, the same candidate classification, the same derived indexes. The full suite passes at 100% line and branch coverage.

## Proposed change

Schema construction was ~1.47x slower than voluptuous on Home-Assistant-representative schemas (validation stays 2-2.8x faster). Home Assistant builds thousands of schemas at import, so this is cold-start latency. Profiling (cProfile and py-spy) showed the time going to framework plumbing, not validation work. Three changes close it; construction is now ~1.3-1.6x **faster** than voluptuous, with the validation lead unchanged.

- **Fold Self-detection into the compile walk.** `Schema.__init__` walked the whole tree twice: a standalone `_schema_uses_self` pre-pass, then `_compile`. The Self walk was the single largest construction cost. `_compile` already recurses every mapping value, dict key (via `check_key`), and sequence element; only a combinator or wrapper is opaque to it (it compiles its own branches at construction), so a nested `Self` is detected on that branch node alone, in the callable branch. This is provably equivalent to the old full pre-pass (verified against the exact `_uses_self` results for Self-as-key, Self-in-sequence, the nested-`Schema` boundary, and `Any(Self, ...)`), minus the second traversal.
- **Classify a marker key once in `_make_candidate`.** It ran a cascade of overlapping `isinstance` checks per attribute. The marker's kind is now classified once and the flags reused; a literal key (the common case) does one `isinstance` instead of eight. It stays `isinstance`-based, not a `type()` dispatch, so a custom marker subclass is still honored.
- **Build `_MappingValidator`'s indexes in one pass.** Six separate walks of the candidate list (literal split, `_literal_fast`, `_key_names`, aliases, groups, finalizers) became one. The alias collision check needs the full literal map, so it stays a small post-step (aliases are rare). This dropped `_MappingValidator.__init__` from ~18% to ~13% of construction self-time (py-spy).

It also closes the bench-coverage gap that let this regress unnoticed: there was one construction benchmark on a flat 5-key schema, where the cost barely shows. This adds compile benchmarks for the nested, leaf-heavy, combinator-heavy, and deeply nested shapes (refactoring the existing `NESTED`/`LEAF_HEAVY` schemas into fresh-each-call factories), so CodSpeed gates construction going forward.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
