### PR TITLE
Re-run the whole combinator when Self recurses inside it

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -743,6 +743,16 @@ class Schema:
         validation time. A bare ``Schema(Self)`` (Self with nothing around it) has
         no enclosing schema at all and is a definition error.
         """
+        # Inside a combinator, Self always defers to the root being validated. A
+        # combinator compiles its branches before the enclosing schema exists, so
+        # any _COMPILING_ROOT reached here is an intermediate branch schema, not the
+        # schema Self refers to. In Any({key: Self}, str) the dict branch compiles
+        # as its own Schema and would capture Self; binding to it would trap the
+        # recursion in that one branch, so a string leaf never falls through to the
+        # sibling str branch. Deferring re-runs the whole combinator instead.
+        if _COMPILING_FOR_COMBINATOR.get():
+            return _deferred_self
+
         root = _COMPILING_ROOT.get()
         if root is not None and root.schema is not Self:
             # Direct Self: bind to the enclosing schema now.
@@ -755,16 +765,13 @@ class Schema:
 
             return validate
 
-        if not _COMPILING_FOR_COMBINATOR.get():
-            # A bare Schema(Self), or Self wrapped by a validator that compiles it
-            # outside a combinator: there is no enclosing schema to resolve against.
-            message = (
-                "Self must be a mapping value, sequence element, or combinator "
-                "branch, not a schema on its own"
-            )
-            raise SchemaError(message)
-
-        return _deferred_self
+        # A bare Schema(Self), or Self wrapped by a validator that compiles it
+        # outside a combinator: there is no enclosing schema to resolve against.
+        message = (
+            "Self must be a mapping value, sequence element, or combinator "
+            "branch, not a schema on its own"
+        )
+        raise SchemaError(message)
 
     @staticmethod
     def _compile_type(schema: type) -> CompiledSchema:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -77,6 +77,23 @@ def test_self_inside_any_validates_a_recursive_alternative() -> None:
         schema({"follow": {"number": "1.5"}})
 
 
+def test_self_inside_any_falls_through_to_a_sibling_branch() -> None:
+    """A Self recursion re-runs the whole Any, so a leaf takes a later branch.
+
+    The recursive branch is a mapping whose values are Self; the sibling branch is
+    a scalar. A string leaf fails the mapping branch and must fall through to the
+    str branch, instead of stopping at "expected a dictionary". This is Home
+    Assistant's recursive translations schema (config_panel sections that bottom
+    out in string leaves).
+    """
+    schema = Schema(Any({Any(str, "_"): Self}, str))
+    data = {"section": {"title": "a string", "sub": {"item": "x"}}}
+    assert schema(data) == data
+    assert schema("leaf") == "leaf"
+    with pytest.raises(MultipleInvalid):
+        schema({"section": {"title": 123}})
+
+
 def test_self_inside_all_chains_recursion_with_another_schema() -> None:
     """Self works inside All, chaining the recursive check with a second schema."""
     schema = Schema(


### PR DESCRIPTION
## Breaking change

None. A schema that previously raised on a recursive `Self` inside a combinator now validates the way voluptuous does. It only accepts more, never less.

## Proposed change

A recursive schema where `Self` appears in one branch of an `Any` did not fall through to the other branches when the recursion landed on a value that should match a sibling branch:

```python
schema = Schema(Any({Any(str, "_"): Self}, str))
data = {"section_one": {"title": "a string", "subsection": {"item": "x"}}}
schema(data)
# voluptuous: OK
# probatio:   MultipleInvalid: expected a dictionary ... @ data['section_one']['title']
```

The cause is in how `Self` binds. A combinator compiles its branches before the enclosing schema exists, so in `Any({key: Self}, str)` the dict branch compiles as its own `Schema`, sets the compiling root to itself, and `Self` captured that inner dict through the "direct bind" path in `_compile_self`. The recursion then only ever re-ran that one branch, so a string leaf failed with "expected a dictionary" instead of falling through to the sibling `str` branch.

The fix: when compiling inside a combinator, `Self` always defers to the root being validated rather than binding to the intermediate branch schema. The recursion re-runs the whole combinator, so a leaf can take a later branch. The change is compile-time only; the validation hot path is untouched.

Verified against voluptuous: the reported case and a deeper version pass, sibling fall-through works for mapping, list, and scalar branches, and the existing `Self` cases are unchanged (tree recursion, `Self` as a direct `Any` branch, `Self` in `All`, the bare-`Self` definition error, and a combinator-with-`Self` called on its own). A new test covers the recursive shape.

Real-world impact: Home Assistant's `config_panel` translations schema is `Schema(Any({Any(key, "_"): Self}, translation_value))`, recursive sections that bottom out in string leaves. Before this, every string leaf was wrongly rejected.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
