### PR TITLE
Harden JSON Schema decode against malformed required and item-count keywords

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -849,14 +849,14 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     if not isinstance(required_raw, list):
         message = f"JSON Schema 'required' must be an array, got {type(required_raw).__name__}"
         raise SchemaError(message)
-    # ``required`` entries are property names (strings). A nested array or object
-    # is valid JSON but unhashable, so build the set defensively rather than leak
-    # a TypeError from an untrusted document.
-    try:
-        required: set[Any] = set(required_raw)
-    except TypeError as exc:
-        message = "JSON Schema 'required' must contain only property names"
-        raise SchemaError(message) from exc
+    # ``required`` entries are property names, so every entry must be a string. A
+    # non-string entry (a number, or an unhashable nested array or object) never
+    # matches a property name, so it would silently make a required field optional;
+    # refuse it rather than honor a malformed document.
+    if not all(isinstance(entry, str) for entry in required_raw):
+        message = "JSON Schema 'required' must contain only property names (strings)"
+        raise SchemaError(message)
+    required: set[Any] = set(required_raw)
     mapping: dict[Any, Any] = {}
     for name, subschema in properties.items():
         if subschema is False:
@@ -1028,16 +1028,18 @@ class _ContainsCount:
 
 
 def _item_count(node: dict[str, Any], key: str) -> int | None:
-    """Read an integer item-count bound (``minItems``/``maxItems``), or None.
+    """Read a non-negative integer item-count bound (``minItems``/``maxItems``), or None.
 
-    A non-integer bound would otherwise leak a TypeError from the ``Length`` check
-    at validation time, so it is refused at decode with a clean ``SchemaError``.
+    A non-integer or negative bound would otherwise leak a TypeError from the
+    ``Length`` check or silently validate data under a malformed count, so it is
+    refused at decode with a clean ``SchemaError``. The JSON Schema count keywords
+    are non-negative integers.
     """
     value = node.get(key)
     if value is None:
         return None
-    if not isinstance(value, int) or isinstance(value, bool):
-        message = f"JSON Schema {key!r} must be an integer, got {type(value).__name__}"
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        message = f"JSON Schema {key!r} must be a non-negative integer, got {value!r}"
         raise SchemaError(message)
     return value
 

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -357,6 +357,29 @@ def test_non_list_required_is_a_clean_schema_error() -> None:
         from_json_schema({"type": "object", "required": "name"})
 
 
+@pytest.mark.parametrize("entry", [1, ["a"], {"a": 1}])
+def test_non_string_required_entry_is_a_clean_schema_error(entry: object) -> None:
+    """A non-string 'required' entry is refused, not silently ignored.
+
+    A number or nested value never matches a property name, so honoring it would
+    quietly turn a required field into an optional one.
+    """
+    node = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "required": [entry],
+    }
+    with pytest.raises(SchemaError, match="required"):
+        from_json_schema(node)
+
+
+@pytest.mark.parametrize("key", ["minItems", "maxItems"])
+def test_negative_item_count_is_a_clean_schema_error(key: str) -> None:
+    """A negative item-count keyword is refused; the JSON Schema counts are >= 0."""
+    with pytest.raises(SchemaError, match=key):
+        from_json_schema({"type": "array", key: -1})
+
+
 def test_non_string_type_array_entry_is_a_clean_schema_error() -> None:
     """A non-string entry in a 'type' array is refused rather than widening.
 


### PR DESCRIPTION
## Breaking change

A malformed JSON Schema that previously decoded (and then validated data incorrectly) now raises a `SchemaError` at decode time: a `required` array with a non-string entry, or a negative `minItems`/`maxItems`. Well-formed schemas are unaffected.

## Proposed change

Two fail-open holes in `from_json_schema` on a malformed document:

- A non-string `required` entry (a number, or a nested array/object) never matches a property name, so it was silently ignored and the real required field decoded as optional. Require every `required` entry to be a string. This also subsumes the previous unhashable-entry guard.
- A negative `minItems`/`maxItems` was accepted and used to validate data, even though the JSON Schema count keywords are non-negative integers. Reject a negative bound.

Both now raise a clean `SchemaError` at decode rather than honoring the malformed document. (A typeless `minimum` applied to a string is a separate, more entangled question with the bare-`Range` round-trip and is left for a follow-up.)

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
