### PR TITLE
Match compiled-lane skips on the test file name, not the node id

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,17 +40,28 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-# Tests excluded from the --compiled lane, by a substring of their node id. The
-# property-based and fuzz suites generate thousands of distinct schemas, and
-# compiling each execs a code object that is never reused, so forcing compilation
-# there grows memory without bound. The compile-specific suites drive both modes
-# themselves, so forcing one mode on them is meaningless.
-_COMPILED_LANE_EXCLUDE = (
-    "test_codegen",
-    "test_compile_policy",
-    "fuzz",
-    "safe_contract",
+# Test files excluded from the --compiled lane. The property-based and fuzz suites
+# generate thousands of distinct schemas, and compiling each execs a code object
+# that is never reused, so forcing compilation there grows memory without bound.
+# The compile-specific suites drive both modes themselves, so forcing one mode on
+# them is meaningless. Matched against the test file name only (not the full node
+# id), so a parametrized id or a directory that happens to contain one of these
+# words is never skipped by accident.
+_COMPILED_LANE_EXCLUDE_FILES = frozenset(
+    {
+        "test_codegen.py",
+        "test_compile_policy.py",
+        "test_safe_contract.py",
+    },
 )
+
+
+def _excluded_from_compiled_lane(item: pytest.Item) -> bool:
+    """Whether a test's file is excluded from the ``--compiled`` lane."""
+    name = item.path.name
+    # The fuzz suites are a family (``test_fuzz_*`` across packages), matched by
+    # name; the others are named in full above.
+    return name in _COMPILED_LANE_EXCLUDE_FILES or "fuzz" in name
 
 
 def pytest_collection_modifyitems(
@@ -61,7 +72,7 @@ def pytest_collection_modifyitems(
         return
     skip = pytest.mark.skip(reason="not run under --compiled (property/fuzz/compile)")
     for item in items:
-        if any(token in item.nodeid for token in _COMPILED_LANE_EXCLUDE):
+        if _excluded_from_compiled_lane(item):
             item.add_marker(skip)
 
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The `--compiled` lane skipped any test whose full node id contained `test_codegen`, `test_compile_policy`, `fuzz`, or `safe_contract`. A future parametrized id (`test_x[fuzz_case]`) or a directory carrying one of those words would be skipped by accident.

The match is now scoped to the test file name: exact file names for the compile-specific and safe-contract suites, and a file-name match for the `test_fuzz_*` family. The excluded set is unchanged: the compiled lane reports the same passed/skipped counts before and after.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
