### PR TITLE
Give a clear error when extending a Dataclass or TypedDict schema

### DIFF
--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -631,6 +631,21 @@ class DataclassSchema[DataclassT](Schema):
         )
         super().__init__(built.schema, compile=compile)
 
+    def extend(self, *_args: TypingAny, **_kwargs: TypingAny) -> Schema:
+        """Refuse to extend: a ``DataclassSchema`` is built from a type, not a mapping.
+
+        ``extend`` merges keys into a mapping schema and rebuilds the same class, but
+        a ``DataclassSchema`` is defined by its dataclass type and could not construct
+        anything coherent from the extra keys. Build a new ``DataclassSchema``, or
+        extend a plain ``Schema`` of the fields instead, rather than fail obscurely.
+        """
+        message = (
+            "extend is not supported on a DataclassSchema; it is built from a "
+            "dataclass type, not a mapping. Build a new DataclassSchema, or extend a "
+            "plain Schema of the fields."
+        )
+        raise SchemaError(message)
+
     def construct(self, data: TypingAny) -> DataclassT:
         """Build the dataclass from **trusted** ``data``, skipping validation.
 
@@ -806,6 +821,20 @@ class TypedDictSchema[TypedDictT](Schema):
         # when re-wrapping; the dataclass path gets away without it because there
         # the ``extra`` is baked into an inner Schema wrapped in ``All``.
         super().__init__(built.schema, extra=extra, compile=compile)
+
+    def extend(self, *_args: TypingAny, **_kwargs: TypingAny) -> Schema:
+        """Refuse to extend: a ``TypedDictSchema`` is built from a type, not a mapping.
+
+        ``extend`` merges keys and rebuilds the same class, but a ``TypedDictSchema``
+        is defined by its TypedDict type. Build a new ``TypedDictSchema``, or extend a
+        plain ``Schema`` of the fields instead, rather than fail obscurely.
+        """
+        message = (
+            "extend is not supported on a TypedDictSchema; it is built from a "
+            "TypedDict type, not a mapping. Build a new TypedDictSchema, or extend a "
+            "plain Schema of the fields."
+        )
+        raise SchemaError(message)
 
     def __call__(
         self, data: TypingAny, *, context: TypingAny = _INHERIT_CONTEXT

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -56,6 +56,33 @@ def test_extend_requires_a_mapping_argument() -> None:
         Schema({"a": int}).extend(int)
 
 
+def test_extend_on_a_dataclass_schema_is_a_clear_error() -> None:
+    """A DataclassSchema is built from a type, so extend refuses with a clear message."""
+    import dataclasses  # noqa: PLC0415
+
+    from probatio import DataclassSchema  # noqa: PLC0415
+
+    @dataclasses.dataclass
+    class User:
+        name: str
+
+    with pytest.raises(SchemaError, match="DataclassSchema"):
+        DataclassSchema(User).extend({"extra": int})
+
+
+def test_extend_on_a_typeddict_schema_is_a_clear_error() -> None:
+    """A TypedDictSchema is built from a type, so extend refuses with a clear message."""
+    from typing import TypedDict  # noqa: PLC0415
+
+    from probatio import TypedDictSchema  # noqa: PLC0415
+
+    class Movie(TypedDict):
+        title: str
+
+    with pytest.raises(SchemaError, match="TypedDictSchema"):
+        TypedDictSchema(Movie).extend({"extra": int})
+
+
 def test_extend_can_make_keys_required() -> None:
     """Passing required=True flips bare keys of the merged schema to required."""
     extended = Schema({"a": int}).extend({"b": int}, required=True)


### PR DESCRIPTION
## Breaking change

None. `extend()` on a `DataclassSchema` or `TypedDictSchema` already failed; it now fails with a clear message instead of an obscure one.

## Proposed change

`Schema.extend` rebuilds the same class with `type(self)(merged, ...)` so that extending a `Schema` subclass returns that subclass. For a `DataclassSchema` or `TypedDictSchema` that calls the constructor with a merged mapping, but those constructors take a dataclass or TypedDict type, so it failed with a confusing "X is not a dataclass" `SchemaError` from deep inside the builder. Override `extend` on both subclasses to raise a clear, actionable `SchemaError` that names the situation and the workaround (build a new typed schema, or extend a plain `Schema` of the fields). Returning a plain `Schema` was the alternative, but that would silently drop the dataclass construction, which is more surprising than a clear refusal.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
