### PR TITLE
Describe a FromEpoch field as a number, not an integer

### DIFF
--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -386,7 +386,9 @@ def _serialize_constraint(node: Any) -> dict[str, Any] | None:
         return field
 
     if isinstance(node, FromEpoch):
-        # A Unix timestamp arrives as an integer; the datetime is internal.
-        return {"type": "integer"}
+        # A Unix timestamp arrives as a number (``FromEpoch`` takes an int or a
+        # fractional-second float); the datetime is internal. The field vocabulary
+        # has no "number", so "float" is the type that accepts both.
+        return {"type": "float"}
 
     return None

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -350,9 +350,10 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     if temporal is not None:
         return temporal
 
-    # A Unix timestamp is an integer on the wire; the datetime is internal.
+    # A Unix timestamp on the wire is a number (``FromEpoch`` takes an int or a
+    # fractional-second float); the datetime is internal.
     if isinstance(node, FromEpoch):
-        return {"type": "integer"}
+        return {"type": "number"}
 
     if isinstance(node, Unique):
         return {"uniqueItems": True}

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -330,8 +330,9 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
         return {"type": "string", "format": "date-time"}
 
     if isinstance(node, FromEpoch):
-        # A Unix timestamp is an integer on the wire; the datetime is internal.
-        return {"type": "integer"}
+        # A Unix timestamp on the wire is a number (``FromEpoch`` takes an int or a
+        # fractional-second float); the datetime is internal.
+        return {"type": "number"}
     if isinstance(node, Match):
         return {"pattern": node.pattern.pattern}
     if isinstance(node, In):

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -94,9 +94,9 @@ def test_as_parser_with_format_serializes_the_format() -> None:
     }
 
 
-def test_epoch_serializes_as_an_integer_field() -> None:
-    """FromEpoch takes an integer timestamp on the wire, so it serializes as integer."""
-    assert serialize(Schema(FromEpoch())) == {"type": "integer"}
+def test_epoch_serializes_as_a_float_field() -> None:
+    """FromEpoch takes an int or fractional-second float, so it serializes as float."""
+    assert serialize(Schema(FromEpoch())) == {"type": "float"}
 
 
 def test_bare_key_is_not_optional() -> None:

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -418,7 +418,7 @@ def test_as_datetime_round_trips_to_the_string_datetime() -> None:
         (Port(), {"type": "integer", "minimum": 1, "maximum": 65535}),
         (Percentage(), {"type": "number", "minimum": 0, "maximum": 100}),
         (MultipleOf(5), {"multipleOf": 5}),
-        (FromEpoch(), {"type": "integer"}),
+        (FromEpoch(), {"type": "number"}),
     ],
 )
 def test_new_validators_export(validator: object, expected: dict) -> None:

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -307,7 +307,7 @@ def test_bare_callable_with_unresolvable_annotation_is_open_schema() -> None:
         (Port(), {"type": "integer", "minimum": 1, "maximum": 65535}),
         (Percentage(), {"type": "number", "minimum": 0, "maximum": 100}),
         (MultipleOf(5), {"type": "number", "multipleOf": 5}),
-        (FromEpoch(), {"type": "integer"}),
+        (FromEpoch(), {"type": "number"}),
     ],
 )
 def test_new_validators_to_openapi(validator: object, expected: dict) -> None:


### PR DESCRIPTION
## What

`FromEpoch` parses a Unix timestamp into a `datetime` and accepts an `int` **or** a fractional-second `float` (`time.time()` returns a float, sub-second precision is kept, and `test_epoch_accepts_a_float` covers it). The three codecs advertised the input as an `integer`, so a schema generated from a `FromEpoch` field wrongly rejected a valid fractional timestamp.

## Change

- `jsonschema.py` and `openapi.py`: `{"type": "integer"}` becomes `{"type": "number"}`.
- `fields.py`: becomes `{"type": "float"}` (the field-list vocabulary has no "number"; "float" is the type that accepts both).

## Notes

- No snapshot regeneration: no `.ambr` case uses `FromEpoch`, only the three direct-assertion tests, which are updated.
- Widening, not breaking: `number` is a superset of `integer`, so an existing integer timestamp still validates.
- Full gate green (`just check`, 100% line+branch coverage).