### PR TITLE
Keep the Union required policy on a discriminant-built branch

### DIFF
--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -378,9 +378,13 @@ class Union(_Combinator):
         # A discriminant returns a subset of the raw validators; resolve each to
         # its compiled form, compiling any object it returns that was not among
         # the originals (matching voluptuous, which recompiles the chosen set).
+        # Compile a fresh object under the same required and extra policy as the
+        # originals, so a discriminant-returned mapping does not lose the Union's
+        # ``required`` intent. A fresh object is not cached: it may be short-lived,
+        # and caching it by ``id`` would risk a reused id mapping to a stale branch.
         candidates = [
             self._compiled_by_id.get(id(option))
-            or compile_schema(option, extra=self._extra)
+            or compile_schema(option, required=self.required, extra=self._extra)
             for option in self.discriminant(value, self.validators)
         ]
         # The discriminant chose a subset, so the all-branches label would not

--- a/tests/validators/test_combinators.py
+++ b/tests/validators/test_combinators.py
@@ -156,6 +156,23 @@ def test_union_with_discriminant_narrows_candidates() -> None:
         schema({"kind": "str", "value": 9})
 
 
+def test_union_discriminant_branch_keeps_the_required_policy() -> None:
+    """A fresh mapping a discriminant returns is compiled under the Union's required.
+
+    The originals are compiled with the Union's ``required`` intent; a branch the
+    discriminant builds fresh (not one of the originals) must be too, or it would
+    silently drop the policy and treat its keys as optional.
+    """
+
+    def make_branch(_value: object, _alternatives: list) -> list:
+        return [{"b": int}]  # a fresh mapping each call, never one of the originals
+
+    schema = Schema(Union({"a": int}, discriminant=make_branch, required=True))
+    assert schema({"b": 1}) == {"b": 1}
+    with pytest.raises(MultipleInvalid):
+        schema({})  # 'b' is required under required=True
+
+
 def test_required_propagates_into_a_nested_mapping() -> None:
     """Any(..., required=True) makes its nested mapping keys required."""
     with pytest.raises(MultipleInvalid) as caught:


### PR DESCRIPTION
## Breaking change

None for the common case. A `Union(..., required=True, discriminant=...)` whose discriminant returns a fresh mapping (not one of the original branches) now enforces `required` on that branch's keys, where before it silently treated them as optional.

## Proposed change

`Union` compiles its original branches with `required=self.required`. The discriminant path resolves each chosen branch through `_compiled_by_id` (the originals) or, for an object the discriminant returns that is not among the originals, recompiles it. That recompile passed `extra` but not `required`, so a fresh discriminant-built mapping silently lost the Union's `required` intent and treated its keys as optional. Thread `required` through the recompile so it matches the originals.

The fresh object is deliberately not cached: it may be short-lived, and caching it by `id` would risk a reused id mapping to a stale compiled branch. The common case (a discriminant returning a subset of the original branches) is already cached via `_compiled_by_id`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
