### PR TITLE
Update the docs structure tree in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,9 +21,11 @@ docs/
 │   ├── content.config.ts         # Starlight content collection
 │   └── content/docs/
 │       ├── index.mdx             # landing page
-│       ├── getting-started.md    # install + quick example
-│       ├── guides/               # migrating from voluptuous, …
-│       └── reference/            # API reference
+│       ├── getting-started/      # install, quick start, migrating from voluptuous
+│       ├── guides/               # dict schemas, combinators, codecs, …
+│       ├── recipes/              # config files, Home Assistant, cookbook
+│       ├── reference/            # API reference, errors, typing, performance
+│       └── project/              # architecture, roadmap, security, credits
 ```
 
 The site is served at `https://probatio.frenck.dev` (set in `astro.config.mjs`).


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The structure example in `docs/README.md` was stale: it listed a single `getting-started.md` (now a `getting-started/` directory) and omitted the `recipes/` and `project/` sections. Refresh the tree to match the current docs content.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
