### PR TITLE
Re-raise a broken optional backend instead of masking it as absent

### DIFF
--- a/src/probatio/serde/_optional.py
+++ b/src/probatio/serde/_optional.py
@@ -12,11 +12,20 @@ from typing import Any
 
 
 def _load(name: str) -> Any:
-    """Import a module by name, returning None when it is not installed."""
+    """Import a module by name, returning None when it is not installed.
+
+    A genuinely absent backend raises ``ModuleNotFoundError`` naming that module, so
+    return None for it. Any other import failure (a different ``ImportError``, or a
+    ``ModuleNotFoundError`` naming some other module the backend imports) means the
+    backend is installed but broken, so re-raise rather than silently masking it as
+    absent and falling back.
+    """
     try:
         return import_module(name)
-    except ImportError:
-        return None
+    except ModuleNotFoundError as exc:
+        if exc.name == name:
+            return None
+        raise
 
 
 orjson = _load("orjson")

--- a/tests/serde/test_loaders.py
+++ b/tests/serde/test_loaders.py
@@ -50,6 +50,24 @@ def test_optional_load_returns_none_for_missing_module() -> None:
     assert _optional._load("probatio_no_such_backend") is None
 
 
+def test_optional_load_reraises_a_broken_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installed-but-broken backend re-raises instead of being masked as absent.
+
+    A ModuleNotFoundError naming a different module (a dependency the backend imports)
+    is a real install problem, not the backend being absent, so it must propagate.
+    """
+
+    def boom(_name: str) -> object:
+        message = "No module named 'innards'"
+        raise ModuleNotFoundError(message, name="innards")
+
+    monkeypatch.setattr(_optional, "import_module", boom)
+    with pytest.raises(ModuleNotFoundError, match="innards"):
+        _optional._load("orjson")
+
+
 def test_load_json_uses_orjson_when_present() -> None:
     """With orjson installed (the test env has it), JSON parses through it."""
     assert load_json('{"a": 1, "b": [2, 3]}') == {"a": 1, "b": [2, 3]}


### PR DESCRIPTION
## Breaking change

A previously masked failure now surfaces: if an optional backend (orjson, YAMLRocks, PyYAML, tomli-w) is installed but fails to import (a missing dependency, a broken native extension), probatio now propagates that `ModuleNotFoundError` instead of silently treating the backend as absent and falling back. A backend that is simply not installed is unaffected.

## Proposed change

`_load` caught every `ImportError` and returned `None`, so an installed-but-broken backend looked identical to one that was never installed, and probatio silently used the fallback. Catch `ModuleNotFoundError` and return `None` only when it names the requested module (the genuinely-absent case); re-raise anything else (a different `ImportError`, or a `ModuleNotFoundError` naming a dependency the backend imports) so a real install problem is visible instead of hidden behind a slow fallback.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
