### PR TITLE
Trim per-node work in the compile callable branch

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -560,13 +560,20 @@ class Schema:
             # (matching voluptuous), on a copy so the shared instance is untouched.
             if self.extra != PREVENT_EXTRA:
                 rebind = getattr(schema, "__probatio_with_extra__", None)
-                if rebind is not None:
+                # Rebinding only matters when a branch holds a nested mapping (the
+                # policy changes how a dict compiles); a combinator of types and
+                # lists compiles identically, so skip the copy and recompile.
+                needs = getattr(schema, "__probatio_needs_extra__", None)
+                if rebind is not None and (needs is None or needs()):
                     schema = rebind(self.extra)
             # A combinator or wrapper compiled its own branches at construction, so
             # the compile walk never descends into them; detect a ``Self`` nested in
-            # one on the branch node itself. Cheap for a plain callable (it has no
-            # ``validators``/``validator`` to walk) and skipped once a Self is found.
-            if not self._uses_self:
+            # one on the branch node itself. Only a node that holds child schemas
+            # (``validators``/``validator``) can carry a nested ``Self``, so a plain
+            # leaf validator skips the walk entirely.
+            if not self._uses_self and (
+                hasattr(schema, "validators") or hasattr(schema, "validator")
+            ):
                 self._uses_self = _schema_uses_self(schema)
             # probatio's own validators always raise Invalid (never leak a
             # ValueError), so they can be called directly. Arbitrary callables go

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -25,6 +25,25 @@ from probatio.schema import PREVENT_EXTRA, compile_schema
 from probatio.validators._base import _SafeValidator
 
 
+def _branch_holds_mapping(node: typing.Any) -> bool:
+    """Whether a node holds a dict schema the rebind's extra policy would reach.
+
+    The rebind recompiles a branch under the new policy, which reaches a mapping
+    directly, through a sequence, or through a nested combinator (combinators
+    re-thread the policy too). It does not reach into a nested ``Schema`` or a
+    wrapper like ``Maybe`` (they compile their own contents under their own
+    policy), so those are leaves here.
+    """
+    if isinstance(node, dict):
+        return True
+    if isinstance(node, list | tuple | set | frozenset):
+        return any(_branch_holds_mapping(element) for element in node)
+    children = getattr(node, "validators", None)
+    if isinstance(children, list):
+        return any(_branch_holds_mapping(child) for child in children)
+    return False
+
+
 class _Combinator(_SafeValidator):
     """Base for the combinators, threading an enclosing schema's extra policy in.
 
@@ -37,10 +56,20 @@ class _Combinator(_SafeValidator):
     """
 
     _extra: int
+    validators: list[typing.Any]
 
     def _compile_branches(self) -> None:  # pragma: no cover - each combinator overrides
         """Recompile ``self.validators`` into ``self._compiled`` under ``self._extra``."""
         raise NotImplementedError
+
+    def __probatio_needs_extra__(self) -> bool:
+        """Whether a non-strict extra could reach a nested mapping in the branches.
+
+        The extra policy only changes how a dict schema compiles, so a combinator
+        whose branches hold no mapping (``Any(str, [str])``) compiles identically
+        under any policy and need not be rebound, skipping the copy and recompile.
+        """
+        return any(_branch_holds_mapping(branch) for branch in self.validators)
 
     def __probatio_with_extra__(self, extra: int) -> _Combinator:
         """Return a copy of this combinator recompiled under ``extra``.


### PR DESCRIPTION
## Breaking change

None. Both changes are behavior-preserving: `Self` detection is identical (verified against the full edge-case set: `Self` as key, in a sequence, through a combinator, and the nested-`Schema` boundary), and the existing extra-propagation tests pin that `ALLOW_EXTRA`/`REMOVE_EXTRA` still reaches every combinator-nested dict.

## Proposed change

Profiling construction of Home-Assistant-style schemas (many `ALLOW_EXTRA` platform schemas full of type/list combinators like `Any(str, [str])`) surfaced two costs that a flatter synthetic workload hid. Both are in the compile-time callable branch; together they cut that construction by about 25% (7.6s to 5.7s on the workload).

- **Skip the `Self`-detection walk for a leaf validator.** Only a node that holds child schemas (`validators`/`validator`) can carry a nested `Self`, so a plain leaf (`Coerce`, `Range`, `In`, ...) need not be walked at all. A cheap `hasattr` guard replaces the function call and its `isinstance` checks. This dropped `_schema_uses_self` from ~2.2M calls to ~1.5M on the workload.

- **Skip the extra rebind for a combinator with no nested mapping.** The extra policy only changes how a dict schema compiles, so `Any(str, [str])` and friends compile identically under any policy. The combinator reports whether a branch holds a mapping (`__probatio_needs_extra__`), and the compiler skips the `copy.copy` and recompile when none does. `ALLOW_EXTRA` still reaches a dict nested directly, through a sequence, or through a nested combinator (combinators re-thread the policy); a `Maybe` or nested `Schema` compiles under its own policy, so it is a leaf for this check. This removed `copy.copy` from the profile entirely for those schemas.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
