### PR TITLE
Pin that validate propagates a body exception unchanged

### DIFF
--- a/src/probatio/validators/decorators.py
+++ b/src/probatio/validators/decorators.py
@@ -138,6 +138,11 @@ def validate(
 
         @validate(arg1=int, arg2=str, __return__=int)
         def f(arg1, arg2): ...
+
+    Only the arguments and the return value are validated; the function body is the
+    caller's own code. An exception it raises (anything but the ``Invalid`` from a
+    failed argument or return schema) propagates unchanged. ``validate`` is a
+    convenience wrapper, not a safe-validator boundary.
     """
     returns_defined = False
     returns = None

--- a/tests/validators/test_decorators.py
+++ b/tests/validators/test_decorators.py
@@ -86,6 +86,22 @@ def test_validate_without_argument_schemas() -> None:
     assert add(1, 2) == 3
 
 
+def test_validate_propagates_a_body_exception_unchanged() -> None:
+    """A non-Invalid exception from the wrapped body propagates, not wrapped.
+
+    ``validate`` checks the arguments and return value; the body is the caller's own
+    code, so its own error is not a validation failure and is not converted.
+    """
+
+    @validate(_value=int)
+    def boom(_value: int) -> int:
+        message = "kaboom"
+        raise RuntimeError(message)
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        boom(1)
+
+
 def test_raises_accepts_a_matching_exception() -> None:
     """raises swallows the expected exception."""
     with raises(MultipleInvalid):


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`validate` checks the decorated function's arguments and return value, but the body is the caller's own code: an exception the body raises is not a validation failure and is not converted to `Invalid`. This was implicit. Document it on `validate` and pin it with a test, so it is clear `validate` is a convenience wrapper, not a safe-validator boundary.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
