### PR TITLE
Rebuild a namedtuple positionally in ExactSequence

### DIFF
--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -72,7 +72,13 @@ class ExactSequence(_SafeValidator):
                     errors.append(error)
         if errors:
             raise MultipleInvalid(errors)
-        return type(value)(result)
+        # Rebuild the sequence as its own type. A namedtuple takes its fields
+        # positionally (``Point(*result)``), not as a single iterable, so detect it
+        # the way the sequence engine does rather than leak a TypeError.
+        out_type = type(value)
+        if issubclass(out_type, tuple) and hasattr(out_type, "_fields"):
+            return out_type(*result)
+        return out_type(result)
 
 
 class Unique(_SafeValidator):

--- a/tests/validators/test_structural.py
+++ b/tests/validators/test_structural.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import namedtuple
+
 import pytest
 
 from probatio import (
@@ -36,6 +38,18 @@ def test_exact_sequence_keeps_the_type() -> None:
     result = Schema(ExactSequence([int, int]))((1, 2))
     assert result == (1, 2)
     assert isinstance(result, tuple)
+
+
+def test_exact_sequence_rebuilds_a_namedtuple() -> None:
+    """A namedtuple is rebuilt with positional fields, not leaked as a TypeError.
+
+    ``Point(result)`` would pass the list as a single field; a namedtuple needs its
+    fields spread positionally.
+    """
+    point = namedtuple("Point", "x y")  # noqa: PYI024 - a runtime namedtuple fixture
+    result = Schema(ExactSequence([int, int]))(point(1, 2))
+    assert result == point(1, 2)
+    assert isinstance(result, point)
 
 
 def test_exact_sequence_item_error_has_index() -> None:


### PR DESCRIPTION
## Breaking change

None. This fixes a `TypeError` leak; previously `ExactSequence` raised it on a namedtuple input.

## Proposed change

`ExactSequence` rebuilt the validated sequence with `type(value)(result)`. That passes the result list to the constructor as a single iterable, which works for `list` and a plain `tuple` but leaks a `TypeError` for a namedtuple, which takes its fields positionally. Detect a namedtuple (a `tuple` subclass with `_fields`) and spread the result with `out_type(*result)`, exactly the way `_SequenceValidator` already rebuilds sequences.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
