### PR TITLE
Detect Self through a child-schema protocol, not attribute guessing

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -199,12 +199,12 @@ def _schema_uses_self(node: Any) -> bool:
         )
     if isinstance(node, list | tuple | set | frozenset):
         return any(_schema_uses_self(element) for element in node)
-    children = getattr(node, "validators", None)
-    if isinstance(children, list):
-        return any(_schema_uses_self(child) for child in children)
-    wrapped = getattr(node, "validator", None)
-    if wrapped is not None:
-        return _schema_uses_self(wrapped)
+    # A validator that wraps other schemas (a combinator, a sequence shaper,
+    # ``Maybe``/``Msg``) exposes them through ``__probatio_child_schemas__``, so the
+    # walk reaches them without guessing which attribute each stored them under.
+    child_schemas = getattr(node, "__probatio_child_schemas__", None)
+    if child_schemas is not None:
+        return any(_schema_uses_self(child) for child in child_schemas())
     return False
 
 

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -63,6 +63,10 @@ class _Combinator(_SafeValidator):
         """Recompile ``self.validators`` into ``self._compiled`` under ``self._extra``."""
         raise NotImplementedError
 
+    def __probatio_child_schemas__(self) -> tuple[typing.Any, ...]:
+        """Return the raw child schemas this combinator wraps, for ``Self`` detection."""
+        return tuple(self.validators)
+
     def __probatio_needs_extra__(self) -> bool:
         """Whether a non-strict extra could reach a nested mapping in the branches.
 

--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -56,6 +56,10 @@ class ExactSequence(_SafeValidator):
         """Render as a constructor call, matching voluptuous."""
         return f"ExactSequence({self.validators!r})"
 
+    def __probatio_child_schemas__(self) -> tuple[typing.Any, ...]:
+        """Return the raw per-position schemas this wraps, for ``Self`` detection."""
+        return tuple(self.validators)
+
     def __call__(self, value: typing.Any) -> typing.Any:
         """Validate each position, rebuilding the sequence of the same type."""
         if not isinstance(value, list | tuple) or len(value) != len(self._schemas):
@@ -176,6 +180,10 @@ class Unordered(_SafeValidator):
         self.msg = msg
         self._schemas = [Schema(validator, **kwargs) for validator in self.validators]
 
+    def __probatio_child_schemas__(self) -> tuple[typing.Any, ...]:
+        """Return the raw element schemas this wraps, for ``Self`` detection."""
+        return tuple(self.validators)
+
     def __call__(self, value: typing.Any) -> typing.Any:
         """Match each item to an unused validator, in any order."""
         if not isinstance(value, list | tuple):
@@ -263,6 +271,10 @@ class Maybe(_SafeValidator):
         """
         return f"Maybe({self.validator!r}, msg={self.msg!r})"
 
+    def __probatio_child_schemas__(self) -> tuple[typing.Any, ...]:
+        """Return the single wrapped schema, for ``Self`` detection."""
+        return (self.validator,)
+
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return None unchanged, else the validated value."""
         if value is None:
@@ -290,6 +302,10 @@ class Msg(_SafeValidator):
         self.msg = msg
         self.cls = cls
         self._schema = Schema(validator)
+
+    def __probatio_child_schemas__(self) -> tuple[typing.Any, ...]:
+        """Return the single wrapped schema, for ``Self`` detection."""
+        return (self.validator,)
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Validate, re-raising any failure with the replacement message."""


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`_schema_uses_self` (which decides whether a schema records an active root for recursive `Self` validation) walked a validator's children by probing the informal `.validators` / `.validator` attributes. A future wrapper that stored its children under a different name would silently fall through, breaking `Self` detection and recursive-schema handling with no error.

The child-holding validators now expose their children through a `__probatio_child_schemas__()` method, matching the existing `__probatio_*` convention (`__probatio_safe__`, `__probatio_needs_extra__`, …): `_Combinator` (All/Any/Union/SomeOf), `ExactSequence`, `Unordered`, `Maybe`, and `Msg`. The walk reads that protocol instead of guessing attribute names. `_branch_holds_mapping` keeps its narrower `.validators`-only walk on purpose (it must not descend into a `Maybe`). Behavior is unchanged.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
