### PR TITLE
Parse ISO 8601 durations in the Duration validator

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -250,9 +250,12 @@ Schema(Date(format="%d/%m/%Y"))("25/06/2026")       # '25/06/2026'
 `Time` is the time-of-day sibling, defaulting to `%H:%M:%S`. `Duration`,
 `TimeZoneInfo`, and `TimeZone` are Probatio additions that coerce to a Python
 object: `Duration` parses a `timedelta`, a number of seconds (an `int`, `float`, or
-numeric string), a `H:MM[:SS]` string, or a mapping into a `datetime.timedelta`;
-`TimeZoneInfo` resolves an IANA name to a `zoneinfo.ZoneInfo`, while `TimeZone`
-parses a fixed UTC offset (`+01:00`, `Z`, `UTC`) into a `datetime.timezone`.
+numeric string), a `H:MM[:SS]` string, an ISO 8601 duration (`P1DT2H30M`, `PT45S`,
+`-P3D`), or a mapping into a `datetime.timedelta`; `TimeZoneInfo` resolves an IANA
+name to a `zoneinfo.ZoneInfo`, while `TimeZone` parses a fixed UTC offset (`+01:00`,
+`Z`, `UTC`) into a `datetime.timezone`. An ISO 8601 duration is limited to the
+fields a `timedelta` can represent (weeks, days, hours, minutes, seconds); a year
+or a month is rejected, since neither is a fixed length.
 
 ```python
 from probatio import Schema, Time, Duration, TimeZone, TimeZoneInfo
@@ -261,6 +264,7 @@ Schema(Time())("14:30:00")                  # '14:30:00'
 Schema(Duration())("1:30:00")               # datetime.timedelta(seconds=5400)
 Schema(Duration())(90)                      # datetime.timedelta(seconds=90)
 Schema(Duration())("90")                    # datetime.timedelta(seconds=90)
+Schema(Duration())("P1DT2H30M")             # datetime.timedelta(days=1, seconds=9000)
 Schema(TimeZoneInfo())("Europe/Amsterdam")  # zoneinfo.ZoneInfo(key='Europe/Amsterdam')
 Schema(TimeZone())("+01:00")                # datetime.timezone(datetime.timedelta(seconds=3600))
 ```

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -226,7 +226,7 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
 - `AsTime(format=None, msg=None)`: parse a string to a `datetime.time` (ISO 8601 by
   default, or a `strptime` `format=`).
 - `Duration(msg=None)`: parse a duration (timedelta, seconds as an int/float/string,
-  `H:MM[:SS]`, or a mapping) to a `timedelta`.
+  `H:MM[:SS]`, an ISO 8601 duration like `P1DT2H30M`, or a mapping) to a `timedelta`.
 - `TimeZoneInfo(msg=None)`: validate an IANA zone name, returned as
   `zoneinfo.ZoneInfo`.
 - `TimeZone(msg=None)`: parse a fixed UTC offset (`+01:00`, `Z`, `UTC`) to a

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -32,7 +32,27 @@ from probatio.validators._base import _SafeValidator
 # A colon duration has hours:minutes or hours:minutes:seconds.
 _DURATION_PARTS = (2, 3)
 _MAX_CLOCK_FIELD = 59  # the minute and second fields of an H:MM:SS duration
-_DURATION_MSG = "expected a duration like H:MM, H:MM:SS, or a number of seconds"
+_DURATION_MSG = (
+    "expected a duration like H:MM, H:MM:SS, an ISO 8601 duration like PT1H30M, "
+    "or a number of seconds"
+)
+
+# An ISO 8601 duration, limited to the fields a ``timedelta`` can represent: weeks
+# and days, then a time part of hours, minutes, and seconds. Each field is optional
+# and may be fractional (a comma or a period). Years and months are left out on
+# purpose, since neither is a fixed length. Every quantifier is bounded and anchored
+# to a distinct trailing letter, so the match is linear and cannot hang. Emptiness
+# (``P``, ``PT``) and a dangling ``T`` are caught after the match, not by the pattern.
+_ISO8601_DURATION = re.compile(
+    r"P"
+    r"(?:(?P<weeks>\d+(?:[.,]\d+)?)W)?"
+    r"(?:(?P<days>\d+(?:[.,]\d+)?)D)?"
+    r"(?:T"
+    r"(?:(?P<hours>\d+(?:[.,]\d+)?)H)?"
+    r"(?:(?P<minutes>\d+(?:[.,]\d+)?)M)?"
+    r"(?:(?P<seconds>\d+(?:[.,]\d+)?)S)?"
+    r")?",
+)
 
 # A fixed UTC offset: a sign, two-digit hours, optional colon, two-digit minutes.
 # Matched in full, no backtracking, so a crafted string cannot make it hang.
@@ -48,6 +68,15 @@ def _format_message(kind: str, fmt: str | None) -> str:
     if fmt is None:
         return f"expected an ISO 8601 {kind}"
     return f"value does not match expected format {fmt}"
+
+
+def _iso_field(raw: str | None) -> float:
+    """Read one ISO 8601 duration field (``"1"``, ``"1.5"``, ``"1,5"``) as a float.
+
+    A missing field (``None``) reads as zero, and a comma decimal separator is
+    normalized to a period for ``float``.
+    """
+    return float(raw.replace(",", ".")) if raw else 0.0
 
 
 class Datetime(_SafeValidator):
@@ -222,8 +251,11 @@ class Duration(_SafeValidator):
 
     Accepts a ``timedelta`` (passed through), a number of seconds (an ``int``,
     ``float``, or numeric string like ``"90"``), a colon string (``"H:MM"`` or
-    ``"H:MM:SS"``, optionally negative), or a mapping of ``timedelta`` keyword
-    arguments (``{"hours": 1, "minutes": 30}``).
+    ``"H:MM:SS"``, optionally negative), an ISO 8601 duration (``"P1DT2H30M"``,
+    ``"PT45S"``, ``"-P3D"``), or a mapping of ``timedelta`` keyword arguments
+    (``{"hours": 1, "minutes": 30}``). An ISO 8601 duration is limited to the fields
+    a ``timedelta`` can represent (weeks, days, hours, minutes, seconds); years and
+    months are rejected, since neither is a fixed length.
     """
 
     def __init__(self, msg: str | None = None) -> None:
@@ -258,13 +290,21 @@ class Duration(_SafeValidator):
         raise DurationInvalid(self.msg or "expected a duration")
 
     def _parse_string(self, value: str) -> datetime.timedelta:
-        """Parse a ``H:MM`` / ``H:MM:SS`` colon string or a number of seconds.
+        """Parse an ISO 8601, ``H:MM`` / ``H:MM:SS`` colon, or seconds string.
 
-        A bare numeric string (``"90"``, ``"90.5"``) is read as seconds, matching
-        an ``int``/``float`` input, so ``Duration`` covers the whole time-period
-        family rather than only the colon form.
+        An ISO 8601 duration (``"P1DT2H"``, ``"PT30M"``, ``"-P3D"``) is coerced to a
+        ``timedelta``. A bare numeric string (``"90"``, ``"90.5"``) is read as
+        seconds, matching an ``int``/``float`` input, so ``Duration`` covers the whole
+        time-period family rather than only the colon form.
         """
         text = value.strip()
+
+        # An ISO 8601 duration: an optional sign, then ``P`` and its fields.
+        head = text[1:] if text[:1] in ("+", "-") else text
+        if head[:1] == "P":
+            sign = -1 if text[:1] == "-" else 1
+            return sign * self._parse_iso8601(head)
+
         sign = 1
         if text.startswith("-"):
             sign, text = -1, text[1:]
@@ -299,6 +339,34 @@ class Duration(_SafeValidator):
         except (ValueError, OverflowError) as exc:
             # ``float("abc")`` and an empty string raise ValueError; ``"inf"`` or a
             # huge value overflows timedelta; ``"nan"`` raises ValueError there.
+            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
+
+    def _parse_iso8601(self, body: str) -> datetime.timedelta:
+        """Coerce an ISO 8601 duration body (``"P..."``) to a ``timedelta``.
+
+        Only the timedelta-representable fields are accepted (weeks, days, hours,
+        minutes, seconds). A bare ``"P"``, a ``"PT"`` with no time field, a dangling
+        ``"T"``, and any years or months all raise ``DurationInvalid``.
+        """
+        match = _ISO8601_DURATION.fullmatch(body)
+        if match is None:
+            raise DurationInvalid(self.msg or _DURATION_MSG)
+
+        fields = match.groupdict()
+        has_time = fields["hours"] or fields["minutes"] or fields["seconds"]
+        if not any(fields.values()) or ("T" in body and not has_time):
+            # ``P`` alone carries nothing; ``P1DT`` has a time separator but no field.
+            raise DurationInvalid(self.msg or _DURATION_MSG)
+
+        try:
+            return datetime.timedelta(
+                weeks=_iso_field(fields["weeks"]),
+                days=_iso_field(fields["days"]),
+                hours=_iso_field(fields["hours"]),
+                minutes=_iso_field(fields["minutes"]),
+                seconds=_iso_field(fields["seconds"]),
+            )
+        except (ValueError, OverflowError) as exc:
             raise DurationInvalid(self.msg or _DURATION_MSG) from exc
 
 

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -40,9 +40,11 @@ _DURATION_MSG = (
 # An ISO 8601 duration, limited to the fields a ``timedelta`` can represent: weeks
 # and days, then a time part of hours, minutes, and seconds. Each field is optional
 # and may be fractional (a comma or a period). Years and months are left out on
-# purpose, since neither is a fixed length. Every quantifier is bounded and anchored
-# to a distinct trailing letter, so the match is linear and cannot hang. Emptiness
-# (``P``, ``PT``) and a dangling ``T`` are caught after the match, not by the pattern.
+# purpose, since neither is a fixed length. Each quantifier is anchored to a distinct
+# trailing letter and none nest, so the match is linear with no backtracking blowup;
+# a long digit run is matched and ``float``-parsed in linear time (``float`` has no
+# quadratic path and overflows to a caught error), not a hang. Emptiness (``P``,
+# ``PT``) and a dangling ``T`` are caught after the match, not by the pattern.
 _ISO8601_DURATION = re.compile(
     r"P"
     r"(?:(?P<weeks>\d+(?:[.,]\d+)?)W)?"

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -121,14 +121,17 @@ def test_every_failing_item_is_reported() -> None:
     assert paths == [(0, "name"), (1, "name")]
 
 
-def test_one_item_failing_on_several_counts_flattens_each_under_its_index() -> None:
-    """A single item that fails its schema more than once reports every error at [0].
+def test_item_failing_every_element_schema_flattens_the_last_error() -> None:
+    """When an item matches no element schema, the last error flattens under its index.
 
-    The element schema raises a ``MultipleInvalid`` (a wrong value type and an extra
-    key), so the sequence path flattens those errors under the item's index rather
-    than nesting them.
+    With more than one element schema, an item is tried against each in turn. Here the
+    item (a dict) fails the ``int`` schema and then the ``{"a": int}`` schema, and the
+    latter raises a ``MultipleInvalid`` (a wrong value type and an extra key). That last
+    error is the one reported, its errors flattened under the item's index rather than
+    nested. A single element schema takes a faster path, so two are needed to reach the
+    per-item loop that does this.
     """
     with pytest.raises(MultipleInvalid) as caught:
-        Schema([{"a": int}])([{"a": "x", "b": 2}])
+        Schema([int, {"a": int}])([{"a": "x", "b": 2}])
     paths = sorted(tuple(error.path) for error in caught.value.errors)
     assert paths == [(0, "a"), (0, "b")]

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -205,6 +205,30 @@ def test_duration_numeric_string_matches_int() -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("P1DT2H30M", datetime.timedelta(days=1, hours=2, minutes=30)),
+        ("PT30M", datetime.timedelta(minutes=30)),
+        ("PT45S", datetime.timedelta(seconds=45)),
+        ("P3D", datetime.timedelta(days=3)),
+        ("P1W", datetime.timedelta(weeks=1)),
+        ("P2W3DT4H", datetime.timedelta(weeks=2, days=3, hours=4)),
+        ("PT1H30M45S", datetime.timedelta(hours=1, minutes=30, seconds=45)),
+        ("PT0S", datetime.timedelta(0)),
+        ("-P3D", -datetime.timedelta(days=3)),
+        ("+PT1H", datetime.timedelta(hours=1)),
+        # A fractional field, with either decimal separator ISO 8601 allows.
+        ("PT0.5S", datetime.timedelta(seconds=0.5)),
+        ("PT1,5S", datetime.timedelta(seconds=1.5)),
+        (" P1D ", datetime.timedelta(days=1)),
+    ],
+)
+def test_duration_from_iso8601(value: str, expected: datetime.timedelta) -> None:
+    """An ISO 8601 duration parses into the right timedelta, sign included."""
+    assert Schema(Duration())(value) == expected
+
+
+@pytest.mark.parametrize(
     "value",
     [
         True,
@@ -216,6 +240,14 @@ def test_duration_numeric_string_matches_int() -> None:
         "1:99",  # 99 minutes is out of the 0..59 clock range
         "0:60",  # 60 minutes is out of range
         "1:00:99",  # 99 seconds is out of range
+        "P",  # a bare designator carries no fields
+        "PT",  # a time separator with no time field
+        "P1DT",  # a dangling time separator
+        "P1Y",  # a year is not a fixed length
+        "P1M",  # a month is not a fixed length
+        "P1YT1H",  # a year, even alongside a valid field
+        "PT1H1D",  # a date field after the time separator
+        "PX",  # junk after the designator
     ],
 )
 def test_duration_rejects_invalid(value: object) -> None:
@@ -227,7 +259,14 @@ def test_duration_rejects_invalid(value: object) -> None:
 
 @pytest.mark.parametrize(
     "value",
-    [10**20, "100000000000000:0:0", "inf", "1e400", {"days": 10**20}],
+    [
+        10**20,
+        "100000000000000:0:0",
+        "inf",
+        "1e400",
+        {"days": 10**20},
+        "P999999999999999999W",  # an ISO 8601 duration past timedelta's range
+    ],
 )
 def test_duration_rejects_overflow(value: object) -> None:
     """A duration too large for timedelta is rejected, not a leaked OverflowError."""


### PR DESCRIPTION
## Breaking change

None. The change is additive: `Duration` accepts a superset of what it did before, so every existing schema keeps validating the same values.

## Proposed change

`Duration` already coerced a `timedelta`, a number of seconds, an `H:MM[:SS]` colon string, and a mapping of keyword arguments. This adds ISO 8601 durations (`P1DT2H30M`, `PT45S`, `-P3D`), the form most JSON and configuration producers emit, so the validator matches what people actually serialize.

Parsing is limited to the fields a `timedelta` can represent: weeks, days, and a time part of hours, minutes, and seconds, each optionally fractional (a comma or a period, both of which ISO 8601 allows). Years and months are rejected, since neither is a fixed length, and mapping them onto a `timedelta` would be a guess. The match uses a bounded, anchored regular expression, so a crafted string cannot make it hang. Emptiness (`P`, `PT`), a dangling `T`, junk after the designator, and overflow all raise `DurationInvalid`.

This also corrects the sequence test added in #106. That test was meant to cover the engine branch that flattens a per-item `MultipleInvalid` under the item's index, but a single-element list schema takes a faster path that never reaches that branch, so the test passed without exercising it (coverage held only because the JSON Schema fuzzer happened to hit the branch too). The test now uses two element schemas, so it goes through the per-item loop it describes and pins the branch deterministically.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: #106 (corrects the sequence test it added)
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
