### PR TITLE
Reject NaN and Infinity in load_json regardless of backend

### DIFF
--- a/src/probatio/serde/loaders.py
+++ b/src/probatio/serde/loaders.py
@@ -75,6 +75,12 @@ def _forward_options(
         raise
 
 
+def _reject_json_constant(token: str) -> Any:
+    """Refuse the non-standard JSON constants NaN/Infinity/-Infinity."""
+    message = f"{token} is not valid JSON"
+    raise ValueError(message)
+
+
 def load_json(source: Any, *, options: dict[str, Any] | None = None) -> Any:
     """Parse JSON from a string, bytes, path, or file-like object.
 
@@ -86,11 +92,17 @@ def load_json(source: Any, *, options: dict[str, Any] | None = None) -> Any:
     if opts:
         # orjson.loads accepts no options at all, so any load option (parse_float,
         # object_hook, and the like) is a standard-library one; honor it there,
-        # whether or not orjson is installed, instead of leaking a TypeError.
-        return json.loads(data, **opts)
+        # whether or not orjson is installed, instead of leaking a TypeError. Default
+        # to rejecting NaN/Infinity (the caller can override parse_constant) so the
+        # result does not depend on which backend is installed.
+        merged: dict[str, Any] = {"parse_constant": _reject_json_constant, **opts}
+        return json.loads(data, **merged)
     if _optional.orjson is not None:
         return _optional.orjson.loads(data)
-    return json.loads(data)
+    # The standard library accepts the JavaScript constants NaN/Infinity/-Infinity by
+    # default, where orjson (strict RFC 8259) rejects them. Reject them here too so
+    # hostile non-standard JSON behaves the same with or without orjson installed.
+    return json.loads(data, parse_constant=_reject_json_constant)
 
 
 def load_yaml(source: Any, *, options: dict[str, Any] | None = None) -> Any:

--- a/tests/serde/test_loaders.py
+++ b/tests/serde/test_loaders.py
@@ -61,6 +61,35 @@ def test_load_json_falls_back_to_stdlib(monkeypatch: pytest.MonkeyPatch) -> None
     assert load_json('{"a": 1}') == {"a": 1}
 
 
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.parametrize("with_orjson", [True, False])
+def test_load_json_rejects_non_standard_constants(
+    token: str,
+    *,
+    with_orjson: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NaN/Infinity are rejected the same way with or without orjson.
+
+    The standard library accepts these JavaScript constants by default while orjson
+    rejects them, which would otherwise make hostile non-standard JSON backend-
+    dependent. Both paths now refuse them.
+    """
+    if not with_orjson:
+        monkeypatch.setattr(_optional, "orjson", None)
+    with pytest.raises(ValueError):  # noqa: PT011 - both backends raise ValueError subtypes
+        load_json(token)
+
+
+def test_load_json_caller_can_opt_into_non_standard_constants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-supplied parse_constant overrides the default rejection."""
+    monkeypatch.setattr(_optional, "orjson", None)
+    result = load_json("NaN", options={"parse_constant": lambda token: token})
+    assert result == "NaN"
+
+
 def test_load_yaml_with_yamlrocks() -> None:
     """With YAMLRocks installed, it parses YAML."""
     assert load_yaml("a: 1\nb: two\n") == {"a": 1, "b": "two"}


### PR DESCRIPTION
## Breaking change

`load_json` now rejects the non-standard JSON constants `NaN`, `Infinity`, and `-Infinity` on the standard-library path, where it previously parsed them into floats when orjson was not installed. With orjson installed the behavior is unchanged (it already rejected them). A caller who wants the old behavior can pass `options={"parse_constant": ...}`.

## Proposed change

The standard library's `json` accepts the JavaScript constants `NaN`/`Infinity`/`-Infinity` by default, while orjson (strict RFC 8259) rejects them. So `load_json` on hostile non-standard JSON returned a float when orjson was absent but raised when it was present, making the result depend on which backend happened to be installed. Default the standard-library path to a `parse_constant` that rejects those tokens, so both backends behave the same. The caller can still opt back in by supplying their own `parse_constant`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
