### PR TITLE
Add unregister_type to the type registry

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -206,9 +206,11 @@ clear_type_registry()  # reset, so the rest of this page is unaffected
 The registration is read when the schema is built and baked in, so a schema does
 not change once constructed. `register_type` sets it process-wide (for an
 application's entry point); a library should prefer the `type_registry` context
-manager, which scopes the registrations to a `with` block. A use-site validator
-(an `Annotated` hint or `additional_constraints`) still applies on top, so the
-type is coerced first and the extra rule checks the result. The hand-written
+manager, which scopes the registrations to a `with` block. `unregister_type(cls)`
+removes a single type again, and `clear_type_registry()` empties the registry. A
+use-site validator (an `Annotated` hint or `additional_constraints`) still applies
+on top, so the type is coerced first and the extra rule checks the result. The
+hand-written
 `Schema(datetime)` path is never affected; only annotation-driven building reads
 the registry.
 

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -239,11 +239,12 @@ carries forward an upstream request.
   raw value of itself, used in place of the bare `isinstance` check when that type
   is a schema. `EnumInvalid` is the error its built-in consumer (an enum class)
   raises. voluptuous has no such hook.
-- `register_type`, `type_registry`, `clear_type_registry`: a registry mapping a
-  type to a validator, consulted by the annotation-driven builders (the dataclass
-  schema today) so coercion of a type like `datetime` is opt-in and applies
-  wherever the type appears. Process-wide or scoped to a `with` block. voluptuous
-  has no equivalent.
+- `register_type`, `unregister_type`, `type_registry`, `clear_type_registry`: a
+  registry mapping a type to a validator, consulted by the annotation-driven builders
+  (the dataclass and TypedDict schemas) so coercion of a type like `datetime` is
+  opt-in and applies wherever the type appears. Register or remove a single type, or
+  empty the registry; process-wide or scoped to a `with` block. voluptuous has no
+  equivalent.
 - `current_context` with `schema(data, context=...)`: an optional call argument
   that hands per-call state to validators that read `current_context()`, so one
   compiled schema validates against state known only at call time. Additive (a

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -439,7 +439,9 @@ Two Probatio additions let a type carry its own validator, so a type validates b
 more than `isinstance`:
 
 - `__probatio_validate__`: a classmethod a type can define to validate (and coerce) a value itself. Whenever that type is compiled as a bare schema, Probatio calls `Type.__probatio_validate__(value)` instead of an `isinstance` check and uses the return value. Works anywhere a type is used, including a hand-written `Schema(Type)`. See the [custom validators guide](/guides/custom-validators/).
-- `register_type(cls, validator)`: register a validator for `cls`, consulted when `cls` appears as a field annotation while building a dataclass or TypedDict schema (it takes precedence over the type's own check there). A hand-written `Schema(cls)` is not affected. `clear_type_registry()` empties the registry. See the [dataclasses guide](/guides/dataclasses/).
+- `register_type(cls, validator)`: register a validator for `cls`, consulted when `cls` appears as a field annotation while building a dataclass or TypedDict schema (it takes precedence over the type's own check there). A hand-written `Schema(cls)` is not affected. See the [dataclasses guide](/guides/dataclasses/).
+- `unregister_type(cls)`: drop the registration for `cls`, so its fields go back to a strict `isinstance` check. A no-op when `cls` is not registered.
+- `clear_type_registry()`: empty the registry, dropping every registration.
 - `type_registry(registrations)`: a context manager that applies a mapping of `{type: validator}` for the duration of a `with` block, then restores the previous state. Async- and thread-safe, so a library should prefer it over the process-wide `register_type`.
 
 ## Loading and dumping

--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -23,6 +23,7 @@ from probatio._type_registry import (
     clear_type_registry,
     register_type,
     type_registry,
+    unregister_type,
 )
 from probatio.dataclass_schema import (
     DataclassSchema,
@@ -539,5 +540,6 @@ __all__ = [
     "to_openapi",
     "truth",
     "type_registry",
+    "unregister_type",
     "validate",
 ]

--- a/src/probatio/_type_registry.py
+++ b/src/probatio/_type_registry.py
@@ -11,7 +11,8 @@ Two layers, like the serde options in ``serde/_config.py``: a process-wide
 registry set with ``register_type`` (for an application's entry point), and a
 scoped overlay from the ``type_registry`` context manager (async- and thread-safe,
 for code that must not mutate global state). A scoped registration wins over a
-process-wide one for the same type.
+process-wide one for the same type. ``unregister_type`` drops a single type and
+``clear_type_registry`` empties the process-wide layer.
 
 The registry is read when a schema is *built*, and the chosen validator is baked
 in, so a schema is stable once constructed: registering later does not change a
@@ -48,6 +49,16 @@ def register_type(cls: type, validator: Any) -> None:
         message = f"register_type expects a type, got {cls!r}"
         raise TypeError(message)
     _registry.glob[cls] = validator
+
+
+def unregister_type(cls: type) -> None:
+    """Remove ``cls`` from the registry, back to a strict ``isinstance`` check.
+
+    Drops the process-wide registration for ``cls`` if there is one, so an
+    annotation-driven field of ``cls`` builds to a plain ``isinstance`` check again.
+    A no-op when ``cls`` is not registered.
+    """
+    _registry.glob.pop(cls, None)
 
 
 def clear_type_registry() -> None:

--- a/tests/test_type_registry.py
+++ b/tests/test_type_registry.py
@@ -22,6 +22,7 @@ from probatio import (
     clear_type_registry,
     register_type,
     type_registry,
+    unregister_type,
 )
 from probatio.error import MultipleInvalid
 
@@ -160,3 +161,21 @@ def test_re_registering_replaces_the_previous_entry() -> None:
         1,
         1,
     )
+
+
+def test_unregister_type_makes_a_field_strict_again() -> None:
+    """unregister_type drops one registration, so its field rejects a string again."""
+    register_type(datetime, Coerce(_parse))
+    unregister_type(datetime)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(Event)({"when": "2020-01-01T00:00"})
+    assert caught.value.errors[0].path == ["when"]
+
+
+def test_unregister_type_is_a_noop_for_an_unregistered_type() -> None:
+    """Unregistering a type that was never registered does nothing and does not raise."""
+    unregister_type(datetime)  # never registered
+
+    with pytest.raises(MultipleInvalid):
+        DataclassSchema(Event)({"when": "2020-01-01T00:00"})


### PR DESCRIPTION
## Breaking change

None. The change is additive: the existing registry API (`register_type`, `type_registry`, `clear_type_registry`) is unchanged.

## Proposed change

The type registry could add a type-to-validator entry (`register_type`) and drop every entry at once (`clear_type_registry`), but there was no way to remove a single one. `unregister_type(cls)` fills that gap: it pops one type from the process-wide registry, so an annotation-driven field of that type goes back to a strict `isinstance` check. It is a no-op when the type was never registered, so callers do not have to guard the call.

This rounds out the registry's management surface (add one, remove one, empty all) and is the natural counterpart to `register_type`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
