### PR TITLE
Preserve the decorated signature in @validate

### DIFF
--- a/src/probatio/validators/decorators.py
+++ b/src/probatio/validators/decorators.py
@@ -13,6 +13,12 @@ from probatio.schema import ALLOW_EXTRA, Schema
 
 _RETURNS_KEY = "__return__"
 
+# ``validate`` preserves the decorated function's signature for callers: the
+# wrapper transforms the arguments internally (so it cannot forward a ParamSpec
+# directly), so it is typed ``Any`` and cast to the function's own ``(**P) -> R``.
+_P = typing.ParamSpec("_P")
+_R = typing.TypeVar("_R")
+
 
 def message(
     default: str | None = None,
@@ -117,7 +123,7 @@ def _args_to_dict(
 
 def validate(
     *args: typing.Any, **kwargs: typing.Any
-) -> typing.Callable[..., typing.Any]:
+) -> typing.Callable[[typing.Callable[_P, _R]], typing.Callable[_P, _R]]:
     """Decorate a function to validate its arguments (and return) against schemas.
 
     Name a schema per argument, positionally or by keyword, and optionally a
@@ -135,8 +141,8 @@ def validate(
         returns = schema_arguments.pop(_RETURNS_KEY)
 
     def decorate(
-        func: typing.Callable[..., typing.Any],
-    ) -> typing.Callable[..., typing.Any]:
+        func: typing.Callable[_P, _R],
+    ) -> typing.Callable[_P, _R]:
         """Wrap ``func`` so its arguments and return value are validated."""
         positional = _args_to_dict(func, args)
         arguments = {**positional, **schema_arguments}
@@ -164,7 +170,7 @@ def validate(
             ]
             return output_schema(func(*leading, **validated))
 
-        return wrapper
+        return typing.cast("typing.Callable[_P, _R]", wrapper)
 
     return decorate
 


### PR DESCRIPTION
## Breaking change

None. Type annotations only, no runtime change.

## Proposed change

`validate` returned `Callable[..., Any]`, so decorating a typed function erased its parameter and return types: a caller of a `@validate`-decorated function got no argument checking and an `Any` result. Type the decorator with a `ParamSpec` and `TypeVar` so a decorated function keeps its own signature (`reveal_type` now shows `(a: int, b: str) -> int` rather than `(...) -> Any`).

The wrapper transforms the arguments internally (it validates and may coerce them), so it cannot forward a `ParamSpec` directly; it stays `Any`-typed and is `cast` to the function's `(**P) -> R`, the standard idiom for a signature-preserving decorator. Runtime behavior is unchanged.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
