### PR TITLE
Defer the codec and serde layers to speed up import

### DIFF
--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -12,18 +12,12 @@ and the JSON/YAML/TOML loaders and dumpers.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from probatio._type_registry import (
     clear_type_registry,
     register_type,
     type_registry,
-)
-from probatio.codecs import (
-    UNSUPPORTED,
-    from_json_schema,
-    from_openapi,
-    serialize,
-    to_json_schema,
-    to_openapi,
 )
 from probatio.dataclass_schema import (
     DataclassSchema,
@@ -114,20 +108,6 @@ from probatio.schema import (
     Schema,
     Schemable,
     current_context,
-)
-from probatio.serde import (
-    clear_default_options,
-    default_options,
-    dump,
-    dump_json,
-    dump_toml,
-    dump_yaml,
-    load,
-    load_json,
-    load_toml,
-    load_yaml,
-    load_yaml_with_locations,
-    set_default_options,
 )
 from probatio.validators import (
     ASCII,
@@ -244,6 +224,66 @@ from probatio.validators import (
     validate,
 )
 
+if TYPE_CHECKING:
+    # Eagerly visible to type-checkers so ``probatio.to_json_schema`` and friends
+    # keep their real signatures, while at runtime they are re-exported lazily
+    # (below) to keep a validate-only import cheap.
+    from probatio.codecs import (
+        UNSUPPORTED,
+        from_json_schema,
+        from_openapi,
+        serialize,
+        to_json_schema,
+        to_openapi,
+    )
+    from probatio.serde import (
+        clear_default_options,
+        default_options,
+        dump,
+        dump_json,
+        dump_toml,
+        dump_yaml,
+        load,
+        load_json,
+        load_toml,
+        load_yaml,
+        load_yaml_with_locations,
+        set_default_options,
+    )
+
+# The codec and serde layers cost more to import than the validation engine, and a
+# plain ``import probatio`` for validation needs neither. Their public names are
+# re-exported lazily (PEP 562): the submodule is imported on first access of one of
+# its names, and the resolved attribute is cached as a real module global so later
+# reads are free. Maps each re-exported name to the module it lives in.
+_LAZY_NAMES = dict.fromkeys(
+    (
+        "UNSUPPORTED",
+        "from_json_schema",
+        "from_openapi",
+        "serialize",
+        "to_json_schema",
+        "to_openapi",
+    ),
+    "probatio.codecs",
+) | dict.fromkeys(
+    (
+        "clear_default_options",
+        "default_options",
+        "dump",
+        "dump_json",
+        "dump_toml",
+        "dump_yaml",
+        "load",
+        "load_json",
+        "load_toml",
+        "load_yaml",
+        "load_yaml_with_locations",
+        "set_default_options",
+    ),
+    "probatio.serde",
+)
+
 
 # ``__version__`` is resolved lazily from the installed package metadata on first
 # access (PEP 562). A plain ``import probatio`` for validation never reads it, so
@@ -251,8 +291,8 @@ from probatio.validators import (
 # (~20 ms). The resolved value is cached as a real module global afterwards. It
 # falls back to "0.0.0" for a bare source-tree import (no install); the release
 # workflow stamps the real version at publish time.
-def __getattr__(name: str) -> str:
-    """Resolve ``__version__`` from the package metadata on first access."""
+def __getattr__(name: str) -> object:
+    """Resolve ``__version__`` and the lazy codec/serde re-exports on first access."""
     if name == "__version__":
         from importlib import metadata  # noqa: PLC0415
 
@@ -262,6 +302,13 @@ def __getattr__(name: str) -> str:
             version = "0.0.0"
         globals()["__version__"] = version
         return version
+    module_name = _LAZY_NAMES.get(name)
+    if module_name is not None:
+        from importlib import import_module  # noqa: PLC0415
+
+        value = getattr(import_module(module_name), name)
+        globals()[name] = value
+        return value
     message = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(message)
 

--- a/src/probatio/validators/encoding.py
+++ b/src/probatio/validators/encoding.py
@@ -22,7 +22,6 @@ from probatio.error import (
     YamlInvalid,
 )
 from probatio.schema import compile_schema
-from probatio.serde import _optional, load_yaml
 from probatio.validators._base import _SafeValidator
 
 
@@ -139,6 +138,8 @@ class YAMLString(_SafeValidator):
 
     def __init__(self, schema: typing.Any = None, msg: str | None = None) -> None:
         """Compile the optional inner schema; require a YAML backend up front."""
+        from probatio.serde import _optional  # noqa: PLC0415
+
         if _optional.yamlrocks is None and _optional.pyyaml is None:
             message = "YAMLString needs a YAML parser; install probatio[yaml]"
             raise SchemaError(message)
@@ -147,6 +148,8 @@ class YAMLString(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the decoded (and validated) value, else raise YamlInvalid."""
+        from probatio.serde import load_yaml  # noqa: PLC0415
+
         if not isinstance(value, str | bytes):
             raise YamlInvalid(self.msg or "expected a YAML string")
         try:


### PR DESCRIPTION
## Breaking change

None. Every public name still imports and behaves the same; the codec and serde names are just resolved on first access instead of at import.

## Proposed change

`import probatio` eagerly imported the JSON-Schema/OpenAPI codecs and the YAML/JSON/TOML serde layer purely to re-export their public names, and the encoding validators (`YAMLString`) pulled `serde` in as well. None of that is needed for a validate-only import, which is the common case (for example a Home Assistant or ESPHome config load), yet all of it loaded on every `import probatio`.

This re-exports the six codec names and twelve serde names lazily through the module `__getattr__` (PEP 562): the submodule is imported on first access of one of its names, and the resolved attribute is cached as a real module global so later reads are free. A `TYPE_CHECKING` block keeps the eager imports for type-checkers, so `probatio.to_json_schema`, `probatio.load_yaml`, and the rest keep their real signatures. `YAMLString` imports its serde helpers inside its methods, matching the lazy pattern the `Schema` convenience loaders already use.

After this, `import probatio` no longer loads `probatio.codecs` or `probatio.serde`; they load on first use. Measured on an installed wheel, cold import drops from ~43 ms to ~28 ms. Together with the lazy `__version__` change already merged in #49, that takes a cold `import probatio` from ~54 ms to ~28 ms, roughly half.

Note on a small typing detail: the `__getattr__` return annotation is `object` rather than `Any`, because `Any` is one of probatio's own public validators and importing `typing.Any` into the facade would collide with it. The lazily re-exported names keep precise types through the `TYPE_CHECKING` imports; `object` only affects genuinely unknown attributes, which raise `AttributeError`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #49
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
