### PR TITLE
Type Url and FqdnUrl as returning str or bytes, not Any

### DIFF
--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -349,21 +349,25 @@ def _validate_url(value: typing.Any, msg: str | None) -> typing.Any:
     return value
 
 
-def Url(msg: str | None = None) -> typing.Callable[[typing.Any], typing.Any]:
-    """Return a validator for a URL with a scheme and a host (voluptuous factory)."""
+def Url(msg: str | None = None) -> typing.Callable[[typing.Any], str | bytes]:
+    """Return a validator for a URL with a scheme and a host (voluptuous factory).
 
-    def validate(value: typing.Any) -> typing.Any:
+    The validator returns its input unchanged on success: a URL is a ``str`` or
+    ``bytes``, so the result is typed ``str | bytes`` rather than ``Any``.
+    """
+
+    def validate(value: typing.Any) -> str | bytes:
         """Validate a URL, parsing with the standard library."""
-        return _validate_url(value, msg)
+        return typing.cast("str | bytes", _validate_url(value, msg))
 
     setattr(validate, "__probatio_json_format__", "uri")  # noqa: B010
     return validate
 
 
-def FqdnUrl(msg: str | None = None) -> typing.Callable[[typing.Any], typing.Any]:
+def FqdnUrl(msg: str | None = None) -> typing.Callable[[typing.Any], str | bytes]:
     """Return a validator for a URL whose host is a fully-qualified domain name."""
 
-    def validate(value: typing.Any) -> typing.Any:
+    def validate(value: typing.Any) -> str | bytes:
         """Validate a URL and require its host to contain a dot."""
         _validate_url(value, msg)
 
@@ -377,7 +381,7 @@ def FqdnUrl(msg: str | None = None) -> typing.Callable[[typing.Any], typing.Any]
         if host is None or dot not in host:
             raise UrlInvalid(msg or "expected a URL with a fully-qualified domain name")
 
-        return value
+        return typing.cast("str | bytes", value)
 
     setattr(validate, "__probatio_json_format__", "uri")  # noqa: B010
     return validate


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`Url()` and `FqdnUrl()` returned `Callable[[Any], Any]`, leaking `Any` into typed callers. The validator returns its input unchanged on success, and a URL is a `str` or `bytes`, so the result is now typed `str | bytes`. The input stays `Any`, the way every validator the engine calls is typed; narrowing it tripped a `ty` `urlparse`-overload issue for no real gain.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
