### PR TITLE
Contain a value's raising dunders in every built-in validator

### DIFF
--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -40,14 +40,19 @@ class Coerce[T](_SafeValidator):
     def __call__(self, value: typing.Any) -> T:
         """Return ``type(value)``, or raise CoerceInvalid if it cannot.
 
-        ArithmeticError joins ValueError/TypeError so numeric conversions fail
-        cleanly: ``Coerce(int)`` on infinity (OverflowError) and ``Coerce(Decimal)``
-        on junk (decimal.InvalidOperation) raise CoerceInvalid rather than leaking,
-        keeping the safe-validator contract.
+        Calling the target is user code (``int(value)`` runs the value's
+        ``__int__``/``__index__``, a custom converter runs whatever it likes), so it
+        may raise anything: ``Coerce(int)`` on infinity (OverflowError),
+        ``Coerce(Decimal)`` on junk (decimal.InvalidOperation), a hostile dunder.
+        Any such failure becomes a CoerceInvalid rather than leaking, keeping the
+        safe-validator contract. A target that raises ``Invalid`` itself passes
+        through unchanged.
         """
         try:
             return typing.cast("T", self.type(value))
-        except (ValueError, TypeError, ArithmeticError) as exc:
+        except Invalid:
+            raise
+        except Exception as exc:
             # The suggestion match is deferred to the error, so a miss inside a
             # combinator branch that is then discarded never pays for difflib.
             raise CoerceInvalid(
@@ -96,7 +101,12 @@ def Boolean(value: typing.Any) -> bool:
             return False
         raise ValueError
 
-    return bool(value)
+    try:
+        return bool(value)
+    except Exception as exc:
+        # Surface as ValueError so the ``message`` wrapper renders it as the
+        # configured BooleanInvalid rather than letting the dunder error escape.
+        raise ValueError from exc
 
 
 class SetTo(_SafeValidator):

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -40,7 +40,7 @@ def _sorted_for_message(container: typing.Any) -> list[typing.Any]:
     """
     try:
         return sorted(container)
-    except TypeError:
+    except Exception:  # noqa: BLE001 - a member's comparison dunder may raise anything
         return list(container)
 
 
@@ -59,12 +59,13 @@ class Equal(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it equals the target, else raise Invalid.
 
-        A comparison that itself errors (a signaling ``Decimal('sNaN')`` raises on
-        ``!=``, an ArithmeticError) is reported as a mismatch, not leaked.
+        ``!=`` calls the value's ``__eq__``, which is user code and may raise
+        anything (a signaling ``Decimal('sNaN')`` raises, a hostile object can raise
+        worse). Any such failure is reported as a mismatch, never leaked.
         """
         try:
             unequal = value != self.target
-        except (TypeError, ArithmeticError):
+        except Exception:  # noqa: BLE001 - the value's __eq__ is user code; never leak
             unequal = True
 
         if unequal:
@@ -88,7 +89,7 @@ class Literal(_SafeValidator):
         """Return the literal if the value matches it, else LiteralInvalid."""
         try:
             unequal = self.lit != value
-        except (TypeError, ArithmeticError):
+        except Exception:  # noqa: BLE001 - the value's __eq__ is user code; never leak
             unequal = True
 
         if unequal:
@@ -121,11 +122,11 @@ class Contains(_SafeValidator):
         """Return the value if it contains the item, else ContainsInvalid."""
         try:
             present = self.item in value
-        except (TypeError, ArithmeticError, AttributeError) as exc:
-            # ``in`` calls the container's ``__contains__``, which can raise more
-            # than TypeError: an ``ipaddress`` network checks ``other._version``,
-            # so ``5 in ip_network(...)`` raises AttributeError. Treat any such
-            # mismatch as "not a collection that contains the item".
+        except Exception as exc:
+            # ``in`` calls the container's ``__contains__``, which is user code and
+            # may raise anything: an ``ipaddress`` network checks ``other._version``
+            # (AttributeError), a hostile object can raise worse. Treat any such
+            # failure as "not a collection that contains the item".
             message = self.msg or "value is not a collection"
             raise ContainsInvalid(message) from exc
 
@@ -164,9 +165,9 @@ class Range(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is in range, else raise RangeInvalid.
 
-        A value that cannot be compared to the bounds (a TypeError), or a
-        comparison that itself errors (a ``Decimal('NaN')`` raises
-        ``decimal.InvalidOperation``, an ArithmeticError), is reported as a
+        The bound comparisons call the value's comparison dunders, which are user
+        code and may raise anything (a ``Decimal('NaN')`` raises ``InvalidOperation``,
+        a hostile object can raise worse). Any such failure is reported as a
         RangeInvalid too, so the validator never leaks a raw exception.
         """
         try:
@@ -185,7 +186,11 @@ class Range(_SafeValidator):
                     bound = "at most" if self.max_included else "lower than"
                     message = self.msg or f"value must be {bound} {self.max}"
                     raise RangeInvalid(message)
-        except (TypeError, ArithmeticError) as exc:
+        except Invalid:
+            # An out-of-bounds RangeInvalid raised just above carries the precise
+            # message; let it through rather than redescribing it below.
+            raise
+        except Exception as exc:
             message = self.msg or "invalid value or type"
             raise RangeInvalid(message) from exc
 
@@ -217,7 +222,7 @@ class Clamp(_SafeValidator):
                 return self.min
             if self.max is not None and value > self.max:
                 return self.max
-        except (TypeError, ArithmeticError) as exc:
+        except Exception as exc:
             message = self.msg or "invalid value or type"
             raise RangeInvalid(message) from exc
 
@@ -272,9 +277,10 @@ class MultipleOf(_SafeValidator):
 
         try:
             # ``%`` with a float factor promotes a huge int to float, which can
-            # overflow (an ArithmeticError); report it cleanly, not as a leak.
+            # overflow (an ArithmeticError); an ``int`` subclass can also define a
+            # ``__mod__`` that raises. Report either cleanly, not as a leak.
             remainder = value % self.factor
-        except ArithmeticError as exc:
+        except Exception as exc:
             raise MultipleOfInvalid(message) from exc
 
         if remainder != 0:
@@ -305,10 +311,11 @@ class Percentage(_SafeValidator):
 
         raw = value[:-1] if isinstance(value, str) and value.endswith("%") else value
         try:
-            # ``float`` on an int too large to represent raises OverflowError (an
-            # ArithmeticError); report it cleanly rather than leaking it.
+            # ``float`` on an int too large to represent raises OverflowError, and on
+            # an object it calls a user-defined ``__float__`` that may raise anything;
+            # report either cleanly rather than leaking it.
             number = float(raw)
-        except (TypeError, ValueError, ArithmeticError) as exc:
+        except Exception as exc:
             message = self.msg or "expected a percentage between 0 and 100"
             raise RangeInvalid(message) from exc
 
@@ -360,12 +367,12 @@ class NonEmpty(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it has a non-zero length, else raise LengthInvalid.
 
-        A value with no length (a TypeError from ``len``) is reported as a
-        LengthInvalid too, rather than leaking the TypeError.
+        A value with no usable length (``len`` raising, including a user ``__len__``
+        that raises anything) is reported as a LengthInvalid too, never leaked.
         """
         try:
             empty = len(value) == 0
-        except TypeError as exc:
+        except Exception as exc:
             raise LengthInvalid(self.msg or "value must not be empty") from exc
 
         if empty:
@@ -395,15 +402,15 @@ class Length(_SafeValidator):
         """Return the value if its length is in bounds, else LengthInvalid.
 
         With no bound set, the length is never measured, so any value passes
-        (matching voluptuous). A value with no length (a TypeError from ``len``)
-        is reported as a LengthInvalid rather than leaking the TypeError.
+        (matching voluptuous). A value with no usable length (``len`` raising,
+        including a user ``__len__`` that raises) is a LengthInvalid, never leaked.
         """
         if self.min is None and self.max is None:
             return value
 
         try:
             length = len(value)
-        except TypeError as exc:
+        except Exception as exc:
             message = self.msg or "value has no length"
             raise LengthInvalid(message) from exc
 
@@ -481,7 +488,7 @@ class In(_SafeValidator):
 
         try:
             present = candidate in self.container if fast else self._contains(candidate)
-        except (TypeError, ArithmeticError) as exc:
+        except Exception as exc:
             message = self.msg or "value is not allowed"
             raise InInvalid(message) from exc
 
@@ -516,7 +523,7 @@ class NotIn(_SafeValidator):
         """Return the value if it is not in the container, else NotInInvalid."""
         try:
             present = value in self.container
-        except (TypeError, ArithmeticError) as exc:
+        except Exception as exc:
             message = self.msg or "value is not allowed"
             raise NotInInvalid(message) from exc
 

--- a/src/probatio/validators/network.py
+++ b/src/probatio/validators/network.py
@@ -199,7 +199,9 @@ class Port(_SafeValidator):
 
         try:
             port = int(value)
-        except (TypeError, ValueError, OverflowError) as exc:
+        except Exception as exc:
+            # ``int(float('inf'))`` raises OverflowError, and a value's ``__int__``
+            # or ``__index__`` is user code that may raise anything; reject cleanly.
             raise RangeInvalid(message) from exc
 
         if not _MIN_PORT <= port <= _MAX_PORT:

--- a/src/probatio/validators/predicates.py
+++ b/src/probatio/validators/predicates.py
@@ -49,8 +49,13 @@ class IsTrue(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is truthy, else raise TrueInvalid."""
-        if not value:
-            message = self.msg or "value was not true"
+        message = self.msg or "value was not true"
+        try:
+            truthy = bool(value)
+        except Exception as exc:
+            raise TrueInvalid(message) from exc
+
+        if not truthy:
             raise TrueInvalid(message)
         return value
 
@@ -64,8 +69,13 @@ class IsFalse(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is falsy, else raise FalseInvalid."""
-        if value:
-            message = self.msg or "value was not false"
+        message = self.msg or "value was not false"
+        try:
+            truthy = bool(value)
+        except Exception as exc:
+            raise FalseInvalid(message) from exc
+
+        if truthy:
             raise FalseInvalid(message)
         return value
 
@@ -96,8 +106,13 @@ class _FilesystemCheck(_SafeValidator):
                 raise self.error(self.empty_msg)
             if type(self).test(str(value)):
                 return value
-        except (TypeError, ValueError) as exc:
-            # ValueError covers a path with an embedded NUL byte (os.stat raises).
+        except Invalid:
+            # The empty-value error raised just above is already this validator's
+            # own error type; let it through rather than re-wrapping it.
+            raise
+        except Exception as exc:
+            # ValueError covers a path with an embedded NUL byte (os.stat raises);
+            # the value's ``__bool__``/``__str__`` are user code and may raise anything.
             raise self.error(self.empty_msg) from exc
 
         message = self.msg or self.default_msg

--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -25,14 +25,14 @@ class Sorted(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is sorted, else raise ValueInvalid.
 
-        A non-iterable, one with incomparable items (a TypeError from ``sorted``),
-        or one whose comparison itself errors (a ``Decimal('NaN')`` raises
-        ``decimal.InvalidOperation``, an ArithmeticError) is reported as a
-        ValueInvalid, not a leaked exception.
+        Iterating and comparing the items runs user code (``__iter__`` and the
+        items' comparison dunders), which may raise anything: a non-iterable, an
+        incomparable pair, a ``Decimal('NaN')``, or a hostile object. Any such
+        failure is reported as a ValueInvalid, not a leaked exception.
         """
         try:
             in_order = list(value) == sorted(value)
-        except (TypeError, ArithmeticError) as exc:
+        except Exception as exc:
             raise ValueInvalid(
                 self.msg or "value is not sorted", code="sorted"
             ) from exc
@@ -107,17 +107,17 @@ class Unique(_SafeValidator):
         """
         try:
             length = len(value)
-        except TypeError:
+        except Exception:  # noqa: BLE001 - __len__ is user code; may raise anything
             try:
                 value = list(value)
-            except TypeError as exc:
+            except Exception as exc:
                 message = self.msg or f"expected a collection: {exc}"
                 raise TypeInvalid(message) from exc
             length = len(value)
 
         try:
             unique = set(value)
-        except TypeError as exc:
+        except Exception as exc:
             message = self.msg or f"contains unhashable elements: {exc}"
             raise TypeInvalid(message) from exc
 
@@ -151,7 +151,7 @@ class Set(_SafeValidator):
         """Return ``set(value)``, or raise TypeInvalid if it cannot be built."""
         try:
             return set(value)
-        except TypeError as exc:
+        except Exception as exc:
             message = self.msg or f"cannot be converted to a set: {exc}"
             raise TypeInvalid(message) from exc
 

--- a/src/probatio/validators/transition.py
+++ b/src/probatio/validators/transition.py
@@ -31,7 +31,7 @@ def _changed(old: typing.Any, new: typing.Any) -> bool:
     """
     try:
         return bool(old != new)
-    except (TypeError, ArithmeticError):
+    except Exception:  # noqa: BLE001 - __eq__/__bool__ are user code; never leak
         return True
 
 

--- a/tests/validators/test_safe_contract.py
+++ b/tests/validators/test_safe_contract.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import contextlib
 from decimal import Decimal
-from typing import Any
+from typing import Any, NoReturn
 
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
@@ -164,6 +164,37 @@ def test_every_safe_validator_subclass_is_covered() -> None:
     )
 
 
+class _HostileDunders:
+    """A value whose validation-path dunders all raise, to enforce the contract.
+
+    Models a malicious or buggy object: comparison, membership, length, truthiness,
+    iteration, and numeric-conversion dunders each raise a non-``Invalid`` exception.
+    A built-in validator that applies one of these operators to the value must
+    contain the failure as ``Invalid``, never let it escape.
+
+    ``__str__``/``__repr__`` stay safe on purpose: a value that cannot even be
+    rendered is degenerate (no code anywhere could format it), so it is out of the
+    contract's scope, which is about validation *operations* on the value.
+    """
+
+    @staticmethod
+    def _boom(*_args: object) -> NoReturn:
+        message = "hostile dunder"
+        raise RuntimeError(message)
+
+    __eq__ = __ne__ = __lt__ = __le__ = __gt__ = __ge__ = _boom
+    __contains__ = __len__ = __bool__ = __iter__ = _boom
+    __float__ = __int__ = __index__ = __mod__ = _boom
+
+    def __hash__(self) -> int:
+        """Stay hashable (hashing the value is not the operation under test)."""
+        return 0
+
+    def __repr__(self) -> str:
+        """Render safely, so an error message about this value never raises."""
+        return "<hostile>"
+
+
 _hostile = st.sampled_from(
     [
         float("nan"),
@@ -179,6 +210,7 @@ _hostile = st.sampled_from(
         "a\x00b",
         (),
         (1, 2),
+        _HostileDunders(),
     ],
 )
 
@@ -210,3 +242,17 @@ def test_no_builtin_validator_leaks_a_non_invalid_exception(value: Any) -> None:
     for schema in _SAFE_SCHEMAS:
         with contextlib.suppress(Invalid):
             schema(value)
+
+
+def test_no_builtin_leaks_on_a_value_whose_dunders_raise() -> None:
+    """A value whose validation dunders all raise still yields only Invalid.
+
+    Deterministic counterpart to the fuzz above: it feeds the dunder-raising value
+    to every built-in so each operator-boundary guard (comparison, membership,
+    length, truthiness, iteration, numeric conversion) is exercised on every run,
+    independent of which inputs Hypothesis happens to generate.
+    """
+    hostile = _HostileDunders()
+    for schema in _SAFE_SCHEMAS:
+        with contextlib.suppress(Invalid):
+            schema(hostile)


### PR DESCRIPTION
## Breaking change

None for clean values. This is a deliberate divergence from voluptuous toward the safe-validator contract: a value whose operator dunder raises now produces the validator's `Invalid` instead of letting the raw exception escape. voluptuous lets several of these propagate.

## Proposed change

The safe-validator contract (the library's #1 invariant) says a built-in validator returns a value or raises a subclass of `Invalid`, and nothing else, on any input. Several built-ins broke it: they apply an operator to the value (`==`/`!=`, `<`/`>` comparisons, `in`, `len()`, `bool()`, `int()`/`float()`, `%`, `set()`/`sorted()`/iteration), and those operators run the value's dunders, which are user code and can raise anything. A hostile or buggy object made `Equal`, `Range`, `Contains`, `In`, `Coerce`, `Boolean`, `Port`, `Sorted`, `Unique`, the truthiness and filesystem predicates, and others leak a `RuntimeError` (or worse) past the `Invalid` boundary a caller catches.

Every such operator boundary now contains a non-`Invalid` exception and re-raises it as that validator's own `Invalid` subclass. Where a `try` also held an intentional `raise XInvalid` (`Range`, `Coerce`, the filesystem checks), an `except Invalid: raise` preserves the precise message. The guards only run on the failure path, so the success path and the hot path are untouched.

The enforcement is the keystone: `tests/validators/test_safe_contract.py` already fuzzes every built-in for this contract but never fed it a value whose dunders raise. It now does, both in the fuzz strategy and a deterministic per-validator pass, so a new validator that forgets to contain an operator fails the suite.

Scope boundary: `__str__`/`__repr__` are intentionally left out. A value that cannot be rendered at all is degenerate (no code anywhere could format it), so defending error-message rendering against a raising `__repr__` is not a meaningful boundary; the contract is about validation operations on the value.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
