### PR TITLE
Emit a stable order for set-based JSON Schema output

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -180,9 +180,21 @@ def _property(marker: Marker | None, value: Any) -> dict[str, Any]:
     return prop
 
 
+def _ordered(values: Any) -> list[Any]:
+    """List a container's values, sorting a set so the emitted schema is stable.
+
+    A list or tuple keeps the author's order. A set or frozenset has none, so its
+    values are sorted by ``repr`` to keep ``to_json_schema`` output deterministic
+    across runs (stable snapshots, no spurious schema diffs, no cache misses).
+    """
+    if isinstance(values, set | frozenset):
+        return sorted(values, key=repr)
+    return list(values)
+
+
 def _convert_sequence(node: Any) -> dict[str, Any]:
     """Render a sequence/set schema as a JSON Schema array."""
-    items = [_child(element) for element in node]
+    items = [_child(element) for element in _ordered(node)]
 
     result: dict[str, Any] = {"type": "array"}
     if len(items) == 1:
@@ -273,10 +285,10 @@ def _retarget_length(merged: dict[str, Any]) -> dict[str, Any]:
 def _convert_equality(node: Any) -> dict[str, Any] | None:
     """Render the equality/membership validators as enum/const/not, or None."""
     if isinstance(node, In):
-        return {"enum": list(node.container)}
+        return {"enum": _ordered(node.container)}
 
     if isinstance(node, NotIn):
-        return {"not": {"enum": list(node.container)}}
+        return {"not": {"enum": _ordered(node.container)}}
 
     if isinstance(node, Equal):
         return {"const": node.target}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -119,8 +119,20 @@ def test_list_of_several_types() -> None:
 
 
 def test_in_becomes_enum() -> None:
-    """In exports an enum."""
-    assert to_json_schema(Schema(In(["a", "b"]))) == {"enum": ["a", "b"]}
+    """In exports an enum, keeping the author's order for an ordered container."""
+    assert to_json_schema(Schema(In(["b", "a"]))) == {"enum": ["b", "a"]}
+
+
+def test_unordered_containers_emit_a_stable_order() -> None:
+    """A set has no order, so its emitted enum/items are sorted for deterministic output."""
+    assert to_json_schema(Schema(In({"c", "a", "b"}))) == {"enum": ["a", "b", "c"]}
+    assert to_json_schema(Schema(NotIn(frozenset({3, 1, 2})))) == {
+        "not": {"enum": [1, 2, 3]},
+    }
+    # A set of element schemas renders a stable anyOf regardless of iteration order.
+    assert to_json_schema(Schema({Range(min=1), Range(min=2)}))["items"] == {
+        "anyOf": [{"minimum": 1}, {"minimum": 2}],
+    }
 
 
 def test_range_bounds() -> None:


### PR DESCRIPTION
## Breaking change

None. Output for an ordered container (a list or tuple) is unchanged; only set-based output, which was already nondeterministic, becomes stable.

## Proposed change

A `set` or `frozenset` schema, and `In`/`NotIn` over an unordered container, were emitted with `list(...)`, so the `enum` or `anyOf` order varied from run to run. That produces noisy snapshots, unstable generated schemas, and cache misses for anything keyed on the output.

A small `_ordered` helper sorts a set or frozenset by `repr` before emission; a list or tuple keeps the author's order. Applied at both sites: the array/items renderer and the `In`/`NotIn` enum renderer.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
