### PR TITLE
Reject an unrecognized JSON Schema type name instead of widening

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -806,13 +806,19 @@ def _resolve_pointer(ref: str, root: dict[str, Any]) -> Any:
 
 
 def _from_typed(node: dict[str, Any], ctx: _Decode) -> Any:
-    """Dispatch on the ``type`` keyword, defaulting to an accept-anything schema."""
+    """Dispatch on the ``type`` keyword, one of the seven JSON Schema type names.
+
+    Only reached when ``type`` is present (a typeless node is handled by its
+    constraints upstream), so the keyword must be a string or an array of them.
+    """
     json_type = node.get("type")
     if isinstance(json_type, list):
         return _from_type_list(node, json_type, ctx)
 
-    # Keep malformed ``type`` values from leaking as hashing or membership errors.
-    if json_type is not None and not isinstance(json_type, str):
+    # A non-string, non-array ``type`` (including an explicit ``null``) is malformed.
+    # Reject it rather than letting it leak as a hashing or membership error, or fall
+    # through and widen to an accept-anything schema.
+    if not isinstance(json_type, str):
         message = (
             f"JSON Schema 'type' must be a string or array, "
             f"got {type(json_type).__name__}"
@@ -835,11 +841,12 @@ def _from_typed(node: dict[str, Any], ctx: _Decode) -> Any:
         base = int if json_type == "integer" else AnyValidator(int, float)
         return _from_number(node, base=base)
 
-    # An unrecognized type keyword: ignore it and honor any constraint keywords on
-    # their own, so the type does not swallow the rest of the schema. A node with
-    # no constraint accepts any value.
-    combined = _combine_constraints(node, ctx)
-    return object if combined is None else combined
+    # A non-empty ``type`` that is none of the seven JSON Schema types is malformed.
+    # The schema may be untrusted, so it fails closed here rather than ignoring the
+    # type and widening to an accept-anything ``object`` that would swallow the
+    # sibling constraint keywords and accept input the author meant to forbid.
+    message = f"JSON Schema 'type' is not a recognized type name: {json_type!r}"
+    raise SchemaError(message)
 
 
 def _from_type_list(node: dict[str, Any], types: list[Any], ctx: _Decode) -> Any:

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -840,19 +840,22 @@ def test_array_length_round_trips_as_item_count() -> None:
         schema([1])  # below the array length
 
 
-def test_unrecognized_type_accepts_anything() -> None:
-    """An unknown ``type`` value is ignored, leaving an accept-anything schema."""
-    schema = from_json_schema({"type": "nonsense"})
-    assert schema("x") == "x"
-    assert schema(5) == 5
+def test_unrecognized_type_is_rejected() -> None:
+    """An unknown ``type`` name fails closed rather than accepting anything."""
+    with pytest.raises(SchemaError, match="not a recognized type name"):
+        from_json_schema({"type": "nonsense"})
 
 
-def test_unrecognized_type_still_honors_a_constraint() -> None:
-    """An unknown ``type`` does not swallow a sibling constraint keyword."""
-    schema = from_json_schema({"type": "nonsense", "minimum": 5})
-    assert schema(7) == 7
-    with pytest.raises(Invalid):
-        schema(3)  # the sibling minimum still applies
+def test_unrecognized_type_is_rejected_even_with_a_constraint() -> None:
+    """A sibling constraint does not rescue an unknown ``type``; it still fails closed."""
+    with pytest.raises(SchemaError, match="not a recognized type name"):
+        from_json_schema({"type": "nonsense", "minimum": 5})
+
+
+def test_unrecognized_type_in_a_type_array_is_rejected() -> None:
+    """An unknown name inside a ``type`` array fails closed too (issue: fail-open widen)."""
+    with pytest.raises(SchemaError, match="not a recognized type name"):
+        from_json_schema({"type": ["integer", "nonsense"]})
 
 
 def test_object_length_round_trips_as_property_count() -> None:


### PR DESCRIPTION
## Breaking change

Decoding a JSON Schema whose `type` is not one of the seven JSON Schema types (or is an explicit `null`) now raises `SchemaError` instead of accepting any value. This is intentional fail-closed hardening for untrusted schemas, in line with the existing decoder rejections (#77). A document that relied on a bogus `type` being ignored will now be refused; fix the `type` to adapt.

## Proposed change

`from_json_schema({"type": "bogus"})` compiled to an accept-anything `object`, and `{"type": ["integer", "bogus"]}` to `Any(int, object)`, both of which accept any input. For an untrusted schema that fails open, which is the same class of issue #77 hardened.

The decoder now rejects an unrecognized `type` name (scalar, inside a `type` array, or an explicit `null`) with a clear `SchemaError`, rather than ignoring it and widening validation. A typeless node (no `type` keyword) is unchanged: it is still handled by its constraint keywords upstream.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
