### PR TITLE
Drop a Python-only regex when emitting a JSON Schema pattern

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -391,12 +391,18 @@ def _convert_named(node: Any) -> dict[str, Any] | None:
 
 # Regex syntax that Python's ``re`` accepts but JSON Schema's ECMA-262 dialect does
 # not. A ``pattern`` using one of these would be rejected, or silently behave
-# differently, in an external (non-Python) validator: a Python named group or
-# backreference, an inline ``(?#...)`` comment, a ``(?(id)...)`` conditional, a
-# ``(?>...)`` atomic group, an inline ``(?i)``/``(?im:...)`` flag set, or the
-# ``\A``/``\Z`` anchors that ECMA-262 spells ``^``/``$``.
+# differently, in an external (non-Python) validator. The detection is conservative:
+# a false negative (a Python-only construct not listed) emits an invalid pattern, so
+# err toward listing; a false positive only drops a valid pattern, the safe direction.
 _PYTHON_ONLY_REGEX = re.compile(
-    r"\(\?P[<=]|\(\?\#|\(\?\(|\(\?>|\(\?[aiLmsux]+[:)]|\\[AZ]",
+    r"\(\?P[<=]"  # named group (?P<n>...) or backreference (?P=n)
+    r"|\(\?\#"  # inline comment (?#...)
+    r"|\(\?\("  # conditional (?(id)yes|no)
+    r"|\(\?>"  # atomic group (?>...)
+    r"|\(\?[aiLmsux]+[:)]"  # inline flags (?i) or scoped (?im:...)
+    r"|\(\?[aiLmsux]*-[aiLmsux]+:"  # negated/mixed scoped flags (?-i:...)
+    r"|(?<!\\)[*+?}]\+"  # possessive quantifier (*+ ++ ?+ }+), not an escape
+    r"|\\[AZ]",  # \A / \Z anchors, which ECMA-262 spells ^ / $
 )
 
 

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -315,7 +315,7 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
         return _convert_length(node)
 
     if isinstance(node, Match):
-        return {"type": "string", "pattern": node.pattern.pattern}
+        return _convert_match(node)
 
     if isinstance(node, Maybe):
         return {"anyOf": [{"type": "null"}, _child(node.validator)]}
@@ -387,6 +387,32 @@ def _convert_named(node: Any) -> dict[str, Any] | None:
         return {"type": "string"}
 
     return None
+
+
+# Regex syntax that Python's ``re`` accepts but JSON Schema's ECMA-262 dialect does
+# not. A ``pattern`` using one of these would be rejected, or silently behave
+# differently, in an external (non-Python) validator: a Python named group or
+# backreference, an inline ``(?#...)`` comment, a ``(?(id)...)`` conditional, a
+# ``(?>...)`` atomic group, an inline ``(?i)``/``(?im:...)`` flag set, or the
+# ``\A``/``\Z`` anchors that ECMA-262 spells ``^``/``$``.
+_PYTHON_ONLY_REGEX = re.compile(
+    r"\(\?P[<=]|\(\?\#|\(\?\(|\(\?>|\(\?[aiLmsux]+[:)]|\\[AZ]",
+)
+
+
+def _convert_match(node: Match) -> dict[str, Any]:
+    """Render a Match as a string, with a JSON Schema ``pattern`` when ECMA-safe.
+
+    JSON Schema patterns are ECMA-262 regular expressions, while ``Match`` holds a
+    Python ``re`` pattern. A pattern that uses Python-only syntax is dropped, leaving
+    a plain ``{"type": "string"}``, so the emitted schema stays valid for an external
+    validator rather than carrying a pattern that validator would reject. An
+    ECMA-compatible pattern is emitted unchanged.
+    """
+    source = node.pattern.pattern
+    if _PYTHON_ONLY_REGEX.search(source):
+        return {"type": "string"}
+    return {"type": "string", "pattern": source}
 
 
 def _convert_range(node: Range) -> dict[str, Any]:

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -177,15 +177,37 @@ def test_match_exports_pattern() -> None:
 @pytest.mark.parametrize(
     "pattern",
     [
-        r"(?P<year>\d{4})",  # Python named group
+        r"(?P<year>\d{4})",  # named group
         r"\A\d+\Z",  # Python-only anchors
-        r"(?i)abc",  # inline flag
+        r"(?i)abc",  # global inline flag
+        r"(?i:abc)",  # scoped inline flags
+        r"(?-i:abc)",  # negated scoped flag
+        r"(?i-s:abc)",  # mixed scoped flags
         r"(?#a comment)x",  # inline comment
+        r"(?>\d+)",  # atomic group
+        r"(\d)(?(1)a|b)",  # conditional
+        r"a*+",  # possessive quantifier
     ],
 )
 def test_match_drops_a_python_only_pattern(pattern: str) -> None:
     """A pattern using Python-only regex syntax is dropped, leaving a valid string."""
     assert to_json_schema(Schema(Match(pattern))) == {"type": "string"}
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"(?:ab)+c",  # non-capturing group (valid ECMA, must not be dropped)
+        r"a(?=b)",  # lookahead
+        r"\}+",  # an escaped brace with a quantifier is not a possessive
+    ],
+)
+def test_match_keeps_an_ecma_compatible_pattern(pattern: str) -> None:
+    """An ECMA-compatible pattern, including ones that resemble Python-only, is kept."""
+    assert to_json_schema(Schema(Match(pattern))) == {
+        "type": "string",
+        "pattern": pattern,
+    }
 
 
 def test_maybe_is_nullable() -> None:

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -167,11 +167,25 @@ def test_any_becomes_any_of() -> None:
 
 
 def test_match_exports_pattern() -> None:
-    """Match exports a string pattern."""
+    """Match exports an ECMA-compatible pattern unchanged."""
     assert to_json_schema(Schema(Match(r"^\d+$"))) == {
         "type": "string",
         "pattern": r"^\d+$",
     }
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"(?P<year>\d{4})",  # Python named group
+        r"\A\d+\Z",  # Python-only anchors
+        r"(?i)abc",  # inline flag
+        r"(?#a comment)x",  # inline comment
+    ],
+)
+def test_match_drops_a_python_only_pattern(pattern: str) -> None:
+    """A pattern using Python-only regex syntax is dropped, leaving a valid string."""
+    assert to_json_schema(Schema(Match(pattern))) == {"type": "string"}
 
 
 def test_maybe_is_nullable() -> None:


### PR DESCRIPTION
## Breaking change

None for an ECMA-compatible pattern (the common case), which is emitted unchanged. A `Match` whose Python pattern uses Python-only syntax now emits `{"type": "string"}` with no `pattern`, where before it emitted a `pattern` an external validator would reject.

## Proposed change

`Match` emitted its Python `re` pattern verbatim as a JSON Schema `pattern`. JSON Schema patterns are ECMA-262 regular expressions, so a Python named group (`(?P<...>)`), inline flag (`(?i)`), comment (`(?#...)`), conditional, atomic group, or `\A`/`\Z` anchor produces a `pattern` that an external (non-Python) validator rejects or reads differently.

The encoder now emits the `pattern` only when it is ECMA-safe; otherwise it drops the pattern and leaves a valid `{"type": "string"}`. This is a fidelity-versus-validity trade: the emitted schema is valid everywhere, at the cost of not constraining the string when the pattern cannot be expressed in ECMA-262.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
