### PR TITLE
Decode prefixItems to ExactSequence only when the array is closed

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -889,20 +889,41 @@ def _from_key(name: str, subschema: Any, *, required: bool) -> Marker:
     return marker_cls(name, description=description)
 
 
+def _from_prefix_items(prefix: Any, node: dict[str, Any], ctx: _Decode) -> Any:
+    """Decode a closed positional ``prefixItems`` array into an ``ExactSequence``.
+
+    Only the closed form (``items: false``, what ``to_json_schema`` emits for an
+    ``ExactSequence``) maps cleanly. With ``items`` absent or a schema, JSON Schema
+    allows additional items beyond the prefix, which ``ExactSequence`` (a
+    fixed-length tuple) cannot represent, so the open tail is refused rather than
+    silently rejecting valid arrays that carry extra items.
+    """
+    if not isinstance(prefix, list):
+        message = (
+            f"JSON Schema 'prefixItems' must be an array, got {type(prefix).__name__}"
+        )
+        raise SchemaError(message)
+    if node.get("items") is not False:
+        message = (
+            "JSON Schema 'prefixItems' is only supported with 'items': false "
+            "(a closed, fixed-length array); a schema or open tail does not map "
+            "to a probatio sequence"
+        )
+        raise SchemaError(message)
+    return ExactSequence([_from_node(element, ctx) for element in prefix])
+
+
 def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     """Render a JSON Schema array as a sequence schema, honoring item-count bounds.
 
-    ``prefixItems`` (a positional tuple) round-trips an ``ExactSequence``. A bool
-    ``items`` (``false`` forbids extra items, ``true`` allows any) carries no
-    per-item schema, so it is treated as an unconstrained list rather than fed to
-    the node decoder.
+    ``prefixItems`` with ``items: false`` (a closed, fixed-length positional array)
+    round-trips an ``ExactSequence``. A bool ``items`` (``false`` forbids extra
+    items, ``true`` allows any) carries no per-item schema, so it is treated as an
+    unconstrained list rather than fed to the node decoder.
     """
     prefix = node.get("prefixItems")
     if prefix is not None:
-        if not isinstance(prefix, list):
-            message = f"JSON Schema 'prefixItems' must be an array, got {type(prefix).__name__}"
-            raise SchemaError(message)
-        return ExactSequence([_from_node(element, ctx) for element in prefix])
+        return _from_prefix_items(prefix, node, ctx)
     items = node.get("items")
     if isinstance(items, bool):
         items = None

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -377,6 +377,31 @@ def test_non_list_prefix_items_is_a_clean_schema_error() -> None:
 
 
 @pytest.mark.parametrize(
+    "node",
+    [
+        {"type": "array", "prefixItems": [{"type": "string"}]},  # open tail
+        {  # typed tail
+            "type": "array",
+            "prefixItems": [{"type": "string"}],
+            "items": {"type": "integer"},
+        },
+        {"type": "array", "prefixItems": [{"type": "string"}], "items": True},
+    ],
+)
+def test_prefix_items_open_tail_is_a_clean_schema_error(
+    node: dict[str, object],
+) -> None:
+    """prefixItems with an open or typed tail is refused, not mapped to a fixed length.
+
+    Only the closed form (``items: false``) maps to an ``ExactSequence``. Without it,
+    JSON Schema allows items beyond the prefix, so decoding to a fixed-length tuple
+    would wrongly reject a valid array; refuse it with a clean SchemaError instead.
+    """
+    with pytest.raises(SchemaError, match="prefixItems"):
+        from_json_schema(node)
+
+
+@pytest.mark.parametrize(
     "validator",
     [Unique(), Contains(1), MultipleOf(2), Range(min=1), Length(min=2)],
 )


### PR DESCRIPTION
## Breaking change

A JSON Schema that previously decoded (and then mis-validated) now raises a clean `SchemaError` at decode time: `prefixItems` without `items: false` (an open or typed tail). Previously `from_json_schema` accepted it but built a fixed-length `ExactSequence`, so the resulting validator wrongly rejected valid arrays that carried extra items. The round-trip form (`prefixItems` with `items: false`) is unchanged.

## Proposed change

`from_json_schema` mapped any `prefixItems` array to `ExactSequence`, a fixed-length tuple, ignoring `items`. In JSON Schema 2020-12, `prefixItems` constrains only the leading positions: with `items` absent or a schema, additional items beyond the prefix are allowed. So decoding such a schema to a fixed-length `ExactSequence` produced a validator that rejected valid input.

Only the closed form (`items: false`, what `to_json_schema` emits for an `ExactSequence`) maps cleanly to a probatio sequence. Decode that, and refuse the open or typed tail with a clear `SchemaError`, the same fail-closed behavior the codec already uses for the unsupported Draft-4 positional `items` list form. The `prefixItems` handling moves to a small `_from_prefix_items` helper.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
