### PR TITLE
Resolve __version__ lazily to speed up import

### DIFF
--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -12,8 +12,6 @@ and the JSON/YAML/TOML loaders and dumpers.
 
 from __future__ import annotations
 
-from importlib import metadata
-
 from probatio._type_registry import (
     clear_type_registry,
     register_type,
@@ -246,13 +244,27 @@ from probatio.validators import (
     validate,
 )
 
-# Resolved from the installed package metadata, falling back to "0.0.0" for a
-# bare source-tree import (no install); the release workflow stamps the real
-# version at publish time.
-try:
-    __version__ = metadata.version("probatio")
-except metadata.PackageNotFoundError:  # pragma: no cover - only without an install
-    __version__ = "0.0.0"
+
+# ``__version__`` is resolved lazily from the installed package metadata on first
+# access (PEP 562). A plain ``import probatio`` for validation never reads it, so
+# it should not pay for the metadata lookup, which scans the installed dist-info
+# (~20 ms). The resolved value is cached as a real module global afterwards. It
+# falls back to "0.0.0" for a bare source-tree import (no install); the release
+# workflow stamps the real version at publish time.
+def __getattr__(name: str) -> str:
+    """Resolve ``__version__`` from the package metadata on first access."""
+    if name == "__version__":
+        from importlib import metadata  # noqa: PLC0415
+
+        try:
+            version = metadata.version("probatio")
+        except metadata.PackageNotFoundError:  # pragma: no cover
+            version = "0.0.0"
+        globals()["__version__"] = version
+        return version
+    message = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(message)
+
 
 __all__ = [
     "ALLOW_EXTRA",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from importlib import metadata
 
+import pytest
+
 import probatio
 
 
@@ -16,3 +18,9 @@ def test_version_is_a_non_empty_string() -> None:
     """__version__ is a usable version string."""
     assert isinstance(probatio.__version__, str)
     assert probatio.__version__
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """Accessing an undefined module attribute still raises AttributeError."""
+    with pytest.raises(AttributeError):
+        _ = probatio.does_not_exist


### PR DESCRIPTION
## Breaking change

None. `probatio.__version__` still resolves to the same value; it is just computed on first access instead of at import.

## Proposed change

`import probatio` resolved `__version__` eagerly from the installed package metadata. `importlib.metadata.version` scans the installed dist-info, which costs about 20 ms on a real install, and nothing on the validation or schema-building path ever reads the version. So every import paid for a value almost no importer uses.

This moves `__version__` behind a module `__getattr__` (PEP 562). The metadata lookup runs only on first access of `probatio.__version__` and then caches the result as a real module global, so repeated reads are free. The attribute behaves exactly as before for anyone who reads it, including `voluptuous.__version__` through the `install_as_voluptuous()` drop-in shim.

Measured on an installed wheel, cold import drops from ~54 ms to ~43 ms. It is the first of two import-cost trims surfaced by profiling probatio inside an ESPHome config load (the second, deferring the serde layer pulled by the encoding validators, follows separately).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
