### PR TITLE
Pin the sequence multi-error branch with a deterministic test

### DIFF
--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -119,3 +119,16 @@ def test_every_failing_item_is_reported() -> None:
         Schema([{"name": str}])([{"name": 123}, {"name": 123}])
     paths = sorted(tuple(error.path) for error in caught.value.errors)
     assert paths == [(0, "name"), (1, "name")]
+
+
+def test_one_item_failing_on_several_counts_flattens_each_under_its_index() -> None:
+    """A single item that fails its schema more than once reports every error at [0].
+
+    The element schema raises a ``MultipleInvalid`` (a wrong value type and an extra
+    key), so the sequence path flattens those errors under the item's index rather
+    than nesting them.
+    """
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema([{"a": int}])([{"a": "x", "b": 2}])
+    paths = sorted(tuple(error.path) for error in caught.value.errors)
+    assert paths == [(0, "a"), (0, "b")]


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

A list item that fails its element schema on more than one count makes the element schema raise a `MultipleInvalid`, and the sequence path in the engine flattens those errors under the item's index (rather than nesting them). That branch (`_engine.py`, the `isinstance(last_error, MultipleInvalid)` case in `_validate_item`) had no deterministic test.

Its only cover was incidental: the JSON Schema round-trip fuzzer happened to generate an input that reached it. That is fragile, a change anywhere that shifts what the fuzzer generates can knock it off that branch and drop coverage below the 100% gate, with nothing in the diff pointing at why.

This adds a small, explicit test for the case (a single item failing a nested mapping on both a wrong value type and an extra key, asserting both errors report under index `[0]`), so the branch is pinned by intent rather than by chance. Test-only, no behavior change.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
