### PR TITLE
Reject out-of-range minutes and seconds in a colon Duration

### DIFF
--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -29,6 +29,7 @@ from probatio.validators._base import _SafeValidator
 
 # A colon duration has hours:minutes or hours:minutes:seconds.
 _DURATION_PARTS = (2, 3)
+_MAX_CLOCK_FIELD = 59  # the minute and second fields of an H:MM:SS duration
 _DURATION_MSG = "expected a duration like H:MM, H:MM:SS, or a number of seconds"
 
 # How many epoch sub-units make one second, per accepted ``Epoch`` unit.
@@ -260,6 +261,11 @@ class Duration(_SafeValidator):
             raise DurationInvalid(self.msg or _DURATION_MSG)
         hours, minutes, *rest = (int(part) for part in parts)
         seconds = rest[0] if rest else 0
+        if minutes > _MAX_CLOCK_FIELD or seconds > _MAX_CLOCK_FIELD:
+            # H:MM:SS is clock notation, so the minute and second fields are 0 to 59;
+            # reject "1:99" rather than overflowing 99 minutes through timedelta. The
+            # hour field is unbounded, since a duration can run past a single day.
+            raise DurationInvalid(self.msg or _DURATION_MSG)
         try:
             return sign * datetime.timedelta(
                 hours=hours,

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -164,6 +164,8 @@ def test_duration_from_seconds() -> None:
         ("1:30:00", datetime.timedelta(hours=1, minutes=30)),
         ("0:45", datetime.timedelta(minutes=45)),
         ("-0:30", -datetime.timedelta(minutes=30)),
+        # The hour field is a duration, not a clock, so it runs past 24.
+        ("100:30", datetime.timedelta(hours=100, minutes=30)),
     ],
 )
 def test_duration_from_colon_string(value: str, expected: datetime.timedelta) -> None:
@@ -198,7 +200,20 @@ def test_duration_numeric_string_matches_int() -> None:
     assert Schema(Duration())("90") == Schema(Duration())(90)
 
 
-@pytest.mark.parametrize("value", [True, "x:y", "nonsense", "", {"bogus": 1}, [1]])
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        "x:y",
+        "nonsense",
+        "",
+        {"bogus": 1},
+        [1],
+        "1:99",  # 99 minutes is out of the 0..59 clock range
+        "0:60",  # 60 minutes is out of range
+        "1:00:99",  # 99 seconds is out of range
+    ],
+)
 def test_duration_rejects_invalid(value: object) -> None:
     """A bool, a malformed/empty string, bad mapping keys, or a wrong type reject."""
     with pytest.raises(MultipleInvalid) as caught:


### PR DESCRIPTION
## Breaking change

A value that used to parse now rejects: a colon `Duration` with a minute or second field outside 0 to 59 (`"1:99"`, `"0:60"`, `"1:00:99"`). Previously these overflowed through `timedelta` (so `"1:99"` became 2h39m); they now raise `DurationInvalid`. The hour field is unchanged and still unbounded, so a long duration like `"100:30"` keeps working.

## Proposed change

A colon `Duration` is `H:MM` or `H:MM:SS` clock notation. The parser only checked the field count and that each field was digits, so an out-of-range minute or second silently overflowed through `timedelta` (`"1:99"` parsed as 1 hour plus 99 minutes). Reject a minute or second field outside 0 to 59, matching the documented format. The hour field stays unbounded, because a duration can legitimately run past 24 hours.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
