### PR TITLE
Narrow loader option-error detection to keyword-rejection TypeErrors

### DIFF
--- a/src/probatio/serde/loaders.py
+++ b/src/probatio/serde/loaders.py
@@ -47,6 +47,17 @@ def _read(source: Any) -> Any:
     raise TypeError(message)
 
 
+# The TypeError messages CPython raises when a call rejects a keyword argument.
+# Matching these (rather than any "argument" in the text) keeps a backend bug or a
+# data-related TypeError, which can also mention "argument", from being misreported
+# as a bad backend option.
+_BAD_OPTION_MARKERS = (
+    "unexpected keyword argument",
+    "got multiple values for keyword argument",
+    "takes no keyword arguments",
+)
+
+
 def _forward_options(
     fn: Callable[..., Any],
     *args: Any,
@@ -64,7 +75,10 @@ def _forward_options(
     try:
         return fn(*args, **options)
     except TypeError as exc:
-        if options and "argument" in str(exc):
+        rejected_option = options and any(
+            marker in str(exc) for marker in _BAD_OPTION_MARKERS
+        )
+        if rejected_option:
             keys = ", ".join(sorted(options))
             message = (
                 f"the active {what} backend ({backend}) does not accept the "

--- a/tests/serde/test_loaders.py
+++ b/tests/serde/test_loaders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -355,3 +356,20 @@ def test_load_yaml_option_rejected_by_backend_is_a_clear_error(
     monkeypatch.setattr(_optional, "yamlrocks", None)
     with pytest.raises(ValueError, match="does not accept the option"):
         load_yaml("v: 1", options={"option": 1})
+
+
+def test_load_yaml_backend_typeerror_is_not_mislabeled_as_a_bad_option(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend TypeError merely mentioning 'argument' propagates, not a bad-option error."""
+
+    def boom(_data: object, **_options: object) -> object:
+        # A data-related TypeError that happens to contain the word "argument": it
+        # accepts the option keywords, so this is not an unaccepted-option error.
+        message = "the document argument is malformed"
+        raise TypeError(message)
+
+    monkeypatch.setattr(_optional, "yamlrocks", None)
+    monkeypatch.setattr(_optional, "pyyaml", SimpleNamespace(safe_load=boom))
+    with pytest.raises(TypeError, match="document argument is malformed"):
+        load_yaml("v: 1", options={"flow": True})


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`_forward_options` wrapped any `TypeError` whose message contained "argument" as a bad backend option. A backend bug, or a data-related `TypeError` that happens to mention "argument" (for example a "missing required positional argument" or a parser's own message), was then misreported as an unaccepted option, hiding the real cause.

It now matches the specific messages CPython raises when a call rejects a keyword argument (`unexpected keyword argument`, `got multiple values for keyword argument`, `takes no keyword arguments`). Anything else propagates unchanged.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
