### PR TITLE
Reject a non-CompilePolicy in set_compile_policy

### DIFF
--- a/src/probatio/_compile_policy.py
+++ b/src/probatio/_compile_policy.py
@@ -46,8 +46,13 @@ def set_compile_policy(policy: CompilePolicy) -> None:
     """Set the process-wide compile policy.
 
     Call it once, early, from deliberate startup code. A per-schema ``compile``
-    flag still overrides it in either direction.
+    flag still overrides it in either direction. Raises ``TypeError`` for anything
+    that is not a ``CompilePolicy``, so a stray string like ``"off"`` fails loudly
+    rather than being stored and silently breaking every later compile decision.
     """
+    if not isinstance(policy, CompilePolicy):
+        message = f"compile policy must be a CompilePolicy, got {type(policy).__name__}"
+        raise TypeError(message)
     global _policy  # noqa: PLW0603 - a single deliberate process-wide setting
     _policy = policy
 

--- a/tests/test_compile_policy.py
+++ b/tests/test_compile_policy.py
@@ -44,6 +44,13 @@ def test_default_policy_is_auto() -> None:
     assert Schema({"a": int}, compile=False)._should_compile() is False
 
 
+def test_set_compile_policy_rejects_a_non_policy() -> None:
+    """A stray value (a string like "off") is refused, not stored and silently wrong."""
+    with pytest.raises(TypeError, match="CompilePolicy"):
+        set_compile_policy("off")  # type: ignore[arg-type]
+    assert isinstance(get_compile_policy(), CompilePolicy)  # unchanged, still valid
+
+
 def test_policy_on_compiles_an_unset_schema() -> None:
     """Under the ON policy a schema with no flag opts in."""
     set_compile_policy(CompilePolicy.ON)


### PR DESCRIPTION
## Breaking change

None for correct use. `set_compile_policy` with a non-`CompilePolicy` argument (which never worked correctly) now raises `TypeError` instead of silently storing the bad value.

## Proposed change

`set_compile_policy` stored its argument without checking it, so `set_compile_policy("off")` left the process-wide policy as the string `"off"`. That string is truthy and never equals a `CompilePolicy` member, so every later compile decision read a nonsense value with no error. Guard the input with an `isinstance(policy, CompilePolicy)` check and raise a clear `TypeError`, so a stray value fails loudly at the call site.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
