### PR TITLE
Preserve a dict subclass through mapping validation

### DIFF
--- a/docs/src/content/docs/getting-started/compatibility.md
+++ b/docs/src/content/docs/getting-started/compatibility.md
@@ -61,7 +61,10 @@ is a deliberate improvement over a sharp edge:
   once. The first, meaningful error is identical.
 - Any `Mapping` is accepted, not only `dict`. A `MappingProxyType`, a multidict,
   or any custom mapping validates and returns a plain `dict`, where voluptuous
-  rejects it. A strict superset, so dict code is unaffected.
+  rejects it. A genuine `dict` subclass is preserved as its own class, matching
+  voluptuous, so a Home Assistant `NodeDictClass` keeps its type (and the source
+  line it carries) across validation. A strict superset, so dict code is
+  unaffected.
 - A callable validator that raises `ValueError("reason")` keeps the reason in
   the error ("not a valid value: reason"), where voluptuous drops it. A
   `ValueError` with no message still reads "not a valid value".

--- a/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
+++ b/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
@@ -82,7 +82,10 @@ is a deliberate improvement, not a regression:
 - **Any `Mapping` is accepted, not only `dict`.** A `MappingProxyType`, a
   multidict, or any custom type implementing the `Mapping` protocol validates
   and returns a plain `dict`, where voluptuous rejects it with "expected a
-  dictionary". This is a strict superset, so dict code is unaffected.
+  dictionary". A genuine `dict` subclass is preserved as its own class, the same
+  as voluptuous, so a subclass that carries metadata (like Home Assistant's
+  `NodeDictClass`) survives validation. This is a strict superset, so dict code
+  is unaffected.
 - **A callable's `ValueError` message is kept.** When a plain callable validator
   raises `ValueError("reason")`, the reason is carried into the error ("not a
   valid value: reason") instead of being dropped. A `ValueError` with no message

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -274,7 +274,10 @@ Probatio does.
 - **Non-dict `Mapping` input (a `MappingProxyType`, a multidict, a custom
   mapping).** voluptuous rejects it with "expected a dictionary". Probatio
   validates any object implementing the `Mapping` protocol and returns a plain
-  `dict`. A strict superset, so existing dict code is unaffected.
+  `dict`. A genuine `dict` subclass, on the other hand, is preserved as its own
+  class, the same as voluptuous, so a `NodeDictClass` and similar metadata-carrying
+  subclasses survive validation. A strict superset, so existing dict code is
+  unaffected.
 - **A callable validator raising `ValueError("reason")`.** voluptuous reports a
   bare "not a valid value", dropping the reason. Probatio appends it: "not a valid
   value: reason". A `ValueError` with no message stays bare.

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -196,12 +196,23 @@ class _MappingValidator:
         if not isinstance(data, dict) and not isinstance(data, Mapping):
             message = "expected a dictionary"
             raise DictInvalid(message)
+        # The output is rebuilt as the input's class when that is a genuine dict
+        # subclass, matching voluptuous. Home Assistant loads YAML into a
+        # NodeDictClass (a dict subclass carrying the source file and line), and
+        # that type has to survive validation. A plain dict stays a plain dict (the
+        # hot case), and a foreign Mapping (a MappingProxyType, a multidict) that is
+        # not a dict subclass normalizes to a plain dict, since it cannot be
+        # reconstructed. Read here, before alias resolution rebuilds data as a plain
+        # dict.
+        data_type = type(data)
         if self._alias_lookup:
             # Rename accepted alias names to their canonical keys before matching,
             # so everything below works on canonical names. Only runs when the
             # schema actually has aliases, so the common case pays nothing.
             data = self._resolve_aliases(data)
-        out: dict[Any, Any] = {}
+        out: dict[Any, Any] = (
+            {} if data_type is dict or not issubclass(data_type, dict) else data_type()
+        )
         errors: list[Invalid] = []
         # ``seen`` flags which candidates matched (by position), so the finalizer
         # pass can tell a provided-but-invalid key from an absent one. A bytearray

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -10,6 +10,7 @@ from probatio import (
     ALLOW_EXTRA,
     REMOVE_EXTRA,
     UNDEFINED,
+    Alias,
     Any,
     Coerce,
     Exclusive,
@@ -44,6 +45,39 @@ def test_accepts_any_mapping() -> None:
     result = Schema({"name": str, "port": int})(proxy)
     assert result == {"name": "app", "port": 80}
     assert type(result) is dict
+
+
+def test_dict_subclass_is_preserved() -> None:
+    """A dict subclass comes back as that subclass, matching voluptuous."""
+
+    class NodeDict(dict):
+        pass
+
+    result = Schema({"a": int})(NodeDict({"a": 1}))
+    assert result == {"a": 1}
+    assert type(result) is NodeDict
+
+
+def test_dict_subclass_is_preserved_with_aliases() -> None:
+    """The subclass survives even when alias resolution rebuilds the input."""
+
+    class NodeDict(dict):
+        pass
+
+    result = Schema({Alias("a", "A"): int})(NodeDict({"A": 1}))
+    assert result == {"a": 1}
+    assert type(result) is NodeDict
+
+
+def test_nested_dict_subclasses_are_preserved() -> None:
+    """A subclass is preserved at every level of a nested mapping."""
+
+    class NodeDict(dict):
+        pass
+
+    result = Schema({"outer": {"a": int}})(NodeDict({"outer": NodeDict({"a": 1})}))
+    assert type(result) is NodeDict
+    assert type(result["outer"]) is NodeDict
 
 
 def test_mapping_value_errors_are_reported() -> None:


### PR DESCRIPTION
## Breaking change

None for dict code. The output of a dict schema now preserves a genuine `dict` subclass instead of flattening it to a plain `dict`. That restores voluptuous behavior, so it only changes the type of the returned mapping for callers that passed a `dict` subclass in (and were previously losing it).

## Proposed change

The mapping validator always built its output as a plain `dict`, so a `dict` subclass passed in came back as a plain `dict`. voluptuous rebuilds the output as the input's class:

```python
class NodeDict(dict): ...
import voluptuous, probatio
voluptuous.Schema({"a": int})(NodeDict({"a": 1}))   # -> NodeDict (preserved)
probatio.Schema({"a": int})(NodeDict({"a": 1}))     # -> dict (was lost)
```

This surfaced in Home Assistant, which loads YAML into `NodeDictClass`, a `dict` subclass that carries the source file and line used to render "... at configuration.yaml, line N" in config errors. Validated config silently became a plain `dict` and lost that type across the codebase (showing up as widespread snapshot churn).

The fix builds the output as the input's class when that is a genuine `dict` subclass, matching voluptuous. A plain `dict` stays a plain `dict` (the hot case), and a foreign `Mapping` (a `MappingProxyType`, a multidict) that is not a `dict` subclass still normalizes to a plain `dict`, since it cannot be reconstructed. The class is captured before alias resolution, which would otherwise rebuild the input as a plain `dict`. The sequence validator already preserved `list` subclasses (`type(data)(result)`); this brings the mapping path in line.

Verified against voluptuous: subclasses preserved (`dict` and `OrderedDict`), plain dict stays plain, `MappingProxyType` normalizes to `dict`, the subclass survives alias resolution, and nested subclasses are preserved at every level.

The cost is one `type(data)` call per mapping validation (the old code skipped it by always building `{}`), which voluptuous pays too. The docs that documented "any Mapping returns a plain dict" are updated to note that genuine `dict` subclasses are preserved.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
