### PR TITLE
Polish the docs: fix stale and contradictory claims, soften drift-prone counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ except Invalid as err:
 It is a config-loading library, so the real question is whether you would feed it
 untrusted input. The evidence, not the adjectives:
 
-- **voluptuous 0.16.0 test suite:** 140 pass, 27 deliberate and documented
-  deviations. voluptuous's own authors' notion of the contract, run against
-  Probatio.
-- **Home Assistant `config_validation`:** 142 of 142 pass, with voluptuous
+- **voluptuous 0.16.0 test suite:** runs against Probatio, with every divergence
+  a deliberate, documented deviation. voluptuous's own authors' notion of the
+  contract, checked.
+- **Home Assistant `config_validation`:** the full suite passes, with voluptuous
   swapped out for Probatio.
 - **100% line and branch coverage**, type-checked under both mypy and ty, in CI.
 - **Fuzzed on every untrusted-input surface.** The first fuzzing pass found
@@ -124,7 +124,7 @@ migration guide, and the API reference.
 
 ## Changelog & Releases
 
-This repository keeps a change log using [GitHub's releases][releases]
+This repository keeps a changelog using [GitHub's releases][releases]
 functionality. The format of the log is based on
 [Keep a Changelog][keepchangelog]. There is intentionally no `CHANGELOG.md` file:
 the GitHub Releases are the changelog.
@@ -134,8 +134,8 @@ of `MAJOR.MINOR.PATCH`. In a nutshell, the version will be incremented
 based on the following:
 
 - `MAJOR`: Incompatible or major changes.
-- `MINOR`: Backwards-compatible new features and enhancements.
-- `PATCH`: Backwards-compatible bugfixes and package updates.
+- `MINOR`: Backward-compatible new features and enhancements.
+- `PATCH`: Backward-compatible bugfixes and package updates.
 
 ## Contributing
 
@@ -150,7 +150,7 @@ Before you start, read the [contributing guide][contributing], the
 [code of conduct][code-of-conduct], and the [security policy][security]. Bugs and
 feature requests go to the [issue tracker][issues].
 
-Thank you for being involved! :heart_eyes:
+Thank you for being involved.
 
 ## Credits and inspiration
 
@@ -168,7 +168,7 @@ json_schema. Probatio stands on that same lineage.
 The original setup of this repository is by [Franck Nijhof][frenck].
 
 For a full list of all authors and contributors,
-check [the contributor's page][contributors].
+check [the contributors page][contributors].
 
 ## License
 

--- a/adr/003-astro-starlight-for-documentation.md
+++ b/adr/003-astro-starlight-for-documentation.md
@@ -17,8 +17,8 @@ beginner-friendly docs site.
 
 **Rationale**:
 
-- Modern, fast, beautiful out of the box.
-- Great search, navigation, dark mode.
+- Modern defaults and fast builds, with no theme to assemble first.
+- Built-in search, navigation, and dark mode.
 - MDX support for interactive examples.
 - Easy to maintain alongside the code.
 - Used by many popular open source projects.

--- a/adr/004-single-validation-engine.md
+++ b/adr/004-single-validation-engine.md
@@ -39,9 +39,11 @@ stays, since it is a small, contract-based optimization, not a second engine. If
 a future, measured workload genuinely needs more speed, a native core is the
 path to revisit, not regenerated Python source.
 
-**Revisited by ADR-011.** This decision is the default and still stands: the
-single interpreted engine is what every schema uses unless asked otherwise.
-ADR-011 reopens the codegen question with a different design (an opt-in, off by
-default, bail-safe compiled variant whose errors and unsupported shapes always
-fall back to this engine), and weighs it honestly against the four objections
-above rather than overturning them.
+**Revisited by ADR-011.** The substance of this decision still stands: the
+interpreted engine remains the only validation semantics and the always-present
+fallback. ADR-011 reopens the codegen question with a different design, an
+adaptive, bail-safe compiled variant whose default policy is `AUTO`: a schema runs
+interpreted and compiles itself only once it proves hot, and every error and
+unsupported shape falls back to this engine. So a cold or one-shot schema still
+uses the interpreted engine, while a hot schema accelerates itself. ADR-011 weighs
+that honestly against the four objections above rather than overturning them.

--- a/adr/011-opt-in-compiled-schema.md
+++ b/adr/011-opt-in-compiled-schema.md
@@ -68,9 +68,9 @@ measured, plus the inlining of the common validators.
    already comfortable, and the workload validates at config load.
 2. An adaptive, bail-safe compiled variant, default `AUTO`, with the interpreted
    engine as the always-present semantics and fallback (this ADR).
-3. mypyc (ADR-010) or a native core: accelerate the existing engine instead of
-   generating code. Higher ceilings or a recompile, but neither helps the
-   construction step and mypyc is only ~1.3x.
+3. mypyc or a native core: accelerate the existing engine instead of generating
+   code. Higher ceilings or a recompile, but neither helps the construction step
+   and mypyc is only ~1.3x.
 
 **Decision**: Option 2, with `AUTO` as the default. ADR-004's substance, that there
 is one set of validation semantics, stands unchanged: the interpreted engine remains

--- a/adr/012-trusted-construction-without-validation.md
+++ b/adr/012-trusted-construction-without-validation.md
@@ -25,7 +25,7 @@ for that one dataclass and stays pure Python.
    One less feature, but the schema you already wrote cannot be reused for the fast
    path, and probatio leaves an easy, real win on the table.
 2. A construction-time flag that makes a whole schema skip validation. Rejected: a
-   schema that silently never validates is a footgun waiting at every call site, and
+   schema that silently never validates is a hazard waiting at every call site, and
    it muddies what a `DataclassSchema` _is_.
 3. An opt-in, per-call `construct` method, validation untouched as the default (this
    ADR).
@@ -50,7 +50,7 @@ where validation is genuinely not needed, not a repositioning as a deserializer.
   nesting are already modelled. A trusted constructor is a second, cheaper reading of
   the same model, not a parallel definition.
 - **The default is unchanged and safe.** Validation is still what a call does. The
-  trust is opt-in, per call, and named loudly. The footgun of option 2 (a schema that
+  trust is opt-in, per call, and named loudly. The hazard of option 2 (a schema that
   never validates) does not exist here.
 - **It is honestly fast.** Because it generates a flat constructor per dataclass, it
   beats the dedicated deserializers on the trust path while remaining pure Python,

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Probatio
-description: A drop-in voluptuous replacement, proven against its own test suite and pushed forward for today.
+description: A drop-in voluptuous replacement, proven against voluptuous's test suite and pushed forward for today.
 hero:
   title: Probatio
   tagline: Put your data to the proof.
@@ -42,13 +42,14 @@ change before 1.0 while the project gathers production feedback.
   <Card title="Drop-in compatible" icon="approve-check">
     The public API mirrors voluptuous: `Schema`, `Required`, `Optional`, `All`,
     `Any`, `Coerce`, `Invalid`, and the rest. Change the import, keep your
-    schemas. voluptuous's own 0.16.0 test suite runs green against it.
+    schemas. voluptuous's own 0.16.0 test suite runs against it, and every
+    divergence is a deliberate, documented deviation.
   </Card>
   <Card title="More than a replacement" icon="rocket">
     It also clears voluptuous's backlog: cross-field rules, dataclass and
     TypedDict schemas, network and format validators, and errors that carry a
     path and suggest the key you meant. Several are voluptuous's own open
-    requests, finally shipped.
+    requests, now implemented.
   </Card>
   <Card title="Proven, not promised" icon="open-book">
     100% line and branch coverage, two type checkers, and continuous fuzzing on
@@ -99,10 +100,10 @@ except Invalid as err:
 It is a config-loading library, so the bar is whether you would hand it untrusted
 input. The evidence, not the adjectives:
 
-- **voluptuous 0.16.0 test suite:** 140 pass, 27 deliberate and documented
-  deviations. voluptuous's own authors' notion of the contract, run against
-  Probatio.
-- **Home Assistant `config_validation`:** 142 of 142 pass, with voluptuous
+- **voluptuous 0.16.0 test suite:** runs against Probatio, with every divergence
+  a deliberate, documented deviation. voluptuous's own authors' notion of the
+  contract, checked.
+- **Home Assistant `config_validation`:** the full suite passes, with voluptuous
   swapped out for Probatio.
 - **100% line and branch coverage**, type-checked under both mypy and ty, in CI.
 - **Fuzzed on every untrusted-input surface.** The first fuzzing pass found

--- a/docs/src/content/docs/project/about.md
+++ b/docs/src/content/docs/project/about.md
@@ -28,12 +28,12 @@ never get supported.
 Reaching for validation in Python tends to mean one of a few trades:
 
 - **voluptuous** is the lightweight, schema-is-data choice that Home Assistant
-  and many others standardized on. The model is a pleasure to use, but the
-  project has seen little movement for years, and several rough edges (a
+  and many others standardized on. The model is compact and easy to compose, but
+  the project has seen little movement for years, and several rough edges (a
   `RecursionError` on deep data, a leaked `TypeError` from a built-in validator,
   errors reported twice) sit unfixed.
 - **mashumaro** is a fast, dataclass-first take focused on serialization and
-  deserialization. It is genuinely first-rate at what it does, and several ideas
+  deserialization. It is excellent at what it does, and several ideas
   in Probatio are borrowed from it with credit (see the architecture decision
   records). It is a codec library more than a free-form validator, though, so the
   schema-is-data model is not the problem it set out to solve.
@@ -64,8 +64,8 @@ It is held to a high bar for code and prose, because it is public and read
 closely.
 
 The compatibility is measured, not asserted: Home Assistant's own
-`config_validation` test suite runs against Probatio (142 of 142 passing), and so
-does voluptuous's own 0.16.0 test suite, with every divergence documented. The
+`config_validation` test suite runs against Probatio (the full suite passing), and
+so does voluptuous's own 0.16.0 test suite, with every divergence documented. The
 [voluptuous compatibility](/reference/compatibility-matrix/) reference lists those
 documented deviations name by name.
 

--- a/docs/src/content/docs/project/projects.md
+++ b/docs/src/content/docs/project/projects.md
@@ -23,8 +23,9 @@ for its design.
 
 Home Assistant validates every integration's configuration with voluptuous, on a
 hot path hit by millions of installations at startup and on every reload.
-Probatio matches that behavior exactly, its compatibility is pinned against Home
-Assistant's own `config_validation` test suite (142 of 142 passing), and it adds
+Probatio tracks that behavior closely (with documented deviations), its
+compatibility is pinned against Home Assistant's own `config_validation` test
+suite (the full suite passing), and it adds
 a cleaner error model with paths, no interpreter-level `RecursionError` on deep
 configuration, and "did you mean ...?" suggestions for misspelled keys. See the
 [Home Assistant recipe](/recipes/home-assistant/).

--- a/docs/src/content/docs/recipes/home-assistant.md
+++ b/docs/src/content/docs/recipes/home-assistant.md
@@ -60,7 +60,7 @@ registers and when to call it.
 
 This is not a paraphrase of compatibility. Probatio is validated against Home
 Assistant's own `config_validation` test suite, with voluptuous swapped out for
-Probatio through `install_as_voluptuous`. All 142 tests in that suite pass.
+Probatio through `install_as_voluptuous`. The whole suite passes.
 
 Getting there surfaced real compatibility gaps that isolated unit tests had
 missed, like `Remove(key)` keeping a value that fails its schema, and the exact

--- a/docs/src/content/docs/reference/performance.md
+++ b/docs/src/content/docs/reference/performance.md
@@ -8,8 +8,8 @@ Probatio is pure Python with no native extension. That is a deliberate choice
 and [ADR-011](https://github.com/frenck/probatio/blob/main/adr/011-opt-in-compiled-schema.md)):
 the drop-in promise and easy installation matter more than a native core. Even so,
 the interpreted engine is well ahead of voluptuous, and a hot schema compiles itself
-into a specialized validator for more. This page explains the cost model and how to
-measure it, with honest numbers.
+into a specialized validator for more speed. This page explains the cost model and
+how to measure it, with honest numbers.
 
 ## The cost model: build once, call cheap
 


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

A review pass over the prose and ADRs, focused on correctness and on claims that drift.

Correctness:

- Drop the dangling `ADR-010` reference in ADR-011 (no ADR-010 exists; the directory goes 009 to 011).
- Reconcile the landing-page "voluptuous's own 0.16.0 test suite runs green" with the documented intentional deviations listed just below it.
- Point the ambiguous "proven against its own test suite" at voluptuous's suite.
- Finish the cut-off sentence on the performance page ("a specialized validator for more" to "for more speed").
- Rewrite ADR-004's "Revisited by ADR-011" note, which still described ADR-011's superseded off-by-default draft instead of the accepted AUTO default.

Drift-prone counts softened to durable wording:

- The voluptuous-suite "140 pass, 27 deviations" and the Home Assistant "142 of 142" / "All 142" counts across the index, README, about, projects, and the recipe become "every divergence is a documented deviation" and "the full suite passes". The CI-enforced "100% line and branch coverage" claim and the Python version list are kept, since neither can silently drift.

Tone:

- ADR-003 "beautiful out of the box" made concrete; ADR-012 "footgun" to "hazard"; README emoji, "change log/changelog", "Backwards/Backward", "contributor's page"; about.md "pleasure to use" and "genuinely first-rate" made concrete; projects.md "matches that behavior exactly" softened to "tracks closely, with documented deviations".

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
