### PR TITLE
Resolve a root "#" JSON pointer to the whole document

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -787,7 +787,12 @@ def _from_ref(ref: str, ctx: _Decode) -> Any:
 
 
 def _resolve_pointer(ref: str, root: dict[str, Any]) -> Any:
-    """Resolve a local JSON pointer (``#/a/b``, ``#/a/0``) against the document."""
+    """Resolve a local JSON pointer (``#``, ``#/a/b``, ``#/a/0``) against the document."""
+    if ref == "#":
+        # A bare ``#`` is the whole document, the common way a recursive schema
+        # references its own root, so there is nothing to traverse.
+        return root
+
     if not ref.startswith("#/"):
         message = f"only local JSON pointers are supported, got {ref!r}"
         raise SchemaError(message)

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -320,6 +320,28 @@ def test_recursive_ref_reports_a_nested_path() -> None:
     assert caught.value.errors[0].path == ["next", "value"]
 
 
+def test_root_ref_resolves_to_the_whole_document() -> None:
+    """A bare ``#`` references the document root, the recursive-schema idiom."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "value": {"type": "integer"},
+                "children": {"type": "array", "items": {"$ref": "#"}},
+            },
+        },
+    )
+
+    assert schema({"value": 1, "children": [{"value": 2, "children": []}]}) == {
+        "value": 1,
+        "children": [{"value": 2, "children": []}],
+    }
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"value": 1, "children": [{"value": "bad", "children": []}]})
+
+    assert caught.value.errors[0].path == ["children", 0, "value"]
+
+
 @pytest.mark.parametrize(
     ("json_format", "valid", "invalid"),
     [


### PR DESCRIPTION
## Breaking change

None. This accepts input that previously raised.

## Proposed change

A bare `{"$ref": "#"}` points at the document root, which is the common way a recursive schema references itself. The pointer resolver only accepted `#/`-prefixed pointers, so a root reference raised `SchemaError`.

`_resolve_pointer` now treats `#` as the whole document. The existing `$ref` memoization already ties the knot, so a self-referential root resolves to its own deferred validator instead of looping.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
