### PR TITLE
Pass a native object through the As* temporal validators

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -274,7 +274,10 @@ Schema(TimeZone())("+01:00")                # datetime.timezone(datetime.timedel
 `time` instead of the original string, and they parse ISO 8601 out of the box, so
 no `format=` is needed for the common case. Pass `format=` to parse a specific
 `strptime` layout instead. `AsDatetime` takes `require_timezone=True` to reject a
-naive result; the ISO default reads the offset, so that needs no extra format.
+naive result; the ISO default reads the offset, so that needs no extra format. A
+native object passes straight through, so a `datetime`, `date`, or `time` that a
+YAML or TOML loader already produced validates without a round-trip (and `AsDate`
+rejects a `datetime`, since it carries a time a pure date would drop).
 
 ```python
 from probatio import Schema, AsDatetime, AsDate, AsTime

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -174,15 +174,22 @@ class AsDatetime(_SafeValidator):
         )
 
     def __call__(self, value: typing.Any) -> datetime.datetime:
-        """Return the parsed datetime, else raise DatetimeInvalid."""
-        try:
-            if self.format is None:
-                parsed = datetime.datetime.fromisoformat(value)
-            else:
-                parsed = datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
-        except (TypeError, ValueError) as exc:
-            message = self.msg or _format_message("datetime", self.format)
-            raise DatetimeInvalid(message) from exc
+        """Return the parsed datetime, passing an existing datetime through.
+
+        A ``datetime`` already (a YAML/TOML loader produces one natively) is returned
+        as-is; a string is parsed. The timezone requirement still applies to both.
+        """
+        if isinstance(value, datetime.datetime):
+            parsed = value
+        else:
+            try:
+                if self.format is None:
+                    parsed = datetime.datetime.fromisoformat(value)
+                else:
+                    parsed = datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
+            except (TypeError, ValueError) as exc:
+                message = self.msg or _format_message("datetime", self.format)
+                raise DatetimeInvalid(message) from exc
 
         if self.require_timezone and parsed.tzinfo is None:
             raise DatetimeInvalid(self.msg or "expected a timezone-aware datetime")
@@ -209,7 +216,15 @@ class AsDate(_SafeValidator):
         return f"{type(self).__name__}(format={self.format})"
 
     def __call__(self, value: typing.Any) -> datetime.date:
-        """Return the parsed date, else raise DateInvalid."""
+        """Return the parsed date, passing an existing date through.
+
+        A pure ``date`` is returned as-is; a ``datetime`` is not a date here (it
+        carries a time, so a date field rejects it), and a string is parsed.
+        """
+        if isinstance(value, datetime.date) and not isinstance(
+            value, datetime.datetime
+        ):
+            return value
         try:
             if self.format is None:
                 return datetime.date.fromisoformat(value)
@@ -238,7 +253,12 @@ class AsTime(_SafeValidator):
         return f"{type(self).__name__}(format={self.format})"
 
     def __call__(self, value: typing.Any) -> datetime.time:
-        """Return the parsed time, else raise TimeInvalid."""
+        """Return the parsed time, passing an existing time through.
+
+        A ``time`` already is returned as-is; a string is parsed.
+        """
+        if isinstance(value, datetime.time):
+            return value
         try:
             if self.format is None:
                 return datetime.time.fromisoformat(value)

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -151,6 +151,24 @@ def test_astime_rejects_a_bad_value() -> None:
     assert isinstance(caught.value.errors[0], TimeInvalid)
 
 
+def test_as_validators_pass_a_native_object_through() -> None:
+    """A native datetime/date/time is returned as-is (a YAML/TOML loader produces one)."""
+    dt = datetime.datetime(2020, 1, 2, 3, 4)
+    day = datetime.date(2020, 1, 2)
+    clock = datetime.time(3, 4)
+
+    assert Schema(AsDatetime())(dt) is dt
+    assert Schema(AsDate())(day) is day
+    assert Schema(AsTime())(clock) is clock
+
+
+def test_asdate_rejects_a_datetime() -> None:
+    """A datetime carries a time, so a date field rejects it rather than truncating."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(AsDate())(datetime.datetime(2020, 1, 2, 3, 4))
+    assert isinstance(caught.value.errors[0], DateInvalid)
+
+
 def test_duration_passes_through_a_timedelta() -> None:
     """An existing timedelta is returned unchanged."""
     delta = datetime.timedelta(minutes=5)

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -169,6 +169,16 @@ def test_asdate_rejects_a_datetime() -> None:
     assert isinstance(caught.value.errors[0], DateInvalid)
 
 
+def test_asdatetime_require_timezone_applies_to_a_native_object() -> None:
+    """require_timezone still holds on the pass-through path: aware passes, naive rejects."""
+    aware = datetime.datetime(2020, 1, 2, 3, 4, tzinfo=datetime.UTC)
+    assert Schema(AsDatetime(require_timezone=True))(aware) is aware
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(AsDatetime(require_timezone=True))(datetime.datetime(2020, 1, 2, 3, 4))
+    assert isinstance(caught.value.errors[0], DatetimeInvalid)
+
+
 def test_duration_passes_through_a_timedelta() -> None:
     """An existing timedelta is returned unchanged."""
     delta = datetime.timedelta(minutes=5)


### PR DESCRIPTION
## Breaking change

None. The change is additive: the `As*` validators now accept a superset of what they did before (a native object as well as a string).

## Proposed change

`AsDatetime`, `AsDate`, and `AsTime` only parsed strings, so handing one a native `datetime`, `date`, or `time` object (exactly what a YAML or TOML loader produces) raised, even though the value was already the target type. They now return such a value as-is, so validating already-parsed data is not a spurious failure and the validators are idempotent (validate a value, feed it back in, same result).

`AsDate` still rejects a `datetime` on purpose. A `datetime` carries a time, so accepting it would mean silently dropping that time, the kind of quiet transformation this library avoids. It also matches the string path, which already rejects a date-with-time string (`date.fromisoformat("2020-01-01T12:00")` raises), so the same logical input behaves the same whether it arrives as a string or an object. If you have a `datetime` and want the date, `.date()` is explicit.

The `require_timezone` check on `AsDatetime` still applies to a passed-through value, so a naive `datetime` is rejected the same as a naive parsed one.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
