### PR TITLE
Serialize a nullable Any to allow_none in either order

### DIFF
--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -256,10 +256,13 @@ def _serialize_validator(node: Any, custom: Any) -> dict[str, Any] | None:  # no
     if isinstance(node, Maybe):
         return _allow_none(_serialize_value(node.validator, custom))
     if isinstance(node, AnyValidator):
-        # ``Maybe(X)`` compiles to ``Any(None, X)``: voluptuous-serialize strips a
-        # leading None and marks the single remaining member allow_none.
-        if len(node.validators) == 2 and node.validators[0] is None:
-            return _allow_none(_serialize_value(node.validators[1], custom))
+        # ``Maybe(X)`` compiles to ``Any(None, X)``: a two-member Any with one None
+        # branch is the nullable form, so strip the None and mark the remaining
+        # member allow_none. voluptuous-serialize only recognized None first;
+        # ``Any(X, None)`` is the same nullable shape, so handle either position.
+        non_none = [member for member in node.validators if member is not None]
+        if len(node.validators) == 2 and len(non_none) == 1:
+            return _allow_none(_serialize_value(non_none[0], custom))
         for validator in node.validators:
             converted = _serialize_value(validator, custom)
             if converted:

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -304,3 +304,19 @@ def test_serialize_matches_voluptuous_serialize(case: str) -> None:
         voluptuous.Schema(_parity_build(voluptuous)[case])
     )
     assert got == want
+
+
+def test_serialize_marks_allow_none_for_either_any_order() -> None:
+    """A nullable ``Any`` serializes to allow_none whether None is first or last.
+
+    voluptuous-serialize only handled ``Any(None, X)``; probatio also recognizes
+    ``Any(X, None)`` as the same nullable shape rather than dropping the None.
+    """
+    assert serialize(Schema(ProbAny(None, str))) == {
+        "type": "string",
+        "allow_none": True,
+    }
+    assert serialize(Schema(ProbAny(str, None))) == {
+        "type": "string",
+        "allow_none": True,
+    }


### PR DESCRIPTION
## Breaking change

None. `serialize(Schema(Any(str, None)))` previously returned `{"type": "string"}` (dropping the nullable marker); it now returns `{"type": "string", "allow_none": True}`. The None-first form `Any(None, str)` is unchanged.

## Proposed change

`serialize` recognized only the None-first nullable shape (`Any(None, X)`, the form `Maybe` compiles to), so `Any(X, None)` silently lost its None branch and serialized without `allow_none`. Detect the single non-None member regardless of position and mark it `allow_none`, the same nullable shape either way.

voluptuous-serialize itself only handles the None-first form and raises "Unable to convert schema" on `Any(str, None)`, so there is no oracle reference for the None-last form to diverge from. Handling it gracefully is a superset of voluptuous-serialize, consistent with how probatio already serializes `Maybe`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
