### PR TITLE
Add license identifiers for the optional integrations

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -11,9 +11,9 @@ ship under their own licenses, not with probatio:
 
 - [orjson](https://github.com/ijl/orjson) for fast JSON loading.
   License: `MPL-2.0 AND (Apache-2.0 OR MIT)`.
-- [YAMLRocks](https://github.com/frenck/yamlrocks) (MIT) or
-  [PyYAML](https://pyyaml.org) (MIT) for YAML loading.
-- [tomli-w](https://github.com/hukkin/tomli-w) for writing TOML. License: MIT.
+- [YAMLRocks](https://github.com/frenck/yamlrocks) (`MIT`) or
+  [PyYAML](https://pyyaml.org) (`MIT`) for YAML loading.
+- [tomli-w](https://github.com/hukkin/tomli-w) for writing TOML. License: `MIT`.
 
 Development and test tooling (pytest, ruff, mypy, ty, and voluptuous as a
 test-only conformance oracle) is not distributed with the package.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -10,9 +10,10 @@ Optional integrations are used only when you install them yourself, and they
 ship under their own licenses, not with probatio:
 
 - [orjson](https://github.com/ijl/orjson) for fast JSON loading.
-- [YAMLRocks](https://github.com/frenck/yamlrocks) or
-  [PyYAML](https://pyyaml.org) for YAML loading.
-- [tomli-w](https://github.com/hukkin/tomli-w) for writing TOML.
+  License: `MPL-2.0 AND (Apache-2.0 OR MIT)`.
+- [YAMLRocks](https://github.com/frenck/yamlrocks) (MIT) or
+  [PyYAML](https://pyyaml.org) (MIT) for YAML loading.
+- [tomli-w](https://github.com/hukkin/tomli-w) for writing TOML. License: MIT.
 
 Development and test tooling (pytest, ruff, mypy, ty, and voluptuous as a
 test-only conformance oracle) is not distributed with the package.


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The optional-integration list in `THIRD_PARTY_LICENSES.md` named each project but not its license, which a compliance reader wants. Add the identifiers, taken from each package's metadata: orjson is `MPL-2.0 AND (Apache-2.0 OR MIT)`; YAMLRocks, PyYAML, and tomli-w are MIT. These remain optional, install-them-yourself integrations, not bundled with probatio.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
