### PR TITLE
Refuse a non-string entry in a JSON Schema type array

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -774,8 +774,20 @@ def _from_typed(node: dict[str, Any], ctx: _Decode) -> Any:
     return object if combined is None else combined
 
 
-def _from_type_list(node: dict[str, Any], types: list[str], ctx: _Decode) -> Any:
-    """Render a ``type`` array (``["string", "null"]``) as an Any of each type."""
+def _from_type_list(node: dict[str, Any], types: list[Any], ctx: _Decode) -> Any:
+    """Render a ``type`` array (``["string", "null"]``) as an Any of each type.
+
+    ``types`` is untrusted JSON, so each entry must be a string: a non-string entry
+    (a ``null`` becomes a ``type`` of None, which would otherwise fall through to an
+    accept-anything schema and silently widen validation) is refused.
+    """
+    for name in types:
+        if not isinstance(name, str):
+            message = (
+                f"JSON Schema 'type' array entries must be strings, "
+                f"got {type(name).__name__}"
+            )
+            raise SchemaError(message)
     validators = [
         None if name == "null" else _from_typed({**node, "type": name}, ctx)
         for name in types

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -357,6 +357,25 @@ def test_non_list_required_is_a_clean_schema_error() -> None:
         from_json_schema({"type": "object", "required": "name"})
 
 
+def test_non_string_type_array_entry_is_a_clean_schema_error() -> None:
+    """A non-string entry in a 'type' array is refused rather than widening.
+
+    A ``null`` entry would become a ``type`` of None and fall through to an
+    accept-anything schema, silently widening validation; refuse it instead.
+    """
+    with pytest.raises(SchemaError, match="type"):
+        from_json_schema({"type": [None]})
+
+
+def test_type_array_decodes_to_a_union() -> None:
+    """A valid 'type' array decodes to an Any of each named type, including null."""
+    schema = from_json_schema({"type": ["string", "null"]})
+    assert schema("x") == "x"
+    assert schema(None) is None
+    with pytest.raises(MultipleInvalid):
+        schema(123)
+
+
 def test_prefix_items_round_trips_an_exact_sequence() -> None:
     """An ExactSequence encodes to prefixItems and decodes back to a tuple schema."""
     schema = from_json_schema(to_json_schema(Schema(ExactSequence([int, str]))))


### PR DESCRIPTION
## Breaking change

None for valid input. A malformed schema like `{"type": [null]}` now raises a clean `SchemaError` at decode time instead of producing an accept-anything validator.

## Proposed change

`_from_typed` already refused a non-string scalar `type`, but the array path dispatched straight to `_from_type_list` without checking each entry. So `{"type": [null]}` turned the `null` into a `type` of `None`, which fell through to the accept-anything fallback and silently widened validation to accept any value. Validate that every entry in a `type` array is a string and refuse a non-string entry with a `SchemaError`, the same fail-closed behavior the scalar path already has. The parameter annotation is corrected from `list[str]` to `list[Any]`, since it receives untrusted JSON.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
