### PR TITLE
Pass positional-only arguments positionally in @validate

### DIFF
--- a/src/probatio/validators/decorators.py
+++ b/src/probatio/validators/decorators.py
@@ -146,12 +146,23 @@ def validate(
         output_schema: typing.Callable[[typing.Any], typing.Any] = (
             Schema(returns) if returns_defined else _identity
         )
+        # A parameter declared before the ``/`` cannot be passed by keyword, so it
+        # has to go back to ``func`` positionally; everything else goes as keywords.
+        positional_only = [
+            name
+            for name, parameter in inspect.signature(func).parameters.items()
+            if parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+        ]
 
         @wraps(func)
         def wrapper(*call_args: typing.Any, **call_kwargs: typing.Any) -> typing.Any:
             """Validate the bound arguments, call ``func``, validate the result."""
             bound = {**_args_to_dict(func, call_args), **call_kwargs}
-            return output_schema(func(**input_schema(bound)))
+            validated = input_schema(bound)
+            leading = [
+                validated.pop(name) for name in positional_only if name in validated
+            ]
+            return output_schema(func(*leading, **validated))
 
         return wrapper
 

--- a/tests/validators/test_decorators.py
+++ b/tests/validators/test_decorators.py
@@ -37,6 +37,23 @@ def test_validate_rejects_a_bad_argument() -> None:
         echo("not an int")
 
 
+def test_validate_preserves_positional_only_parameters() -> None:
+    """A parameter before the ``/`` is passed positionally, not as a keyword.
+
+    Calling the wrapped function with every argument as a keyword would raise a
+    TypeError for a positional-only parameter, so they have to go back positionally.
+    """
+
+    @validate(arg1=int, arg2=int)
+    def multiply(arg1: int, /, arg2: int) -> int:
+        return arg1 * arg2
+
+    assert multiply(3, 4) == 12
+    assert multiply(3, arg2=4) == 12
+    with pytest.raises(MultipleInvalid):
+        multiply("x", 4)
+
+
 def test_validate_checks_the_return_value() -> None:
     """A __return__ schema validates the function's result."""
 


### PR DESCRIPTION
## Breaking change

None. This fixes a `TypeError` that previously made `@validate` unusable on a function with a positional-only parameter.

## Proposed change

The `validate` decorator called the wrapped function with every argument as a keyword (`func(**validated)`). That raises `TypeError: got some positional-only arguments passed as keyword arguments` for any parameter declared before the `/` separator. Compute the positional-only parameter names once at decoration time, then pass those positionally and the rest as keywords.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
