### PR TITLE
Mark ADR-004 as revised by ADR-011

### DIFF
--- a/adr/004-single-validation-engine.md
+++ b/adr/004-single-validation-engine.md
@@ -1,7 +1,7 @@
 # ADR-004: A single validation engine (no codegen)
 
 **Date**: 2026-06-25
-**Status**: Accepted
+**Status**: Accepted, revised by [ADR-011](011-opt-in-compiled-schema.md)
 
 **Context**: Probatio compiles a declarative schema once into a callable, then
 runs that callable per validation (like `re.compile`). An earlier iteration


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

ADR-004 (no codegen) already carries a "Revisited by ADR-011" section, but its `Status` line still read a bare "Accepted", so a reader scanning statuses would not see that ADR-011 reopened the codegen question with the opt-in compiled variant. The status now points at ADR-011. Not "superseded": the substance of ADR-004 still holds (the interpreted engine remains the only validation semantics and the default fallback).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
