### PR TITLE
Correct the E164 docstring to match its two-digit minimum

### DIFF
--- a/src/probatio/validators/formats.py
+++ b/src/probatio/validators/formats.py
@@ -154,8 +154,8 @@ class DataURI(_SafeValidator):
 class E164(_SafeValidator):
     """Require a phone number in international E.164 format.
 
-    A leading ``+``, a first digit 1 to 9, then up to 14 more digits (15 digits
-    total at most). This is a format check, not a guarantee the number is assigned
+    A leading ``+``, a first digit 1 to 9, then 1 to 14 more digits (2 to 15 digits
+    total). This is a format check, not a guarantee the number is assigned
     or dialable, which needs a phone-number database. With ``normalize`` (the
     default) common grouping characters (spaces, hyphens, dots, parentheses) are
     stripped and the compact ``+<digits>`` form is returned; ``normalize=False``

--- a/tests/validators/test_formats.py
+++ b/tests/validators/test_formats.py
@@ -104,6 +104,7 @@ def test_e164_accepts_valid_numbers() -> None:
     assert schema("+14155552671") == "+14155552671"
     assert schema("+442071838750") == "+442071838750"
     assert schema("+1 (415) 555-2671") == "+14155552671"
+    assert schema("+12") == "+12"  # the two-digit minimum (one more than "+1")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change

None. This corrects a docstring; validation behavior is unchanged.

## Proposed change

The `E164` docstring read "a first digit 1 to 9, then up to 14 more digits (15 digits total at most)", which implies a single digit is accepted. The code requires at least two digits, and the suite already rejects `"+1"` as too short. Correct the docstring to "1 to 14 more digits (2 to 15 digits total)" so it matches the implemented and tested behavior, and pin the two-digit minimum (`"+12"`) in the accepts test.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
