### PR TITLE
Check FqdnUrl's dot in the host, not the userinfo

### DIFF
--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -357,10 +357,14 @@ def FqdnUrl(msg: str | None = None) -> typing.Callable[[typing.Any], typing.Any]
     def validate(value: typing.Any) -> typing.Any:
         """Validate a URL and require its host to contain a dot."""
         _validate_url(value, msg)
-        # ``_validate_url`` accepts str or bytes; match the separator to the type
-        # so the dot check on a bytes URL does not leak a TypeError.
+        # Check the dot in the host, not the whole netloc: the netloc also holds the
+        # userinfo and port, so ``http://user.name@localhost`` would otherwise pass
+        # on the dot in ``user.name`` even though the host ``localhost`` has none.
+        # ``hostname`` is bytes for a bytes URL and None when there is no host, so
+        # match the separator to the type and reject a missing host.
+        host = urlparse(value).hostname
         dot = b"." if isinstance(value, bytes) else "."
-        if dot not in urlparse(value).netloc:
+        if host is None or dot not in host:
             raise UrlInvalid(msg or "expected a URL with a fully-qualified domain name")
         return value
 

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -144,6 +144,22 @@ def test_fqdn_url_requires_a_dotted_host() -> None:
     assert isinstance(caught.value.errors[0], UrlInvalid)
 
 
+def test_fqdn_url_ignores_a_dot_in_the_userinfo() -> None:
+    """A dot in the userinfo does not make the host fully-qualified.
+
+    ``http://user.name@localhost`` has the dot in the credentials, not the host
+    ``localhost``, so the check must look at the host alone and reject it.
+    """
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(FqdnUrl())("http://user.name@localhost")
+    assert isinstance(caught.value.errors[0], UrlInvalid)
+    # The host itself being fully-qualified still passes, userinfo and all.
+    assert (
+        Schema(FqdnUrl())("http://user.name@host.example.com")
+        == "http://user.name@host.example.com"
+    )
+
+
 def test_slug_accepts_a_valid_slug() -> None:
     """Slug accepts a lowercase slug and returns it unchanged."""
     assert Schema(Slug())("my_slug-1") == "my_slug-1"


### PR DESCRIPTION
## Breaking change

A value that used to validate now does not: `FqdnUrl()("http://user.name@localhost")` previously passed. A URL whose host is not fully-qualified but whose userinfo contains a dot will now be rejected, which is the intended behavior.

## Proposed change

`FqdnUrl` required a dot in the URL's `netloc`, but the netloc also holds the userinfo and port, so `http://user.name@localhost` passed on the dot in `user.name` even though the host `localhost` is a single label. Check the dot in the host alone (`urlparse(...).hostname`), which strips the userinfo and port, and reject a URL with no host. The host being fully-qualified still passes regardless of userinfo, so `http://user.name@host.example.com` is accepted.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
