### PR TITLE
Check an Annotated base type on the result, not the input

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -127,11 +127,16 @@ schema({"name": "ada"})  # User(name='ada')
 ```
 
 The same rule can live on the field itself with `Annotated`. The first argument
-is the type, and any callable after it is applied as a validator, in order, after
-the type check. This keeps the constraint next to the field instead of in a
-separate map, and it composes inside containers (`list[Annotated[int, Range(min=1)]]`
-checks every element). Metadata that is not callable is left alone, so an
-`Annotated` value you share with another tool passes through untouched.
+is the type and any callable after it is applied as a validator, in order. The
+type is checked on the result, not the raw input, so the annotation says what the
+field _is_: a coercer runs first and the type confirms what it produced.
+`Annotated[datetime, AsDatetime()]` accepts the string, parses it, and confirms a
+`datetime`, keeping the field honestly typed instead of annotating `str` and hiding
+the real type in the validator. This keeps the constraint next to the field instead
+of in a separate map, and it composes inside containers
+(`list[Annotated[int, Range(min=1)]]` checks every element). Metadata that is not
+callable is left alone, so an `Annotated` value you share with another tool passes
+through untouched.
 
 ```python
 from dataclasses import dataclass
@@ -148,6 +153,26 @@ class User:
 
 schema = DataclassSchema(User)
 schema({"name": "ada", "age": 30})  # User(name='ada', age=30)
+```
+
+Because the type checks the result, a coercer produces the annotated type while the
+field stays honestly typed:
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Annotated
+
+from probatio import DataclassSchema, AsDatetime
+
+
+@dataclass
+class Event:
+    when: Annotated[datetime, AsDatetime()]
+
+
+DataclassSchema(Event)({"when": "2020-01-01T12:00"})
+# Event(when=datetime.datetime(2020, 1, 1, 12, 0))
 ```
 
 A `NewType` is followed to the type it wraps, so a field typed

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -21,11 +21,15 @@ validates all the way down. The names match the upstream draft so code written
 against it keeps working if it lands.
 
 A field annotation may also carry its own validators inline with
-``Annotated[X, validator, ...]``: ``X`` is validated first, then each callable in
-the metadata is applied through ``All`` (non-callable metadata is left for other
-tools). A ``NewType`` is followed to the type it wraps. Both are an alternative to
-the ``additional_constraints`` side mapping, with the constraint living next to
-the field it guards.
+``Annotated[X, validator, ...]``: each callable in the metadata is applied through
+``All`` in order (non-callable metadata is left for other tools). When ``X`` is a plain
+type, its ``isinstance`` check runs on the *result*, so the type says what the field is
+rather than gating the raw input: ``Annotated[datetime, AsDatetime()]`` parses the
+string and confirms the result is a ``datetime``, keeping the field honestly typed. When
+``X`` itself coerces (a type registered to a validator, a nested schema), it runs first
+and the metadata layers on top. A ``NewType`` is followed to the type it wraps. Both are
+an alternative to the ``additional_constraints`` side mapping, with the constraint
+living next to the field it guards.
 """
 
 from __future__ import annotations
@@ -147,12 +151,22 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
         return _annotation_to_schema(annotation.__supertype__, self_refs)
 
     if get_origin(annotation) is Annotated:
-        # Treat callable Annotated metadata as extra validators. Other metadata is
-        # for other tools and is ignored here.
+        # Callable Annotated metadata are extra validators; other metadata is for
+        # other tools and is ignored here.
         base, *meta = get_args(annotation)
         base_schema = _annotation_to_schema(base, self_refs)
         extras = [item for item in meta if callable(item)]
-        return All(base_schema, *extras) if extras else base_schema
+        if not extras:
+            return base_schema
+        # A bare type compiles to an ``isinstance`` check: an assertion about what the
+        # field *is*, so it runs on the result, after the metadata. A coercing hint
+        # (``Annotated[int, Coerce(int)]``, ``Annotated[datetime, AsDatetime()]``) then
+        # produces the value the type confirms, keeping the field honestly typed. A base
+        # that is itself a validator (a registry coercer, a nested schema, a container)
+        # is a producer and stays first, so a constraint still layers on top (ADR-008).
+        if isinstance(base_schema, type):
+            return All(*extras, base_schema)
+        return All(base_schema, *extras)
 
     if _is_dataclass_type(annotation):
         if annotation in self_refs:

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -35,6 +35,7 @@ living next to the field it guards.
 from __future__ import annotations
 
 import dataclasses
+import enum
 import types
 from collections.abc import (
     Mapping,
@@ -130,6 +131,22 @@ def _is_dataclass_type(annotation: TypingAny) -> bool:
     return isinstance(annotation, type) and dataclasses.is_dataclass(annotation)
 
 
+def _base_asserts_the_result(base_schema: TypingAny) -> bool:
+    """Whether an ``Annotated`` base only *checks* the value (so it runs last).
+
+    A plain type compiles to an ``isinstance`` assertion about what the field is, so it
+    runs on the metadata's result. An ``Enum`` class and a type carrying a
+    ``__probatio_validate__`` protocol (ADR-007) are bare types too, but they *coerce* a
+    raw value into the validated form when compiled, so they are producers and run first
+    (like a registry coercer, a nested schema, or a container).
+    """
+    return (
+        isinstance(base_schema, type)
+        and not issubclass(base_schema, enum.Enum)
+        and not callable(getattr(base_schema, "__probatio_validate__", None))
+    )
+
+
 def _annotation_to_schema(  # noqa: PLR0911, PLR0912
     annotation: TypingAny,
     self_refs: dict[type, _RecursiveSchemaRef],
@@ -158,13 +175,16 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
         extras = [item for item in meta if callable(item)]
         if not extras:
             return base_schema
-        # A bare type compiles to an ``isinstance`` check: an assertion about what the
+        # A plain type compiles to an ``isinstance`` check: an assertion about what the
         # field *is*, so it runs on the result, after the metadata. A coercing hint
         # (``Annotated[int, Coerce(int)]``, ``Annotated[datetime, AsDatetime()]``) then
         # produces the value the type confirms, keeping the field honestly typed. A base
-        # that is itself a validator (a registry coercer, a nested schema, a container)
-        # is a producer and stays first, so a constraint still layers on top (ADR-008).
-        if isinstance(base_schema, type):
+        # that *produces* the value runs first, so a constraint layers on top of the
+        # produced value (ADR-008): a registry coercer, a nested schema, a container, and
+        # also a bare type that coerces when compiled (an ``Enum`` class, or a type with a
+        # ``__probatio_validate__`` protocol from ADR-007, both turn a raw value into the
+        # validated form).
+        if _base_asserts_the_result(base_schema):
             return All(*extras, base_schema)
         return All(base_schema, *extras)
 

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -8,6 +8,7 @@ additional constraints, instance construction, and the error paths.
 from __future__ import annotations
 
 import datetime
+import enum
 import typing
 from collections.abc import (  # noqa: TC003 - resolved at runtime by get_type_hints
     Iterable,
@@ -25,6 +26,7 @@ from probatio import (
     AsDatetime,
     Coerce,
     DataclassSchema,
+    In,
     Length,
     MultipleInvalid,
     Range,
@@ -414,13 +416,8 @@ def test_annotated_applies_an_inline_validator() -> None:
     assert caught.value.errors[0].path == ["count"]
 
 
-def test_annotated_metadata_coerces_before_the_type_check() -> None:
-    """A coercing validator runs first, so the type describes the result, not the input.
-
-    ``Annotated[int, Coerce(int)]`` accepts ``"5"``: the coercer produces an int, and
-    the base type confirms the result. The annotation stays honest (the field is an
-    ``int``) instead of forcing the source type into the annotation.
-    """
+def test_annotated_metadata_coerces_before_a_plain_type_check() -> None:
+    """A coercer runs first and the plain-type base confirms the result, honestly typed."""
 
     @dataclass
     class Coerced:
@@ -434,23 +431,80 @@ def test_annotated_metadata_coerces_before_the_type_check() -> None:
     assert result.when == datetime.datetime(2020, 1, 1, 12, 0)
 
 
-def test_annotated_type_is_enforced_on_the_result() -> None:
-    """The base type is the last word: a validator that yields the wrong type fails.
-
-    ``Annotated[int, Coerce(str)]`` claims the field is an int but coerces to a string,
-    so the result does not match the annotation and validation rejects it, rather than
-    silently storing a string in an int field.
-    """
+def test_annotated_plain_type_is_enforced_on_the_result() -> None:
+    """A validator that yields the wrong type fails; the base type is the last word."""
 
     @dataclass
     class Mismatch:
-        """A field whose validator contradicts its declared type."""
+        """A field whose validator (Coerce(str)) contradicts its declared int type."""
 
         n: Annotated[int, Coerce(str)]
 
     with pytest.raises(MultipleInvalid) as caught:
         DataclassSchema(Mismatch)({"n": 5})
     assert caught.value.errors[0].path == ["n"]
+
+
+class _AnnColor(enum.Enum):
+    """A small enum whose class coerces a string to a member (Annotated base test)."""
+
+    RED = "red"
+    BLUE = "blue"
+
+
+class _AnnSlug:
+    """A type that validates and normalizes itself, for the Annotated self-validate test."""
+
+    def __init__(self, value: str) -> None:
+        """Store the normalized value."""
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        """Compare by the stored value."""
+        return isinstance(other, _AnnSlug) and self.value == other.value
+
+    __hash__ = None  # type: ignore[assignment]
+
+    @classmethod
+    def __probatio_validate__(cls, value: Any) -> _AnnSlug:
+        """Accept a value, storing it lower-cased."""
+        return cls(str(value).lower())
+
+
+def _require_slug(value: Any) -> _AnnSlug:
+    """Use-site check that only passes a produced ``_AnnSlug``, not the raw string."""
+    if not isinstance(value, _AnnSlug):
+        # ValueError (not TypeError) is the validator convention probatio turns into
+        # an Invalid; the check proves the base coerced to a Slug before this ran.
+        message = "expected a produced _AnnSlug"
+        raise ValueError(message)  # noqa: TRY004
+    return value
+
+
+@dataclass
+class _EnumShirt:
+    """An enum-base Annotated field: the enum coerces before the In check runs."""
+
+    color: Annotated[_AnnColor, In([_AnnColor.RED, _AnnColor.BLUE])]
+
+
+@dataclass
+class _SelfValidatingDoc:
+    """A __probatio_validate__ base Annotated field: it coerces before the metadata."""
+
+    slug: Annotated[_AnnSlug, _require_slug]
+
+
+def test_annotated_enum_base_coerces_first_then_the_constraint_runs() -> None:
+    """An Enum base coerces the raw value first, so a use-site constraint sees the member."""
+    assert DataclassSchema(_EnumShirt)({"color": "red"}).color is _AnnColor.RED
+
+
+def test_annotated_self_validating_base_coerces_first() -> None:
+    """A __probatio_validate__ base (ADR-007) coerces first, so the metadata sees the result."""
+    assert DataclassSchema(_SelfValidatingDoc)({"slug": "HELLO"}).slug == _AnnSlug(
+        "hello"
+    )
 
 
 def test_annotated_applies_every_validator_in_order() -> None:

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -7,6 +7,7 @@ additional constraints, instance construction, and the error paths.
 
 from __future__ import annotations
 
+import datetime
 import typing
 from collections.abc import (  # noqa: TC003 - resolved at runtime by get_type_hints
     Iterable,
@@ -21,6 +22,8 @@ import pytest
 
 from probatio import (
     ALLOW_EXTRA,
+    AsDatetime,
+    Coerce,
     DataclassSchema,
     Length,
     MultipleInvalid,
@@ -402,13 +405,52 @@ class AnnotatedFields:
 
 
 def test_annotated_applies_an_inline_validator() -> None:
-    """A callable in Annotated metadata runs after the base type check."""
+    """A callable in Annotated metadata is applied, and the type checks the result."""
     schema = DataclassSchema(AnnotatedFields)
     assert schema({"count": 3}).count == 3
 
     with pytest.raises(MultipleInvalid) as caught:
         schema({"count": -1})
     assert caught.value.errors[0].path == ["count"]
+
+
+def test_annotated_metadata_coerces_before_the_type_check() -> None:
+    """A coercing validator runs first, so the type describes the result, not the input.
+
+    ``Annotated[int, Coerce(int)]`` accepts ``"5"``: the coercer produces an int, and
+    the base type confirms the result. The annotation stays honest (the field is an
+    ``int``) instead of forcing the source type into the annotation.
+    """
+
+    @dataclass
+    class Coerced:
+        """Fields whose declared type is the result, reached through a coercer."""
+
+        n: Annotated[int, Coerce(int)]
+        when: Annotated[datetime.datetime, AsDatetime()]
+
+    result = DataclassSchema(Coerced)({"n": "5", "when": "2020-01-01T12:00"})
+    assert result.n == 5
+    assert result.when == datetime.datetime(2020, 1, 1, 12, 0)
+
+
+def test_annotated_type_is_enforced_on_the_result() -> None:
+    """The base type is the last word: a validator that yields the wrong type fails.
+
+    ``Annotated[int, Coerce(str)]`` claims the field is an int but coerces to a string,
+    so the result does not match the annotation and validation rejects it, rather than
+    silently storing a string in an int field.
+    """
+
+    @dataclass
+    class Mismatch:
+        """A field whose validator contradicts its declared type."""
+
+        n: Annotated[int, Coerce(str)]
+
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(Mismatch)({"n": 5})
+    assert caught.value.errors[0].path == ["n"]
 
 
 def test_annotated_applies_every_validator_in_order() -> None:


### PR DESCRIPTION
## Breaking change

None. This only touches Probatio's own `Annotated`-on-dataclass handling (voluptuous has no such feature), and it is a pure widening: field annotations that were rejected before now validate, and nothing that validated before changes.

## Proposed change

A dataclass/TypedDict field annotated `Annotated[X, validator]` compiled to `All(X, validator)`, so the bare type `X` gated the raw input before the metadata ran. Two problems followed:

- The natural `Annotated[datetime, AsDatetime()]` was rejected: the `datetime` `isinstance` check fired on the incoming string before `AsDatetime` could parse it. To coerce a field you had to lie about its type (`Annotated[str, AsDatetime()]`) or register the type globally.
- The order did not even guarantee the annotation. `Annotated[int, Coerce(str)]` ran the `int` check on the input, then coerced to a `str`, silently storing a `str` in a field annotated `int`.

When the base is a plain type, the metadata now runs first and the type is checked on the **result**, so the annotation describes what the field *is*: a coercer produces the value the type then confirms, and the field stays honestly typed. A base that is itself a producer (a registry coercer, a nested schema, a container) still runs first, so a use-site constraint layers on top of it (ADR-008 precedence is preserved). The change lives at one compile site (`_annotation_to_schema`).

The result: `when: Annotated[datetime, AsDatetime()]` works, honestly typed, per-field, no global registration, and the latent wrong-type bug is fixed.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: None
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
