### PR TITLE
Add a Key spec for facets on Annotated dataclass/TypedDict fields

### DIFF
--- a/adr/013-markers-on-annotated-fields.md
+++ b/adr/013-markers-on-annotated-fields.md
@@ -1,0 +1,96 @@
+# ADR-013: A field-metadata spec for Annotated dataclass and TypedDict fields
+
+**Date**: 2026-07-02
+**Status**: Accepted
+
+**Context**: The annotation-driven builders (`create_dataclass_schema`,
+`create_typeddict_schema`) generate the mapping _key_ themselves: a field becomes
+`Required(name)` or `Optional(name, default=...)`, inferred from the field's
+default (or, for a TypedDict, from `Required`/`NotRequired`/`total`). Everything a
+field annotation carries is _value_-level; there is no way to give a field a key
+facet the plain type cannot express: redact it (`Secret`), accept it under other
+names (`Alias`), forbid it, group it, or override its presence.
+
+The obvious move, put the markers straight into `Annotated[..., Secret()]`, does
+not work. Markers are mapping keys: they hash and compare by their key so they
+share a dict slot (`Required("x") == "x"`, needed for `extend`). Reused as field
+metadata, a marker's key slot holds the field name (unknown until the builder
+runs), so it is either unset or, worse, holds config (`Alias`'s first alias). Two
+such markers then compare equal and collapse in typing's `Annotated` cache, so
+`Annotated[str, Secret()]` and `Annotated[str, Optional()]`, or two aliases that
+share a leading name, silently become one. Working around it meant either changing
+marker equality (breaking the dict-key semantics `extend` relies on) or a keyless
+construction form for every arg-carrying marker. Both fight the marker system.
+
+The precedent settles it. Pydantic uses a `Field(...)` object assigned as a
+default (`x: str = Field(...)`), which a TypedDict key cannot take. Mashumaro uses
+a dedicated `Annotated[int, Alias("id")]` type that is _not_ a mapping key, which
+is why it never hits the cache problem. Multiple aliases go in a container
+(pydantic's `AliasChoices`).
+
+**Decision**: A small `Key` spec placed in a field's `Annotated` metadata. It is
+plain data, never a mapping key, so it cannot collide in the `Annotated` cache and
+needs no changes to marker equality. The builder reads it and generates the real
+marker chain (`Secret`, `Alias`, ...) with the field name as the key.
+
+```python
+class Login(TypedDict):
+    user_name: Annotated[str, Key(alias=["user-name", "userName"])]
+    password:  Annotated[str, Key(secret=True)]
+    token:     Annotated[str, Key(exclusive="auth")]
+```
+
+The same spelling works on a dataclass. Plain dict schemas keep using the markers
+directly and are untouched, including `Alias`'s multi-alias form
+(`{Alias("user_name", "user-name", "userName"): str}`).
+
+`Key` carries the role-defining facets (`alias`, `forbidden`, `remove`,
+`inclusive`, `exclusive`, mutually exclusive), the `secret` modifier that layers on
+any of them, a `required` override, and `accept_canonical`/`description`/`msg`. It
+carries no `default`: a field's default has one source (the dataclass field, or a
+TypedDict's absence), so validation and `construct()` never diverge on it.
+
+**Rationale**:
+
+- It works for TypedDict, which is the whole point and where pydantic's
+  default-value `Field` cannot reach. `Annotated` metadata is legal in a TypedDict
+  body; a default value is not.
+- It cannot hit the marker-identity / `Annotated`-cache trap, because a `Key` is
+  never a mapping key. That failure class is removed by construction rather than
+  defended against, and marker equality stays exactly as it was.
+- One vocabulary per surface: dict schemas keep markers, annotated fields get a
+  spec, mirroring how pydantic (`Field`/`AliasChoices`) and mashumaro (`Alias`)
+  keep field metadata separate from any key object.
+
+**Consequences**:
+
+- **Normalization is one step.** The builder turns `(inferred presence, Key)` into
+  a single keyed marker chain, then reuses the ordinary compile path. `secret`
+  wraps the base; the role facets pick the base; `required` overrides the inferred
+  presence.
+- **One default source, so validate and construct agree.** Because a `Key` carries no
+  default, a field's default has a single source (the dataclass field, or a TypedDict's
+  absence). There are no marker-only defaults for the validating call and `construct()`
+  to diverge on.
+- **Construction constraints are explicit on a dataclass.** A dataclass constructor
+  needs a value for every field, so a field that can be absent needs a default: a
+  `forbidden`/`remove` field always (it is never taken from the input), and an
+  `optional`/`alias`/group field unless it is required. Without one it is a
+  contradiction and raises `SchemaError`. A TypedDict constructs nothing, so none of
+  this applies there.
+- **A field absent from the validated mapping keeps the dataclass's own default,
+  untouched.** `optional`/`alias`/`inclusive`/`exclusive`-when-the-group-is-empty carry
+  their default into the validated mapping, so the value schema validates and coerces
+  it. But a `forbidden` field (always absent), a `remove` field (always dropped), and an
+  unselected `exclusive` member (absent because a sibling won) leave no entry, so
+  construction falls back to the raw dataclass default, which the schema never validates
+  or coerces. This is a boundary, not a bug: a dataclass's construction defaults are
+  Python-level, outside the schema, which validates _input_, and a value the schema
+  keeps out of the input is not input. Write an already-typed default for such a field;
+  a wrong-typed one is a dataclass-level type error a type-checker flags. A build-time
+  check cannot close this soundly (a default factory or a subtype coercion produces the
+  real value only at construction), so it is left to the type-checker and this note.
+- **Two spellings, one meaning.** The dict-schema `{Secret("password"): str}` and
+  the field `Annotated[str, Key(secret=True)]` produce the same key. This is a small
+  duplication of surface, accepted so each context keeps the idiom that fits it and
+  neither has to distort for the other.

--- a/adr/README.md
+++ b/adr/README.md
@@ -2,16 +2,17 @@
 
 Each record captures what was chosen, the alternatives considered, and why.
 
-| ADR                                                         | Title                                            |
-| ----------------------------------------------------------- | ------------------------------------------------ |
-| [ADR-001](001-clean-room-reimplementation-of-voluptuous.md) | Clean-room reimplementation of voluptuous        |
-| [ADR-002](002-mit-license.md)                               | MIT license                                      |
-| [ADR-003](003-astro-starlight-for-documentation.md)         | Astro Starlight for documentation                |
-| [ADR-004](004-single-validation-engine.md)                  | A single validation engine (no codegen)          |
-| [ADR-005](005-pure-python-no-required-dependencies.md)      | Pure Python, no required runtime dependencies    |
-| [ADR-006](006-python-support-floor.md)                      | Python support floor (requires-python >=3.12)    |
-| [ADR-007](007-self-validation-protocol.md)                  | A self-validation protocol for types             |
-| [ADR-008](008-type-to-validator-registry.md)                | A type-to-validator registry for schema builders |
-| [ADR-009](009-call-time-validation-context.md)              | Call-time validation context                     |
-| [ADR-011](011-opt-in-compiled-schema.md)                    | An adaptive compiled schema variant (codegen)    |
-| [ADR-012](012-trusted-construction-without-validation.md)   | Trusted construction without validation          |
+| ADR                                                         | Title                                                          |
+| ----------------------------------------------------------- | -------------------------------------------------------------- |
+| [ADR-001](001-clean-room-reimplementation-of-voluptuous.md) | Clean-room reimplementation of voluptuous                      |
+| [ADR-002](002-mit-license.md)                               | MIT license                                                    |
+| [ADR-003](003-astro-starlight-for-documentation.md)         | Astro Starlight for documentation                              |
+| [ADR-004](004-single-validation-engine.md)                  | A single validation engine (no codegen)                        |
+| [ADR-005](005-pure-python-no-required-dependencies.md)      | Pure Python, no required runtime dependencies                  |
+| [ADR-006](006-python-support-floor.md)                      | Python support floor (requires-python >=3.12)                  |
+| [ADR-007](007-self-validation-protocol.md)                  | A self-validation protocol for types                           |
+| [ADR-008](008-type-to-validator-registry.md)                | A type-to-validator registry for schema builders               |
+| [ADR-009](009-call-time-validation-context.md)              | Call-time validation context                                   |
+| [ADR-011](011-opt-in-compiled-schema.md)                    | An adaptive compiled schema variant (codegen)                  |
+| [ADR-012](012-trusted-construction-without-validation.md)   | Trusted construction without validation                        |
+| [ADR-013](013-markers-on-annotated-fields.md)               | A field-metadata spec for Annotated dataclass/TypedDict fields |

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -205,6 +205,8 @@ works for one), emitting it under the field name; `accept_canonical=False` makes
 a strict rename. `Key(inclusive="grp")` / `Key(exclusive="grp")` group fields the
 way the [dict form](/guides/dict-schemas-and-markers/) does. `Key(required=True)`
 (or `required=False`) overrides the presence the field's default would imply.
+`required=False` marks a field optional, so on a dataclass it still needs a
+default for the constructor to fall back on; without one it raises `SchemaError`.
 
 `Key` is a field-only spec; a plain dict schema keeps using the markers directly
 (`{Secret("password"): str}`, `{Alias("user_name", "user-name"): str}`). It works

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -178,6 +178,52 @@ DataclassSchema(Event)({"when": "2020-01-01T12:00"})
 A `NewType` is followed to the type it wraps, so a field typed
 `UserId = NewType("UserId", int)` validates as an `int`.
 
+## Key facets on fields
+
+A plain type says what a field _is_. To give a field a key facet, redact it,
+accept it under other names, forbid it, group it, add `Key` to its `Annotated`
+metadata. It sits next to any value validators; the two do not interfere.
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from probatio import DataclassSchema, Key, Length
+
+
+@dataclass
+class Account:
+    name: str
+    password: Annotated[str, Key(secret=True), Length(min=8)]  # redacted, length-checked
+    user_name: Annotated[str, Key(alias=["user-name", "userName"])] = ""  # accept aliases
+    is_admin: Annotated[bool, Key(forbidden=True)] = False  # reject if the caller sends it
+```
+
+`Key(secret=True)` redacts the field's value in validation errors.
+`Key(alias=[...])` accepts the field under alternate input names (a bare string
+works for one), emitting it under the field name; `accept_canonical=False` makes it
+a strict rename. `Key(inclusive="grp")` / `Key(exclusive="grp")` group fields the
+way the [dict form](/guides/dict-schemas-and-markers/) does. `Key(required=True)`
+(or `required=False`) overrides the presence the field's default would imply.
+
+`Key` is a field-only spec; a plain dict schema keeps using the markers directly
+(`{Secret("password"): str}`, `{Alias("user_name", "user-name"): str}`). It works
+the same on a [TypedDict](/guides/typeddict/).
+
+`forbidden` and `remove` make a key contribute nothing to the result, so on a
+dataclass (whose constructor needs a value for every field) such a field must have
+a default; without one it raises `SchemaError`. A TypedDict constructs nothing, so
+there they need no default.
+
+One boundary to know: a field the schema keeps out of the input, a `forbidden`
+field, a `remove` field, or an unselected `exclusive` member, takes the dataclass's
+own default exactly as declared, without validation or coercion (an `optional` or
+selected field carries its default through the schema and is coerced). The schema
+validates input, and these values are not input, so write an already-typed default
+for such a field; a wrong-typed one is a type error your type-checker flags. See
+[ADR-013](https://github.com/frenck/probatio/blob/main/adr/013-markers-on-annotated-fields.md)
+for the model.
+
 ## The functional form and the helper
 
 `create_dataclass_schema(dataclass_type, additional_constraints=None)` builds the

--- a/docs/src/content/docs/guides/typeddict.md
+++ b/docs/src/content/docs/guides/typeddict.md
@@ -178,9 +178,14 @@ guide](/guides/dataclasses/) covers the rest, and it all behaves the same with a
   types, with the same depth guard.
 - [Discriminated unions](/guides/dataclasses/#discriminated-unions) over a shared
   literal tag.
+- [Key facets on fields](/guides/dataclasses/#key-facets-on-fields): `Key(...)` in
+  the `Annotated` metadata to redact, alias, group, forbid, or override the presence
+  of a field.
 
 The one difference is the result: a dataclass schema constructs an instance, a
-TypedDict schema returns the validated dict.
+TypedDict schema returns the validated dict. Because nothing is constructed, a
+`TypedDict` also accepts `Key(forbidden=True)`/`Key(remove=True)` fields with no
+default (they simply shape the validated dict), where a dataclass would need one.
 
 ## Limits
 

--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -90,6 +90,7 @@ from probatio.error import (
     ValueInvalid,
     YamlInvalid,
 )
+from probatio.fields import Key
 from probatio.markers import (
     UNDEFINED,
     Alias,
@@ -430,6 +431,7 @@ __all__ = [
     "IsTrue",
     "JSONString",
     "JsonInvalid",
+    "Key",
     "Latitude",
     "Length",
     "LengthInvalid",

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -451,6 +451,20 @@ def _key_from_spec(  # noqa: PLR0913
         return Required(name) if inferred_required else Optional(name, default=default)
 
     _check_facets(spec, name)
+    if spec.required is not None and (
+        spec.forbidden or spec.remove or spec.inclusive is not None
+    ):
+        # ``required`` governs presence; it is meaningless for a forbidden or removed
+        # field (never taken from the input) or an inclusive group (all-or-none).
+        target = (
+            "Forbidden"
+            if spec.forbidden
+            else "Remove"
+            if spec.remove
+            else "an inclusive group"
+        )
+        message = f"field {name!r}: required does not apply to {target}"
+        raise SchemaError(message)
     required = spec.required if spec.required is not None else inferred_required
 
     if spec.forbidden:
@@ -475,12 +489,6 @@ def _key_from_spec(  # noqa: PLR0913
             name, "Alias", constructs=constructs, present=required, has=has_default
         )
     elif spec.inclusive is not None:
-        if spec.required is not None:
-            message = (
-                f"field {name!r}: required does not apply to an inclusive group "
-                "(the group is all-or-none)"
-            )
-            raise SchemaError(message)
         base = Inclusive(
             name,
             spec.inclusive,
@@ -816,10 +824,16 @@ def _build_constructor(
         annotation = _field_annotation(hints.get(field.name, TypingAny))
         spec = _field_key_spec(_field_annotation(hints_extras.get(field.name)))
         if spec is not None and (
-            spec.alias is not None or spec.remove or spec.forbidden
+            spec.alias is not None
+            or spec.remove
+            or spec.forbidden
+            or spec.inclusive is not None
+            or spec.exclusive is not None
+            or spec.required is not None
         ):
-            # These change which key the field reads from (or drop it), which the
-            # flat by-name reader cannot reproduce; leave them to the validating path.
+            # These either change which key the field reads from (or drop it) or add a
+            # presence rule the flat by-name reader cannot reproduce; leave them to the
+            # validating path.
             return None
 
         expr = _value_expr(

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -62,7 +62,19 @@ from probatio._codegen import compile_mapping
 from probatio._engine import _MappingValidator
 from probatio._type_registry import resolve_type_validator
 from probatio.error import SchemaError
-from probatio.markers import Optional, Required
+from probatio.fields import Key
+from probatio.markers import (
+    UNDEFINED,
+    Alias,
+    Exclusive,
+    Forbidden,
+    Inclusive,
+    Optional,
+    Remove,
+    Required,
+    Secret,
+    resolve_key,
+)
 from probatio.schema import (
     _INHERIT_CONTEXT,
     PREVENT_EXTRA,
@@ -390,6 +402,151 @@ def _field_annotation(hint: TypingAny) -> TypingAny:
     return hint.type if isinstance(hint, dataclasses.InitVar) else hint
 
 
+def _field_key_spec(annotation: TypingAny) -> Key | None:
+    """Return the ``Key`` spec in a field annotation's ``Annotated`` metadata, or None."""
+    if get_origin(annotation) is not Annotated:
+        return None
+    _, *meta = get_args(annotation)
+    specs = [item for item in meta if isinstance(item, Key)]
+    if len(specs) > 1:
+        message = "a field carries more than one Key spec"
+        raise SchemaError(message)
+    return specs[0] if specs else None
+
+
+def _check_facets(spec: Key, name: TypingAny) -> None:
+    """Reject a ``Key`` that sets two role-defining facets at once.
+
+    ``alias``/``forbidden``/``remove``/``inclusive``/``exclusive`` define what the
+    key *is* and are mutually exclusive; ``secret`` layers on top and is exempt.
+    """
+    facets = [
+        facet
+        for facet in ("alias", "forbidden", "remove", "inclusive", "exclusive")
+        if getattr(spec, facet) not in (None, False)
+    ]
+    if len(facets) > 1:
+        message = f"field {name!r} Key sets conflicting facets: {', '.join(facets)}"
+        raise SchemaError(message)
+
+
+def _key_from_spec(  # noqa: PLR0913
+    name: TypingAny,
+    spec: Key | None,
+    *,
+    inferred_required: bool,
+    default: TypingAny,
+    has_default: bool,
+    constructs: bool,
+) -> TypingAny:
+    """Turn a field's ``Key`` spec and inferred presence into one mapping key (ADR-013).
+
+    ``inferred_required`` is the presence the field implies on its own (no default
+    for a dataclass, ``total``/``Required`` for a TypedDict). ``default`` is the
+    marker ``default=`` argument the field's own default supplies (``UNDEFINED`` when
+    it has none). ``constructs`` is true for a dataclass, whose constructor needs a
+    value for every field.
+    """
+    if spec is None:
+        return Required(name) if inferred_required else Optional(name, default=default)
+
+    _check_facets(spec, name)
+    required = spec.required if spec.required is not None else inferred_required
+
+    if spec.forbidden:
+        _guard_never_supplied(name, "Forbidden", constructs=constructs, has=has_default)
+        base: TypingAny = Forbidden(name, msg=spec.msg, description=spec.description)
+    elif spec.remove:
+        _guard_never_supplied(name, "Remove", constructs=constructs, has=has_default)
+        base = Remove(name)
+    elif spec.alias is not None:
+        names = (spec.alias,) if isinstance(spec.alias, str) else tuple(spec.alias)
+        base = Alias(
+            name,
+            *names,
+            accept_canonical=spec.accept_canonical,
+            required=required,
+            # A required alias is always supplied, so it carries no default.
+            default=UNDEFINED if required else default,
+            msg=spec.msg,
+            description=spec.description,
+        )
+        _guard_absent(
+            name, "Alias", constructs=constructs, present=required, has=has_default
+        )
+    elif spec.inclusive is not None:
+        if spec.required is not None:
+            message = (
+                f"field {name!r}: required does not apply to an inclusive group "
+                "(the group is all-or-none)"
+            )
+            raise SchemaError(message)
+        base = Inclusive(
+            name,
+            spec.inclusive,
+            msg=spec.msg,
+            default=default,
+            description=spec.description,
+        )
+        _guard_absent(
+            name, "Inclusive", constructs=constructs, present=False, has=has_default
+        )
+    elif spec.exclusive is not None:
+        # ``required`` names the group requirement (one member present), not this
+        # member's presence. A required group must not be satisfied by a default (that
+        # would neutralize ``required``), so it gets none; the non-selected member then
+        # takes its dataclass default at construction. An optional group keeps the
+        # default, which fills (and coerces) a member when the group is empty.
+        base = Exclusive(
+            name,
+            spec.exclusive,
+            msg=spec.msg,
+            description=spec.description,
+            required=bool(spec.required),
+            default=UNDEFINED if spec.required else default,
+        )
+        _guard_absent(
+            name, "Exclusive", constructs=constructs, present=False, has=has_default
+        )
+    elif required:
+        base = Required(name, msg=spec.msg, description=spec.description)
+    else:
+        base = Optional(
+            name, default=default, msg=spec.msg, description=spec.description
+        )
+        _guard_absent(
+            name, "Optional", constructs=constructs, present=False, has=has_default
+        )
+
+    if spec.secret:
+        base = Secret(base, msg=spec.msg, description=spec.description)
+    return base
+
+
+def _guard_never_supplied(
+    name: TypingAny, marker: str, *, constructs: bool, has: bool
+) -> None:
+    """Reject a Forbidden/Remove dataclass field with no default (never supplied)."""
+    if constructs and not has:
+        message = (
+            f"{marker} field {name!r} needs a default, "
+            "since it is never taken from the input"
+        )
+        raise SchemaError(message)
+
+
+def _guard_absent(
+    name: TypingAny, marker: str, *, constructs: bool, present: bool, has: bool
+) -> None:
+    """Reject a dataclass field that can be absent yet has no default to construct."""
+    if constructs and not present and not has:
+        message = (
+            f"{marker} field {name!r} needs a default: it can be absent from the "
+            "input, and the dataclass constructor needs a value"
+        )
+        raise SchemaError(message)
+
+
 def _field_mapping(
     dataclass_type: type,
     constraints: dict[str, TypingAny],
@@ -412,11 +569,23 @@ def _field_mapping(
             value_schema = All(value_schema, constraints[field.name])
 
         if field.default is not dataclasses.MISSING:
-            key: TypingAny = Optional(field.name, default=_constant(field.default))
+            default: TypingAny = _constant(field.default)
+            has_default = True
         elif field.default_factory is not dataclasses.MISSING:
-            key = Optional(field.name, default=field.default_factory)
+            default = field.default_factory
+            has_default = True
         else:
-            key = Required(field.name)
+            default = UNDEFINED
+            has_default = False
+
+        key = _key_from_spec(
+            field.name,
+            _field_key_spec(annotation),
+            inferred_required=not has_default,
+            default=default,
+            has_default=has_default,
+            constructs=True,
+        )
         mapping[key] = value_schema
 
     return mapping
@@ -427,18 +596,26 @@ class _Constructor:
 
     __slots__ = ("_init_fields", "dataclass_type")
 
-    def __init__(self, dataclass_type: type) -> None:
-        """Remember the type and which of its fields the constructor accepts."""
+    def __init__(
+        self, dataclass_type: type, remove: frozenset[TypingAny] = frozenset()
+    ) -> None:
+        """Remember the type and which of its fields the constructor accepts.
+
+        ``remove`` names the ``Key(remove=True)`` fields, whose value is always
+        dropped, so they take their dataclass default regardless of the input (even a
+        value ``ALLOW_EXTRA`` kept because it failed the field's own validation).
+        """
         self.dataclass_type = dataclass_type
-        self._init_fields = frozenset(
-            field.name for field in _iter_init_fields(dataclass_type)
+        self._init_fields = (
+            frozenset(field.name for field in _iter_init_fields(dataclass_type))
+            - remove
         )
 
     def __call__(self, data: dict[TypingAny, TypingAny]) -> TypingAny:
         """Construct the dataclass, passing only the keys it accepts.
 
-        Extra keys (kept by ``ALLOW_EXTRA``) are dropped here, since a dataclass
-        cannot take an unexpected keyword argument.
+        Extra keys (kept by ``ALLOW_EXTRA``) and dropped ``Remove`` keys are left out
+        here, since a dataclass cannot take an unexpected keyword argument.
         """
         kwargs = {key: value for key, value in data.items() if key in self._init_fields}
         return self.dataclass_type(**kwargs)
@@ -484,7 +661,13 @@ def create_dataclass_schema(
     # DataclassSchema compiles mapping validation and construction together, so it
     # needs an interpreted inner mapping to read from.
     inner = Schema(mapping, required=required, extra=extra, compile=False)
-    schema = Schema(All(inner, _Constructor(dataclass_type)))
+    # Resolve through the chain so a nested Remove (``Secret(Remove(...))``) counts too.
+    remove = frozenset(
+        facets.key
+        for facets in map(resolve_key, mapping)
+        if isinstance(facets.marker, Remove)
+    )
+    schema = Schema(All(inner, _Constructor(dataclass_type, remove)))
     ref.bind(schema)
 
     return schema
@@ -623,12 +806,22 @@ def _build_constructor(
         return None  # a recursive dataclass: leave it to the validating path
     building = building | {dataclass_type}
 
-    # Type hints were already resolved while building the schema.
+    # Type hints were already resolved while building the schema. The plain hints
+    # drive value construction; the extras-carrying hints only detect a Key facet.
     hints = get_type_hints(dataclass_type)
+    hints_extras = get_type_hints(dataclass_type, include_extras=True)
     namespace: dict[str, TypingAny] = {"_Type": dataclass_type}
     parts: list[str] = []
     for index, field in enumerate(_iter_init_fields(dataclass_type)):
         annotation = _field_annotation(hints.get(field.name, TypingAny))
+        spec = _field_key_spec(_field_annotation(hints_extras.get(field.name)))
+        if spec is not None and (
+            spec.alias is not None or spec.remove or spec.forbidden
+        ):
+            # These change which key the field reads from (or drop it), which the
+            # flat by-name reader cannot reproduce; leave them to the validating path.
+            return None
+
         expr = _value_expr(
             annotation, f"data[{field.name!r}]", namespace, building, str(index)
         )
@@ -763,6 +956,31 @@ class DataclassSchema[DataclassT](Schema):
         return generated if generated is not None else interpreted
 
 
+def _typeddict_presence(
+    annotation: TypingAny, *, total: bool
+) -> tuple[bool, TypingAny]:
+    """Read a TypedDict field's required-ness and strip its Required/NotRequired.
+
+    ``Required``/``NotRequired`` may wrap the whole annotation or sit inside an
+    ``Annotated`` (``Annotated[NotRequired[int], Key(...)]``). Handle both, returning
+    the presence and the annotation with the qualifier removed but the ``Annotated``
+    metadata (a ``Key``, a value validator) kept, so it is still read.
+    """
+    origin = get_origin(annotation)
+    if origin is RequiredHint:
+        return True, get_args(annotation)[0]
+    if origin is NotRequired:
+        return False, get_args(annotation)[0]
+    if origin is Annotated:
+        base, *meta = get_args(annotation)
+        base_origin = get_origin(base)
+        if base_origin is RequiredHint:
+            return True, Annotated[(get_args(base)[0], *meta)]
+        if base_origin is NotRequired:
+            return False, Annotated[(get_args(base)[0], *meta)]
+    return total, annotation
+
+
 def _typeddict_mapping(
     typeddict_type: TypingAny,
     constraints: dict[str, TypingAny],
@@ -786,18 +1004,21 @@ def _typeddict_mapping(
     total = typeddict_type.__total__
     mapping: dict[TypingAny, TypingAny] = {}
     for name, annotation in hints.items():
-        origin = get_origin(annotation)
-        if origin is RequiredHint:
-            required, field_type = True, get_args(annotation)[0]
-        elif origin is NotRequired:
-            required, field_type = False, get_args(annotation)[0]
-        else:
-            required, field_type = total, annotation
+        required, field_type = _typeddict_presence(annotation, total=total)
         value_schema = _annotation_to_schema(field_type, self_refs)
         if name in constraints:
             value_schema = All(value_schema, constraints[name])
 
-        key = Required(name) if required else Optional(name)
+        # A TypedDict is a plain dict at runtime: nothing is constructed and a field
+        # has no default, so Forbidden/Remove need none and absence is fine.
+        key = _key_from_spec(
+            name,
+            _field_key_spec(field_type),
+            inferred_required=required,
+            default=UNDEFINED,
+            has_default=False,
+            constructs=False,
+        )
         mapping[key] = value_schema
 
     return mapping

--- a/src/probatio/fields.py
+++ b/src/probatio/fields.py
@@ -14,11 +14,11 @@ field name as the key. Plain dict schemas keep using the markers directly.
 
 from __future__ import annotations
 
+# Imported at runtime, not under TYPE_CHECKING: ``Key`` is public, so
+# ``get_type_hints(Key)`` must resolve without a NameError on ``Sequence``.
+from collections.abc import Sequence  # noqa: TC003
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
+from typing import Any
 
 
 @dataclass

--- a/src/probatio/fields.py
+++ b/src/probatio/fields.py
@@ -1,0 +1,50 @@
+"""Field metadata for the annotation-driven builders (ADR-013).
+
+``Key`` is a small spec placed in a field's ``Annotated`` metadata to give that
+field a key facet the plain type cannot express: redact it, accept it under other
+names, forbid it, group it, or override its presence. It works the same on a
+dataclass and a TypedDict, because it rides in ``Annotated`` (a TypedDict key
+cannot take a default value, so pydantic's ``Field(...)`` default trick does not
+apply there).
+
+A ``Key`` is not a mapping-key marker and never appears as a dict key. The builder
+reads it and generates the real marker chain (``Secret``, ``Alias``, ...) with the
+field name as the key. Plain dict schemas keep using the markers directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@dataclass
+class Key:
+    """Configure the mapping key a builder generates for an ``Annotated`` field.
+
+    ``secret`` redacts the field's value in errors. ``alias`` accepts the field
+    under one or more alternate input names (the field name stays canonical);
+    ``accept_canonical=False`` makes it a strict rename. ``forbidden`` rejects a
+    caller who supplies the field, ``remove`` drops it after validating.
+    ``inclusive``/``exclusive`` name a co-dependent or mutually-exclusive group.
+    ``required`` overrides the presence a dataclass default (or a TypedDict's
+    ``total``) would imply. ``description`` and ``msg`` pass through to the marker.
+
+    The facets that define the key's role (``alias``, ``forbidden``, ``remove``,
+    ``inclusive``, ``exclusive``) are mutually exclusive; ``secret`` layers on top
+    of any of them.
+    """
+
+    secret: bool = False
+    alias: str | Sequence[str] | None = None
+    accept_canonical: bool = True
+    forbidden: bool = False
+    remove: bool = False
+    inclusive: str | None = None
+    exclusive: str | None = None
+    required: bool | None = None
+    description: Any = None
+    msg: str | None = None

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -27,6 +27,7 @@ from probatio import (
     Coerce,
     DataclassSchema,
     In,
+    Key,
     Length,
     MultipleInvalid,
     Range,
@@ -35,6 +36,7 @@ from probatio import (
     is_dataclass,
 )
 from probatio.dataclass_schema import _build_discriminant, _literal_tags
+from probatio.humanize import humanize_error
 
 _TypeVarT = TypeVar("_TypeVarT")
 
@@ -1037,3 +1039,267 @@ def test_construct_aliases_a_trusted_plain_list() -> None:
     validated = schema({"tags": source})
     assert validated.tags is not source  # validation rebuilds a fresh list
     assert validated.tags == source
+
+
+# --- Key field metadata (ADR-013) ----------------------------------------------
+
+
+def test_key_secret_redacts_the_value() -> None:
+    """Key(secret=True) redacts the field's value in errors."""
+
+    @dataclass
+    class Login:
+        user: str
+        password: Annotated[str, Key(secret=True)]
+
+    data = {"user": "bob", "password": 123}
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(Login)(data)
+    assert "<redacted>" in humanize_error(data, caught.value)
+
+
+def test_key_secret_composes_with_a_value_validator() -> None:
+    """A Key facet and a value validator coexist in one annotation."""
+
+    @dataclass
+    class Login:
+        password: Annotated[str, Key(secret=True), Length(min=8)]
+
+    data = {"password": "short"}
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(Login)(data)
+    assert "<redacted>" in humanize_error(data, caught.value)
+
+
+def test_key_alias_accepts_multiple_names() -> None:
+    """Key(alias=[...]) accepts several input names, emitting the field name."""
+
+    @dataclass
+    class Cfg:
+        user_name: Annotated[str, Key(alias=["user-name", "userName"])] = "x"
+
+    schema = create_dataclass_schema(Cfg)
+    assert schema({"user-name": "ada"}).user_name == "ada"
+    assert schema({"userName": "eve"}).user_name == "eve"
+    assert schema({}).user_name == "x"
+
+
+def test_key_alias_single_string() -> None:
+    """Key(alias="one") accepts a bare string as a single alias."""
+
+    @dataclass
+    class Cfg:
+        user_name: Annotated[str, Key(alias="user-name")] = "x"
+
+    assert create_dataclass_schema(Cfg)({"user-name": "ada"}).user_name == "ada"
+
+
+def test_key_alias_default_is_validated() -> None:
+    """The field default is validated through the value schema, like the plain path."""
+
+    @dataclass
+    class Bad:
+        x: Annotated[int, Key(alias=["y"])] = "not-an-int"  # noqa: RUF100
+
+    with pytest.raises(MultipleInvalid):
+        create_dataclass_schema(Bad)({})
+
+
+def test_key_forbidden_rejects_a_supplied_value() -> None:
+    """Key(forbidden=True) rejects a caller-supplied field, else uses the default."""
+
+    @dataclass
+    class Account:
+        name: str
+        is_admin: Annotated[bool, Key(forbidden=True)] = False
+
+    schema = create_dataclass_schema(Account)
+    assert schema({"name": "bob"}).is_admin is False
+    with pytest.raises(MultipleInvalid):
+        schema({"name": "bob", "is_admin": True})
+
+
+def test_key_forbidden_without_default_is_a_schema_error() -> None:
+    """A Forbidden dataclass field is never supplied, so it must have a default."""
+
+    @dataclass
+    class Bad:
+        is_admin: Annotated[bool, Key(forbidden=True)]
+
+    with pytest.raises(SchemaError, match="needs a default"):
+        create_dataclass_schema(Bad)
+
+
+def test_key_remove_drops_a_validated_value() -> None:
+    """Key(remove=True) validates its value, then drops it so the default is used."""
+
+    @dataclass
+    class Cfg:
+        legacy: Annotated[int, Key(remove=True)] = 0
+
+    assert create_dataclass_schema(Cfg)({"legacy": 5}).legacy == 0
+
+
+def test_key_exclusive_group() -> None:
+    """Key(exclusive=group) allows at most one of the group's fields."""
+
+    @dataclass
+    class Auth:
+        token: Annotated[str, Key(exclusive="auth")] = ""
+        secret: Annotated[str, Key(exclusive="auth")] = ""
+
+    schema = create_dataclass_schema(Auth)
+    assert schema({"token": "t"}).token == "t"  # noqa: S105
+    with pytest.raises(MultipleInvalid):
+        schema({"token": "t", "secret": "s"})
+
+
+def test_key_inclusive_group() -> None:
+    """Key(inclusive=group) requires the group's fields together, or none."""
+
+    @dataclass
+    class Point:
+        x: Annotated[int, Key(inclusive="xy")] = 0
+        y: Annotated[int, Key(inclusive="xy")] = 0
+
+    schema = create_dataclass_schema(Point)
+    assert schema({"x": 1, "y": 2}).x == 1
+    with pytest.raises(MultipleInvalid):
+        schema({"x": 1})
+
+
+def test_key_required_overrides_a_default() -> None:
+    """Key(required=True) forces presence even when the field has a default."""
+
+    @dataclass
+    class Cfg:
+        mode: Annotated[str, Key(required=True)] = "auto"
+
+    schema = create_dataclass_schema(Cfg)
+    assert schema({"mode": "manual"}).mode == "manual"
+    with pytest.raises(MultipleInvalid):
+        schema({})
+
+
+def test_key_optional_without_default_is_a_schema_error() -> None:
+    """An optional field that can be absent needs a default to construct from."""
+
+    @dataclass
+    class Cfg:
+        mode: Annotated[str, Key(required=False)]
+
+    with pytest.raises(SchemaError, match="needs a default"):
+        create_dataclass_schema(Cfg)
+
+
+def test_key_conflicting_facets_is_a_schema_error() -> None:
+    """Two role-defining facets on one Key are a schema error."""
+
+    @dataclass
+    class Bad:
+        x: Annotated[str, Key(forbidden=True, alias=["y"])] = "z"
+
+    with pytest.raises(SchemaError, match="conflicting facets"):
+        create_dataclass_schema(Bad)
+
+
+def test_two_key_specs_on_a_field_is_a_schema_error() -> None:
+    """A field may carry at most one Key spec."""
+
+    @dataclass
+    class Bad:
+        x: Annotated[str, Key(secret=True), Key(alias=["y"])] = "z"
+
+    with pytest.raises(SchemaError, match="more than one Key"):
+        create_dataclass_schema(Bad)
+
+
+def test_key_forbidden_default_is_the_dataclass_default_untouched() -> None:
+    """A Forbidden field takes the dataclass's own default; the schema does not touch it.
+
+    The field's value never comes from the input, so it reaches the constructor as
+    the raw dataclass default, unvalidated and uncoerced (a wrong-typed default is a
+    dataclass-level type error a type-checker flags, not the schema's to catch).
+    """
+
+    @dataclass
+    class Cfg:
+        x: Annotated[int, Key(forbidden=True)] = "as-is"  # noqa: RUF100
+
+    assert create_dataclass_schema(Cfg)({}).x == "as-is"
+
+
+def test_key_alias_is_honored_by_construct() -> None:
+    """construct() falls back to validation so a Key alias still resolves."""
+
+    @dataclass
+    class Cfg:
+        user_name: Annotated[str, Key(alias=["user-name"])] = "x"
+
+    schema = DataclassSchema(Cfg)
+    assert schema.construct({"user-name": "ada"}).user_name == "ada"
+
+
+def test_key_exclusive_custom_message() -> None:
+    """A Key(msg=...) on a group reaches the group's error."""
+
+    @dataclass
+    class Auth:
+        a: Annotated[int, Key(exclusive="g", msg="pick exactly one")] = 0
+        b: Annotated[int, Key(exclusive="g", msg="pick exactly one")] = 0
+
+    with pytest.raises(MultipleInvalid) as caught:
+        create_dataclass_schema(Auth)({"a": 1, "b": 2})
+    assert caught.value.errors[0].error_message == "pick exactly one"
+
+
+def test_key_inclusive_with_required_is_a_schema_error() -> None:
+    """required does not apply to an inclusive (all-or-none) group."""
+
+    @dataclass
+    class Bad:
+        a: Annotated[int, Key(inclusive="g", required=True)] = 0
+
+    with pytest.raises(SchemaError, match="required does not apply"):
+        create_dataclass_schema(Bad)
+
+
+def test_key_forbidden_default_is_not_coerced() -> None:
+    """A Forbidden field's default is used as-is, not run through a coercing schema."""
+
+    @dataclass
+    class Cfg:
+        x: Annotated[int, Key(forbidden=True), Coerce(int)] = "1"
+
+    # The plain path would coerce an absent default to ``1``; a forbidden field keeps
+    # the dataclass's own ``"1"`` (its value is never schema-managed input).
+    assert create_dataclass_schema(Cfg)({}).x == "1"
+
+
+def test_key_remove_invalid_value_does_not_reach_the_constructor() -> None:
+    """A Remove field always takes its default, even a value ALLOW_EXTRA kept."""
+
+    @dataclass
+    class Cfg:
+        legacy: Annotated[int, Key(remove=True)] = 0
+
+    # Under ALLOW_EXTRA the failed value is kept in the dict, but the Remove field is
+    # dropped at construction, so it never lands in the instance.
+    assert DataclassSchema(Cfg, extra=ALLOW_EXTRA)({"legacy": "bad"}).legacy == 0
+    assert DataclassSchema(Cfg)({"legacy": 5}).legacy == 0
+
+
+def test_key_required_exclusive_group_is_enforced_with_defaults() -> None:
+    """Key(exclusive, required=True) requires a member even when fields have defaults."""
+
+    @dataclass
+    class Auth:
+        token: Annotated[str, Key(exclusive="auth", required=True)] = ""
+        secret: Annotated[str, Key(exclusive="auth", required=True)] = ""
+
+    schema = create_dataclass_schema(Auth)
+    with pytest.raises(MultipleInvalid):
+        schema({})  # required group: a default must not satisfy it
+    assert schema({"token": "t"}).token == "t"  # noqa: S105
+    with pytest.raises(MultipleInvalid):
+        schema({"token": "t", "secret": "s"})

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -1215,12 +1215,7 @@ def test_two_key_specs_on_a_field_is_a_schema_error() -> None:
 
 
 def test_key_forbidden_default_is_the_dataclass_default_untouched() -> None:
-    """A Forbidden field takes the dataclass's own default; the schema does not touch it.
-
-    The field's value never comes from the input, so it reaches the constructor as
-    the raw dataclass default, unvalidated and uncoerced (a wrong-typed default is a
-    dataclass-level type error a type-checker flags, not the schema's to catch).
-    """
+    """A Forbidden field reaches the constructor as the raw, uncoerced dataclass default."""
 
     @dataclass
     class Cfg:
@@ -1261,6 +1256,28 @@ def test_key_inclusive_with_required_is_a_schema_error() -> None:
         a: Annotated[int, Key(inclusive="g", required=True)] = 0
 
     with pytest.raises(SchemaError, match="required does not apply"):
+        create_dataclass_schema(Bad)
+
+
+def test_key_forbidden_with_required_is_a_schema_error() -> None:
+    """required does not apply to a Forbidden field (never taken from the input)."""
+
+    @dataclass
+    class Bad:
+        a: Annotated[int, Key(forbidden=True, required=True)] = 0
+
+    with pytest.raises(SchemaError, match="required does not apply to Forbidden"):
+        create_dataclass_schema(Bad)
+
+
+def test_key_remove_with_required_is_a_schema_error() -> None:
+    """required does not apply to a Remove field (dropped after validation)."""
+
+    @dataclass
+    class Bad:
+        a: Annotated[int, Key(remove=True, required=True)] = 0
+
+    with pytest.raises(SchemaError, match="required does not apply to Remove"):
         create_dataclass_schema(Bad)
 
 

--- a/tests/test_typeddict_schema.py
+++ b/tests/test_typeddict_schema.py
@@ -14,11 +14,13 @@ import pytest
 
 from probatio import (
     ALLOW_EXTRA,
+    Key,
     Range,
     TypedDictSchema,
     create_typeddict_schema,
 )
 from probatio.error import ExtraKeysInvalid, MultipleInvalid, SchemaError
+from probatio.humanize import humanize_error
 
 
 class Config(TypedDict):
@@ -195,3 +197,76 @@ def test_construct_returns_trusted_data_unchanged() -> None:
 
     with pytest.raises(MultipleInvalid):
         schema(data)  # validation would reject it
+
+
+# --- Key field metadata (ADR-013) ----------------------------------------------
+
+
+def test_key_secret_redacts_on_a_typeddict() -> None:
+    """Key(secret=True) redacts the field's value in errors on a TypedDict."""
+
+    class Login(TypedDict):
+        user: str
+        password: Annotated[str, Key(secret=True)]
+
+    data = {"user": "bob", "password": 123}
+    with pytest.raises(MultipleInvalid) as caught:
+        TypedDictSchema(Login)(data)
+    assert "<redacted>" in humanize_error(data, caught.value)
+
+
+def test_key_alias_multiple_names_on_a_typeddict() -> None:
+    """Key(alias=[...]) accepts several names, emitting the field name."""
+
+    class Cfg(TypedDict):
+        user_name: Annotated[str, Key(alias=["user-name", "userName"])]
+
+    schema = create_typeddict_schema(Cfg)
+    assert schema({"user-name": "ada"}) == {"user_name": "ada"}
+    assert schema({"userName": "eve"}) == {"user_name": "eve"}
+
+
+def test_key_forbidden_needs_no_default_on_a_typeddict() -> None:
+    """A TypedDict constructs nothing, so a Forbidden field needs no default."""
+
+    class Payload(TypedDict):
+        name: str
+        server_set: Annotated[str, Key(forbidden=True)]
+
+    schema = create_typeddict_schema(Payload)
+    assert schema({"name": "x"}) == {"name": "x"}
+    with pytest.raises(MultipleInvalid):
+        schema({"name": "x", "server_set": "nope"})
+
+
+def test_key_exclusive_group_on_a_typeddict() -> None:
+    """Key(exclusive=group) allows at most one group member on a TypedDict."""
+
+    class Auth(TypedDict):
+        token: NotRequired[Annotated[str, Key(exclusive="auth")]]
+        secret: NotRequired[Annotated[str, Key(exclusive="auth")]]
+
+    schema = create_typeddict_schema(Auth)
+    assert schema({"token": "t"}) == {"token": "t"}
+    with pytest.raises(MultipleInvalid):
+        schema({"token": "t", "secret": "s"})
+
+
+def test_required_qualifier_inside_annotated_is_honored() -> None:
+    """Required/NotRequired work inside Annotated, not only as the outer wrapper."""
+
+    class NotReq(TypedDict):
+        x: Annotated[NotRequired[int], Key(secret=True)]
+
+    schema = create_typeddict_schema(NotReq)
+    assert schema({}) == {}  # NotRequired honored despite being inside Annotated
+    with pytest.raises(MultipleInvalid):
+        schema({"x": "bad"})  # value schema still validates the inner type
+
+    class Req(TypedDict, total=False):
+        x: Annotated[Required[int], Key(secret=True)]
+
+    req = create_typeddict_schema(Req)
+    with pytest.raises(MultipleInvalid):
+        req({})  # Required honored inside Annotated, in a total=False TypedDict
+    assert req({"x": 5}) == {"x": 5}


### PR DESCRIPTION
## What

A dataclass or TypedDict field can now carry a key facet the plain type cannot express, by adding `Key(...)` to its `Annotated` metadata:

```python
class Login(TypedDict):                                    # identical on a dataclass
    user_name: Annotated[str, Key(alias=["user-name", "userName"])]
    password:  Annotated[str, Key(secret=True)]
    token:     Annotated[str, Key(exclusive="auth")]
```

`Key` covers `secret` (redact the value in errors), `alias` (accept under other input names, one or many), `forbidden` (reject a caller who supplies it), `remove` (drop after validating), `inclusive`/`exclusive` (co-dependent / mutually-exclusive groups), and a `required` presence override. Plain dict schemas keep using the markers directly and are untouched, including `Alias`'s multi-alias form (`{Alias("user_name", "user-name", "userName"): str}`).

## Why a spec, not the markers in `Annotated`

Markers are mapping keys: they hash and compare by their key (needed for `extend`). Reused as field metadata their key slot is empty or holds config, so two of them collapse in typing's `Annotated` cache (`Annotated[str, Secret()]` vs `Annotated[str, Optional()]`, or two aliases sharing a leading name). Working around that meant breaking marker equality or a keyless construction form. A `Key` is plain data, never a mapping key, so:

- it works in a **TypedDict** body, the actual target, where pydantic's `Field`-as-a-default cannot go (a TypedDict key takes no value);
- it cannot hit the `Annotated`-cache trap, that failure class is removed by construction;
- marker equality and the engine are untouched.

The builder reads the `Key`, generates the real marker chain (`Secret`, `Alias`, ...) with the field name as the key, and reuses the ordinary compile path. Mirrors how pydantic (`Field`/`AliasChoices`) and mashumaro (`Alias`) keep field metadata separate from any key object.

## Notes / boundary

- On a **dataclass**, a field the schema keeps out of the input (`forbidden`, `remove`, or an unselected `exclusive` member) takes the dataclass's own default as-is, without validation or coercion, because a constructor's defaults are Python-level, outside the schema (which validates *input*). A wrong-typed default there is a type-checker's job. This is documented in ADR-013 and the dataclasses guide. A TypedDict constructs nothing, so it doesn't arise there.
- TypedDict fields carrying `Required`/`NotRequired` **inside** `Annotated` (either nesting order) are now unwrapped correctly, a pre-existing gap this surfaced.
- No marker or engine surgery. New `fields.py` (50 lines) plus the builder normalization.

## Model

See [ADR-013](https://github.com/frenck/probatio/blob/main/adr/013-markers-on-annotated-fields.md) for the decision, the alternatives considered (markers-in-Annotated, keyless factories, single-alias), and the boundary.

## Checks

Full gate green (`just check`: ruff, mypy, ty, codespell, 100% line+branch coverage, docs examples) and `just test-compiled` (compiled-path parity).