### PR TITLE
Reject a boolean as a port number

### DIFF
--- a/src/probatio/validators/network.py
+++ b/src/probatio/validators/network.py
@@ -183,6 +183,12 @@ class Port(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> int:
         """Return the port as an int if in range, else raise RangeInvalid."""
+        if isinstance(value, bool):
+            # A bool is an int, so ``int(True)`` would otherwise pass as port 1; a
+            # boolean is never a port, so reject it the way the IP and duration
+            # validators reject a bool.
+            message = self.msg or "expected a port number between 1 and 65535"
+            raise RangeInvalid(message)
         if isinstance(value, float) and not value.is_integer():
             # A fractional float is not a port; reject it rather than silently
             # truncating ``8080.7`` to ``8080``.

--- a/tests/validators/test_network.py
+++ b/tests/validators/test_network.py
@@ -153,6 +153,14 @@ def test_port_accepts_an_integral_float() -> None:
     assert Schema(Port())(8080.0) == 8080
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_port_rejects_a_bool(value: object) -> None:
+    """A bool is an int but never a port, so it raises rather than passing as 1 or 0."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Port())(value)
+    assert isinstance(caught.value.errors[0], RangeInvalid)
+
+
 @pytest.mark.parametrize(
     "validator",
     [IPv4Address(), IPv6Address(), IPAddress(), IPNetwork()],


### PR DESCRIPTION
## Breaking change

A value that used to validate now does not: `Port()(True)` previously returned `1`. Anyone who (most likely by accident) passed a boolean to a port schema will now get a validation error instead of a silent `1`. This matches the existing behavior for `False`, which already failed as out of range.

## Proposed change

A `bool` is an `int` subclass, so `int(True)` is `1` and `Port` let `True` through as port 1, while `False` failed only because `0` is out of range. A boolean is never a port, so reject it up front. This matches the explicit `bool` guards the IP and duration validators already use.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
