### PR TITLE
Verify README examples in the docs example runner

### DIFF
--- a/docs/verify_examples.py
+++ b/docs/verify_examples.py
@@ -46,7 +46,16 @@ import types
 from contextlib import redirect_stdout
 from pathlib import Path
 
-DOCS = Path(__file__).resolve().parent / "src" / "content" / "docs"
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs" / "src" / "content" / "docs"
+
+# READMEs outside the docs tree that carry runnable public examples. They are
+# checked here too, so a snippet in the project or a package README cannot drift
+# while the docs site stays green.
+_EXTRA_PAGES = [
+    ROOT / "README.md",
+    ROOT / "packages" / "pytest-probatio" / "README.md",
+]
 
 # Capture an optional marker on the line before the fence, then the block body.
 # The marker may be an HTML comment (Markdown) or an MDX expression comment.
@@ -82,7 +91,9 @@ def _is_instance_of(exc, name, env):
 
 
 def iter_pages():
-    for path in sorted(DOCS.rglob("*.md")) + sorted(DOCS.rglob("*.mdx")):
+    pages = sorted(DOCS.rglob("*.md")) + sorted(DOCS.rglob("*.mdx"))
+    pages += [path for path in _EXTRA_PAGES if path.exists()]
+    for path in pages:
         text = path.read_text()
 
         blocks = []
@@ -470,7 +481,7 @@ def main() -> int:
     # Each page runs its blocks sequentially in one shared namespace and one
     # shared working directory, mirroring a reader copying blocks top to bottom.
     for path, blocks in iter_pages():
-        rel = path.relative_to(DOCS)
+        rel = path.relative_to(ROOT)
         # Run the page's blocks inside a real module registered in ``sys.modules``,
         # not a bare dict, so ``get_type_hints`` can resolve a forward reference
         # (a self-referential dataclass like ``children: list[Tree]``) against the


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`docs/verify_examples.py` only scanned the docs site, so the runnable Python snippets in the project `README.md` and the `pytest-probatio` README could drift while the docs stayed green. The runner now also includes those READMEs: their blocks run and have their output comments checked like any docs example, using the same skip/`raises` markers if needed. Four extra blocks are now verified, including the migration example, which doubles as a check that both voluptuous and probatio export the named symbols.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
