### PR TITLE
Share the context-overlay plumbing between the registries

### DIFF
--- a/src/probatio/_overlay.py
+++ b/src/probatio/_overlay.py
@@ -1,0 +1,43 @@
+"""A process-wide mapping with a context-scoped overlay, thread- and async-safe.
+
+The type registry (``_type_registry``) and the serde option defaults
+(``serde/_config``) both layer a per-context override over a process-wide default in
+the same shape: a plain ``dict`` for the global layer, and a ``ContextVar`` overlay
+pushed inside a ``with`` block and restored on exit. This holds that contextvar
+plumbing (the ``None`` default that readers treat as empty, and the set/reset token)
+in one place, so the restore semantics cannot drift between the two. Each module
+keeps its own merge and lookup rules on top.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class ContextOverlay[K, V]:
+    """A process-wide ``dict`` plus a context-scoped overlay of the same shape."""
+
+    def __init__(self, name: str) -> None:
+        """Create the empty global map and the per-context overlay variable."""
+        self.glob: dict[K, V] = {}
+        # Default None (not a shared mutable dict, which every context would alias);
+        # readers treat None as an empty overlay.
+        self.scoped: ContextVar[dict[K, V] | None] = ContextVar(name, default=None)
+
+    def current(self) -> dict[K, V]:
+        """Return the current context's overlay, or an empty dict when none is set."""
+        return self.scoped.get() or {}
+
+    @contextlib.contextmanager
+    def pushed(self, overlay: dict[K, V]) -> Iterator[None]:
+        """Install ``overlay`` for the current context, restoring the prior one on exit."""
+        token = self.scoped.set(overlay)
+        try:
+            yield
+        finally:
+            self.scoped.reset(token)

--- a/src/probatio/_type_registry.py
+++ b/src/probatio/_type_registry.py
@@ -23,21 +23,16 @@ building consults the registry.
 from __future__ import annotations
 
 import contextlib
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
+
+from probatio._overlay import ContextOverlay
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
 
-# Process-wide registrations (visible to every thread), keyed by exact type.
-_global: dict[type, Any] = {}
-
-# Scoped overlays, per context (thread or async task), pushed by type_registry.
-# The default is None (not a shared mutable ``{}``); readers treat it as empty.
-_scoped: ContextVar[dict[type, Any] | None] = ContextVar(
-    "probatio_type_registry",
-    default=None,
-)
+# Two layers keyed by exact type: a process-wide ``register_type`` map and a
+# ``type_registry`` overlay scoped to the current thread or async task.
+_registry: ContextOverlay[type, Any] = ContextOverlay("probatio_type_registry")
 
 
 def register_type(cls: type, validator: Any) -> None:
@@ -52,12 +47,12 @@ def register_type(cls: type, validator: Any) -> None:
     if not isinstance(cls, type):
         message = f"register_type expects a type, got {cls!r}"
         raise TypeError(message)
-    _global[cls] = validator
+    _registry.glob[cls] = validator
 
 
 def clear_type_registry() -> None:
     """Drop every process-wide registration made with ``register_type``."""
-    _global.clear()
+    _registry.glob.clear()
 
 
 @contextlib.contextmanager
@@ -74,14 +69,10 @@ def type_registry(registrations: Mapping[type, Any]) -> Iterator[None]:
             message = f"type_registry keys must be types, got {cls!r}"
             raise TypeError(message)
 
-    current = _scoped.get() or {}
-    updated = {**current, **registrations}
-    token = _scoped.set(updated)
-
-    try:
+    # A scoped registration wins over a process-wide one, so the overlay carries the
+    # outer scope plus these registrations (later keys overriding).
+    with _registry.pushed({**_registry.current(), **registrations}):
         yield
-    finally:
-        _scoped.reset(token)
 
 
 def resolve_type_validator(cls: type) -> Any | None:
@@ -90,7 +81,7 @@ def resolve_type_validator(cls: type) -> Any | None:
     Consulted by the annotation-driven builders for an exact-type match. Returns
     ``None`` when nothing is registered, so the caller keeps its default handling.
     """
-    scoped = _scoped.get()
+    scoped = _registry.scoped.get()
     if scoped is not None and cls in scoped:
         return scoped[cls]
-    return _global.get(cls)
+    return _registry.glob.get(cls)

--- a/src/probatio/serde/_config.py
+++ b/src/probatio/serde/_config.py
@@ -11,22 +11,19 @@ which wins over the process-wide default.
 from __future__ import annotations
 
 import contextlib
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
+
+from probatio._overlay import ContextOverlay
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
 _FORMATS = frozenset({"json", "yaml", "toml"})
 
-# Process-wide defaults (visible to every thread), keyed by (format, direction).
-_global: dict[tuple[str, str], dict[str, Any]] = {}
-
-# Scoped overrides, per context (thread or async task), pushed by default_options.
-# The default is None (not a shared mutable ``{}``); readers treat it as empty.
-_scoped: ContextVar[dict[tuple[str, str], dict[str, Any]] | None] = ContextVar(
+# Two layers keyed by (format, direction): the process-wide ``set_default_options``
+# map and a ``default_options`` overlay scoped to the current thread or async task.
+_options: ContextOverlay[tuple[str, str], dict[str, Any]] = ContextOverlay(
     "probatio_serde_options",
-    default=None,
 )
 
 
@@ -54,14 +51,14 @@ def set_default_options(
     _check_format(format)
 
     if load is not None:
-        _global[format, "load"] = dict(load)
+        _options.glob[format, "load"] = dict(load)
     if dump is not None:
-        _global[format, "dump"] = dict(dump)
+        _options.glob[format, "dump"] = dict(dump)
 
 
 def clear_default_options() -> None:
     """Drop every process-wide default set by ``set_default_options``."""
-    _global.clear()
+    _options.glob.clear()
 
 
 @contextlib.contextmanager
@@ -79,18 +76,15 @@ def default_options(
     """
     _check_format(format)
 
-    current = _scoped.get() or {}
+    current = _options.current()
     updated = dict(current)
     if load is not None:
         updated[format, "load"] = {**current.get((format, "load"), {}), **load}
     if dump is not None:
         updated[format, "dump"] = {**current.get((format, "dump"), {}), **dump}
 
-    token = _scoped.set(updated)
-    try:
+    with _options.pushed(updated):
         yield
-    finally:
-        _scoped.reset(token)
 
 
 def effective_options(
@@ -105,8 +99,8 @@ def effective_options(
     """
     key = (format, direction)
     merged: dict[str, Any] = {}
-    merged.update(_global.get(key, {}))
-    merged.update((_scoped.get() or {}).get(key, {}))
+    merged.update(_options.glob.get(key, {}))
+    merged.update(_options.current().get(key, {}))
     if per_call:
         merged.update(per_call)
 


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The type registry (`_type_registry`) and the serde option defaults (`serde/_config`) both layer a context-scoped overlay over a process-wide `dict`, and each reimplemented the same contextvar plumbing: the `None` default that readers treat as empty, and the `set`/`reset` token for restoring the prior overlay on exit. That duplication is where the restore or precedence semantics could quietly drift apart.

A small internal `ContextOverlay[K, V]` now holds that one piece. Each module keeps its own merge and lookup rules (flat replace for the registry, per-key deep merge for the options); only the plumbing is shared. Behavior is unchanged.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
