### PR TITLE
Type serialize's return instead of Any

### DIFF
--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -166,7 +166,11 @@ def _allow_none(field: dict[str, Any]) -> dict[str, Any]:
     return {**field, "allow_none": True}
 
 
-def serialize(schema: Any, *, custom_serializer: Any = None) -> Any:
+# A serialized schema is a single value field, or the field list of a mapping.
+_Serialized = dict[str, Any] | list[dict[str, Any]]
+
+
+def serialize(schema: Any, *, custom_serializer: Any = None) -> _Serialized:
     """Render a schema as the field-list shape voluptuous-serialize produces.
 
     A mapping becomes a list of field dicts (``name``, ``type``, ``required``,
@@ -179,7 +183,7 @@ def serialize(schema: Any, *, custom_serializer: Any = None) -> Any:
     return _serialize_node(schema, custom_serializer)
 
 
-def _serialize_node(node: Any, custom: Any) -> Any:
+def _serialize_node(node: Any, custom: Any) -> _Serialized:
     """Render a mapping as a field list, or any other node as a value dict."""
     if isinstance(node, dict):
         # A Forbidden key is a prohibition, not an input field, so it is left out


### PR DESCRIPTION
## Breaking change

None. Type annotations only.

## Proposed change

`serialize` returned `Any`, so a consumer lost all type information on a result that is always either a single value-field dict or a mapping's field list. Type it (and the internal `_serialize_node`) as `dict[str, Any] | list[dict[str, Any]]` through a small `_Serialized` alias. The `custom_serializer` hook stays `Any`, which is right for a callback. Runtime behavior is unchanged.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
