### PR TITLE
Delegate Schema str and repr to the wrapped schema

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -285,6 +285,15 @@ class _EnumCheck:
             ) from exc
 
 
+# The extra-key policy rendered as its public name, for ``repr`` (matches
+# voluptuous, which shows the policy a Schema was built with).
+_EXTRA_TO_NAME = {
+    PREVENT_EXTRA: "PREVENT_EXTRA",
+    ALLOW_EXTRA: "ALLOW_EXTRA",
+    REMOVE_EXTRA: "REMOVE_EXTRA",
+}
+
+
 class Schema:
     """A compiled, callable schema.
 
@@ -348,6 +357,24 @@ class Schema:
         # Raised outside the except block so the single error is reported on its
         # own, not chained as "during handling of the above exception".
         raise MultipleInvalid([error])
+
+    def __str__(self) -> str:
+        """Render as the wrapped schema, matching voluptuous.
+
+        Callers ``str()`` a Schema to inspect the shape it wraps. Home Assistant's
+        config classifier reads a leading ``{`` or ``[`` to tell dict- from
+        list-based config, so this delegates to the inner schema rather than
+        returning the default object repr.
+        """
+        return str(self.schema)
+
+    def __repr__(self) -> str:
+        """Render as voluptuous does: the inner schema, extra policy, and required."""
+        extra = _EXTRA_TO_NAME.get(self.extra, "??")
+        return (
+            f"<Schema({self.schema}, extra={extra}, "
+            f"required={self.required}) object at 0x{id(self):x}>"
+        )
 
     def _call_with_context(self, data: Any, context: Any) -> Any:
         """Set the call context, then validate through the common path.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from probatio import Invalid, MultipleInvalid, Required, Schema
+from probatio import ALLOW_EXTRA, Invalid, MultipleInvalid, Required, Schema
 from probatio.error import ScalarInvalid, TypeInvalid, ValueInvalid
 
 
@@ -147,3 +147,29 @@ def test_infer_passes_keyword_arguments_through() -> None:
     assert schema({"extra": 1}) == {"extra": 1}
     with pytest.raises(MultipleInvalid):
         schema({"name": 42})
+
+
+def test_str_delegates_to_the_inner_schema() -> None:
+    """str(Schema(x)) reads as str(x), matching voluptuous, not the object repr."""
+    assert str(Schema({"a": int})) == "{'a': <class 'int'>}"
+    assert str(Schema([int])) == "[<class 'int'>]"
+    assert str(Schema(int)) == "<class 'int'>"
+
+
+def test_str_lets_a_leading_brace_or_bracket_classify_the_schema() -> None:
+    """The rendered string starts with { for a dict schema and [ for a list one.
+
+    Home Assistant's config classifier reads exactly that to tell dict- from
+    list-based config, so the delegation has to surface the wrapped container.
+    """
+    assert str(Schema({"a": int})).startswith("{")
+    assert str(Schema([int])).startswith("[")
+
+
+def test_repr_mirrors_voluptuous_with_extra_and_required() -> None:
+    """repr(Schema) shows the inner schema, the extra policy name, and required."""
+    rendered = repr(Schema({"a": int}, extra=ALLOW_EXTRA))
+    assert rendered.startswith(
+        "<Schema({'a': <class 'int'>}, extra=ALLOW_EXTRA, required=False) object at 0x"
+    )
+    assert rendered.endswith(">")


### PR DESCRIPTION
## Breaking change

None. It adds `__str__`/`__repr__` where there were none, so the only change is that `str()`/`repr()` of a `Schema` now read like voluptuous instead of returning the default object repr.

## Proposed change

`Schema` defined neither `__str__` nor `__repr__`, so `str(Schema(...))` fell back to the default object repr (`<probatio.schema.Schema object at 0x...>`). voluptuous delegates: `str(schema)` is `str(schema.schema)`, and `repr(schema)` is a `<Schema(...) object at 0x...>` form.

This surfaced in Home Assistant. `_identify_config_schema` classifies a component's config as dict- or list-based by reading `str(domain_schema)` and checking for a leading `{` or `[` (and `All(<function ensure_list`):

```python
t_schema = str(domain_schema)
if t_schema.startswith("{") or "schema_with_slug_keys" in t_schema:
    return "dict"
if t_schema.startswith(("[", "All(<function ensure_list")):
    return "list"
```

Against probatio that saw the object repr and returned `None`, which breaks config and package merging for any component whose `CONFIG_SCHEMA` is itself a `Schema` (it fails `tests/test_config.py::test_merge_id_schema` in core).

The fix mirrors voluptuous: `__str__` returns `str(self.schema)`, and `__repr__` returns `<Schema(<inner>, extra=<POLICY>, required=<bool>) object at 0x...>` using the existing `schema`/`extra`/`required` attributes. Verified that `str()` matches voluptuous byte-for-byte for dict, list, type-key, and validator schemas, that the Home Assistant classifier now returns `dict`/`list` (including the `All(<function ensure_list` list path), and that `repr()` matches voluptuous's format.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
