### PR TITLE
Preserve the validator signature through the message decorator

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -82,8 +82,11 @@ _STRING_FUNCS = frozenset({Lower, Upper, Capitalize, Title, Strip})
 
 # ``Boolean`` is a ``message`` factory, so each ``Boolean()`` is a fresh wrapper.
 # They all share ``__wrapped__`` (the undecorated function), which is the stable
-# identity to match against.
-_BOOLEAN_FUNC = Boolean.__wrapped__
+# identity to match against. ``functools.wraps`` sets ``__wrapped__`` at runtime,
+# where the factory's call type does not advertise it, so read it via ``getattr``
+# (no default: ``Boolean`` always carries it, and a None fallback could collide with
+# a node that has no ``__wrapped__`` at the identity check below).
+_BOOLEAN_FUNC = getattr(Boolean, "__wrapped__")  # noqa: B009
 
 # The deepest a decoded JSON Schema may nest. Generous for any real schema (which
 # rarely nests past a handful of levels), but low enough that even the most

--- a/src/probatio/validators/decorators.py
+++ b/src/probatio/validators/decorators.py
@@ -13,9 +13,10 @@ from probatio.schema import ALLOW_EXTRA, Schema
 
 _RETURNS_KEY = "__return__"
 
-# ``validate`` preserves the decorated function's signature for callers: the
-# wrapper transforms the arguments internally (so it cannot forward a ParamSpec
-# directly), so it is typed ``Any`` and cast to the function's own ``(**P) -> R``.
+# ``validate`` and ``message`` preserve the decorated function's signature for
+# callers: each wraps it with a ``*args, **kwargs`` forwarder (so it cannot pass a
+# ParamSpec through directly), typed ``Any`` internally and cast back to the
+# function's own ``(**P) -> R``.
 _P = typing.ParamSpec("_P")
 _R = typing.TypeVar("_R")
 
@@ -23,7 +24,10 @@ _R = typing.TypeVar("_R")
 def message(
     default: str | None = None,
     cls: type[Invalid] | None = None,
-) -> typing.Callable[..., typing.Any]:
+) -> typing.Callable[
+    [typing.Callable[_P, _R]],
+    typing.Callable[..., typing.Callable[_P, _R]],
+]:
     """Turn a function that raises ``ValueError`` into a configurable validator.
 
     The decorated function becomes a factory. Calling it returns a validator that
@@ -45,15 +49,15 @@ def message(
         raise SchemaError(problem)
 
     def decorator(
-        func: typing.Callable[..., typing.Any],
-    ) -> typing.Callable[..., typing.Any]:
+        func: typing.Callable[_P, _R],
+    ) -> typing.Callable[..., typing.Callable[_P, _R]]:
         """Wrap ``func`` as a factory producing message-carrying validators."""
 
         @wraps(func)
         def check(
             msg: str | None = None,
             clsoverride: type[Invalid] | None = None,
-        ) -> typing.Callable[..., typing.Any]:
+        ) -> typing.Callable[_P, _R]:
             """Return a validator that runs ``func`` with a fixed failure message."""
 
             @wraps(func)
@@ -66,7 +70,10 @@ def message(
                         msg or default or "invalid value"
                     ) from None
 
-            return wrapper
+            # The wrapper forwards ``*args, **kwargs`` to ``func``, so it carries the
+            # same signature; it is typed ``Any`` internally and cast back to
+            # ``func``'s own ``(**P) -> R``, the way ``validate`` does.
+            return typing.cast("typing.Callable[_P, _R]", wrapper)
 
         return check
 


### PR DESCRIPTION
## Breaking change

None. Typing only, no runtime behavior change.

## Proposed change

`message()` returned `Callable[..., Any]`, so a validator built through it (`Boolean`, and any future `@message` factory) lost its signature and return type for typed callers: `Boolean()` was `Callable[..., Any]` rather than `(value) -> bool`.

It now binds the decorated function's `ParamSpec` and return type and casts the wrapper back to them, the same pattern `validate` already uses. One consequential touch: `Boolean.__wrapped__` in the JSON Schema codec moves to `getattr`, since the now-precise factory type does not statically advertise `__wrapped__` (`functools.wraps` sets it at runtime).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
