### PR TITLE
Redact a failed Secret value in humanized errors

### DIFF
--- a/docs/src/content/docs/project/security.md
+++ b/docs/src/content/docs/project/security.md
@@ -179,9 +179,12 @@ str(result)                            # "{'api_token': SecretValue('**********'
 result["api_token"].get_secret_value() # 's3cr3t'
 ```
 
-One boundary to know: this protects the validated value, not `humanize_error`
-called against the raw, pre-validation input. When secrets are involved, humanize
-the validated output, not the original data.
+`humanize_error` redacts a failed `Secret` too: a rejected credential renders as
+`<redacted>`, not the raw value, so the direct case is covered. One boundary
+remains, because `humanize_error` reads the raw, pre-validation data: a secret in
+one field could still surface if a broader error renders a whole container that
+holds it. For full safety with secrets, humanize the validated output, where every
+`SecretValue` masks itself, rather than the original data.
 
 ## Reporting a vulnerability
 

--- a/src/probatio/humanize.py
+++ b/src/probatio/humanize.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from probatio.error import Error, Invalid, MultipleInvalid
+from probatio.error import Error, Invalid, MultipleInvalid, SecretInvalid
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
     from probatio.schema import Schema
 
 MAX_VALIDATION_ERROR_ITEM_LENGTH = 500
+
+# Shown in place of the offending value for a ``Secret`` failure, so the raw
+# (pre-validation) secret never reaches an error message or a log.
+_REDACTED = "<redacted>"
 
 
 def _nested_getitem(data: Any, path: list[Any]) -> Any:
@@ -52,9 +56,15 @@ def humanize_error(
                 for sub_error in validation_error.errors
             ),
         )
-    offending = repr(_nested_getitem(data, validation_error.path))
-    if len(offending) > max_sub_error_length:
-        offending = offending[: max_sub_error_length - 3] + "..."
+    if isinstance(validation_error, SecretInvalid):
+        # The value at this path is a secret that failed validation, and it is still
+        # the raw, unwrapped value in ``data`` (the SecretValue wrapper only exists
+        # on success). Reading and rendering it would leak the credential, so redact.
+        offending = _REDACTED
+    else:
+        offending = repr(_nested_getitem(data, validation_error.path))
+        if len(offending) > max_sub_error_length:
+            offending = offending[: max_sub_error_length - 3] + "..."
     message = f"{validation_error}. Got {offending}"
     if locator is not None:
         location = locator(validation_error.path)

--- a/tests/test_humanize.py
+++ b/tests/test_humanize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from probatio import Error, Required, Schema
+from probatio import Error, Required, Schema, Secret
 from probatio.humanize import (
     MAX_VALIDATION_ERROR_ITEM_LENGTH,
     humanize_error,
@@ -44,6 +44,23 @@ def test_humanize_multiple_errors_joined() -> None:
         schema({"a": "x", "b": "y"})
     message = humanize_error({"a": "x", "b": "y"}, caught.value)
     assert len(message.splitlines()) == 2
+
+
+def test_humanize_redacts_a_failed_secret_value() -> None:
+    """A Secret that fails validation is redacted, never echoed into the message.
+
+    The raw value is still the unwrapped secret in the data on a failure (the mask
+    only wraps a successful result), so rendering it would leak the credential.
+    """
+    schema = Schema({Required("password"): Secret(int), Required("user"): str})
+    data = {"password": "hunter2-secret", "user": 123}
+    with pytest.raises(Exception) as caught:  # noqa: PT011
+        schema(data)
+    message = humanize_error(data, caught.value)
+    assert "hunter2-secret" not in message
+    assert "<redacted>" in message
+    # A non-secret field's value is still shown, redaction is targeted.
+    assert "Got 123" in message
 
 
 def test_humanize_truncates_long_values() -> None:


### PR DESCRIPTION
## Breaking change

None. A failed `Secret` value now renders as `<redacted>` in `humanize_error` instead of its raw `repr`. Every non-secret value is unchanged.

## Proposed change

`humanize_error` re-read the offending value from the raw `data` by path and rendered its `repr`. That bypassed `Secret`'s masking entirely: a `Secret` field that failed validation leaked its raw credential into the humanized message, and into any log line built from it. `Secret` already raises `SecretInvalid` on failure, and `Secret` is the only validator that sits at a Secret path, so the humanizer now redacts the value for a `SecretInvalid` error (rendering `<redacted>`) while still showing every other field's value. No schema walk is needed, the error type carries the signal.

The security documentation's warning about this is narrowed accordingly: the direct leak is closed, with the honest residual note that `humanize_error` still reads raw pre-validation data, so for full safety with secrets you should humanize the validated output (where every `SecretValue` masks itself).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
