### PR TITLE
Hold marshmallow on the 3.x line in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,12 @@
       "matchPackageNames": ["gcr.io/oss-fuzz-base/base-builder-python"],
       "addLabels": ["maintenance"],
       "schedule": ["before 3am on the first day of the month"]
+    },
+    {
+      "description": "marshmallow is a benchmark-only comparison dependency, capped at <4.0.0 by dataclasses-json (also benchmark-only in the bench-world group), whose latest release has no marshmallow 4 support. A marshmallow 4 bump is unsatisfiable and cannot lock, so hold it on the 3.x line until dataclasses-json supports 4 or is dropped from the benchmark.",
+      "matchManagers": ["pep621"],
+      "matchDepNames": ["marshmallow"],
+      "allowedVersions": "<4.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Breaking change

None. CI and tooling only.

## Proposed change

`marshmallow` is a benchmark-only comparison dependency in the `bench-world` group. `dataclasses-json` (also benchmark-only, same group) caps `marshmallow<4.0.0`, and its latest release (0.6.7, 2023) has no marshmallow 4 support, so a marshmallow 4 bump is unsatisfiable: `uv` cannot resolve it and Renovate cannot regenerate `uv.lock`, which leaves a stale lockfile that fails every `uv sync --locked` job (see #72).

Add a Renovate `packageRule` capping `marshmallow<4.0.0`, with a description recording why, so Renovate stops proposing the v4 bump until `dataclasses-json` supports marshmallow 4 or is dropped from the benchmark group.

Closes the loop on #72, which cannot be made green as-is.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #72
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
