### PR TITLE
Polish a few inaccurate docstrings and one error message

### DIFF
--- a/src/probatio/_type_registry.py
+++ b/src/probatio/_type_registry.py
@@ -1,7 +1,7 @@
 """A registry mapping a type to a validator, for the annotation-driven builders.
 
-The structural builders (``create_dataclass_schema`` today, the ``Annotated`` and
-``TypedDict`` paths as they land) turn a field's type into a validator. For a
+The structural builders (``create_dataclass_schema`` and ``create_typeddict_schema``,
+including their ``Annotated`` field paths) turn a field's type into a validator. For a
 scalar type that arrives as a string (a ``datetime``, a ``UUID``, a ``Path``),
 the default is a strict ``isinstance`` check, which rejects the string a loader
 produced. Registering a validator for that type tells the builders to use it

--- a/src/probatio/codecs/_regex_safety.py
+++ b/src/probatio/codecs/_regex_safety.py
@@ -483,7 +483,7 @@ def _strip_group_modifier(body: str) -> str:
 
 
 def _split_top_level(body: str) -> list[str]:
-    """Split a group body on the ``|`` that sit at its own nesting level."""
+    """Split a group body on the ``|`` tokens that sit at its own nesting level."""
     parts: list[str] = []
     depth = 0
     in_class = False

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -277,8 +277,8 @@ class MultipleOf(_SafeValidator):
 class Percentage(_SafeValidator):
     """Require a percentage in 0 to 100, returning it as a ``float``.
 
-    Accepts a number or a string ending in ``%`` (the sign is stripped before
-    parsing). A bare numeric string works too.
+    Accepts a number or a string ending in ``%`` (the percent sign is stripped
+    before parsing). A bare numeric string works too.
     """
 
     def __init__(self, msg: str | None = None) -> None:

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -436,7 +436,7 @@ class Replace(_SafeValidator):
         return f"Replace({self.pattern.pattern!r}, {self.substitution!r}, msg={self.msg!r})"
 
     def __call__(self, value: typing.Any) -> typing.Any:
-        """Return the string with the pattern replaced, else raise Invalid."""
+        """Return the string with the pattern replaced, else raise MatchInvalid."""
         try:
             return self.pattern.sub(self.substitution, value)
         except TypeError as exc:

--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -138,7 +138,7 @@ class Set(_SafeValidator):
         try:
             return set(value)
         except TypeError as exc:
-            message = self.msg or f"cannot be presented as set: {exc}"
+            message = self.msg or f"cannot be converted to a set: {exc}"
             raise TypeInvalid(message) from exc
 
 


### PR DESCRIPTION
## Breaking change

None. The only runtime-visible change is one error message: `Set` now reports "cannot be converted to a set: ..." instead of "cannot be presented as set: ..." when its input has no usable iterator. No code matches on that text.

## Proposed change

Small accuracy fixes found in a review pass, no behavior change beyond one reworded error string:

- `Percentage`: the docstring said "the sign is stripped"; it strips the percent sign, so say so.
- `Replace`: the `__call__` docstring said it raises `Invalid`; it raises `MatchInvalid` (an `Invalid` subclass), so name the specific error like the sibling validators do.
- `_type_registry`: the module docstring still described the `TypedDict` path as not yet landed; it lists both `create_dataclass_schema` and `create_typeddict_schema` now.
- `_split_top_level`: a small grammar slip ("the `|` that sit" to "the `|` tokens that sit").
- `Set`: the `TypeError` message reads "cannot be converted to a set" rather than the ungrammatical "presented as set".

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
