### PR TITLE
Make recursion_guard a class context manager

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -13,7 +13,6 @@ value and returns the validated (and possibly normalized) result, or raises
 from __future__ import annotations
 
 import sys
-from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
@@ -53,7 +52,7 @@ from probatio.markers import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterator
+    from collections.abc import Callable, Collection
 
 # The schema currently being compiled, so a ``Self`` reference inside it can be
 # resolved to the enclosing (root) schema. Only the outermost compile sets it.
@@ -126,8 +125,7 @@ def current_context() -> Any:
     return _VALIDATION_CONTEXT.get()
 
 
-@contextmanager
-def recursion_guard(cost: int = 1) -> Iterator[None]:
+class recursion_guard:  # noqa: N801 - a context manager, named like contextlib's
     """Bound recursive validation so deep or cyclic data fails cleanly.
 
     Raises ``Invalid`` once the recursion passes a fraction of the interpreter's
@@ -140,16 +138,29 @@ def recursion_guard(cost: int = 1) -> Iterator[None]:
     passes a larger cost so the guard fires before the real stack overflows. The
     budget is shared, so mixed recursion (a ``Self`` schema containing a recursive
     dataclass, say) accounts for both correctly.
+
+    A plain class rather than ``@contextmanager``: it sits on the per-level
+    recursion hot path, and skipping the generator machinery is roughly twice as
+    fast per ``with``.
     """
-    depth = _SELF_DEPTH.get() + cost
-    if depth > sys.getrecursionlimit() // _SELF_DEPTH_DIVISOR:
-        message = "data is nested too deeply for this recursive schema"
-        raise Invalid(message)
-    token = _SELF_DEPTH.set(depth)
-    try:
-        yield
-    finally:
-        _SELF_DEPTH.reset(token)
+
+    __slots__ = ("_cost", "_token")
+
+    def __init__(self, cost: int = 1) -> None:
+        """Store how much this level costs against the shared depth budget."""
+        self._cost = cost
+
+    def __enter__(self) -> None:
+        """Charge one level, raising ``Invalid`` if the budget is exceeded."""
+        depth = _SELF_DEPTH.get() + self._cost
+        if depth > sys.getrecursionlimit() // _SELF_DEPTH_DIVISOR:
+            message = "data is nested too deeply for this recursive schema"
+            raise Invalid(message)
+        self._token = _SELF_DEPTH.set(depth)
+
+    def __exit__(self, *exc: object) -> None:
+        """Release this level's charge back to the budget."""
+        _SELF_DEPTH.reset(self._token)
 
 
 def _deferred_self(data: Any) -> Any:


### PR DESCRIPTION
## Breaking change

None. The public name and call signature are unchanged (`with recursion_guard():`, `recursion_guard(cost=N)`), and the depth guard fires exactly as before.

## Proposed change

`recursion_guard` runs once per level of recursive validation: `Self` schemas, the JSON Schema decoder's recursive `$ref` validators, and recursive dataclass references. It was a `@contextmanager` generator, so the generator machinery sat on that per-level hot path. A plain class with `__enter__`/`__exit__` does the same depth accounting without the generator.

A microbenchmark of the two forms (same body) put the class context manager at about 2.26x the throughput of the `@contextmanager` one (~490ns saved per `with`). For deeply recursive data that is ~one guard per level, so recursive validation gets meaningfully faster; non-recursive validation never enters the guard, so it is unaffected.

The lowercase class name follows `contextlib`'s own context managers (`suppress`, `nullcontext`). Found by profiling validation.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
