### PR TITLE
Add the probatio decorator for annotation-driven argument validation

### DIFF
--- a/adr/014-annotation-driven-argument-decorator.md
+++ b/adr/014-annotation-driven-argument-decorator.md
@@ -1,0 +1,89 @@
+# ADR-014: An annotation-driven argument-validation decorator
+
+**Date**: 2026-07-02
+**Status**: Accepted
+
+**Context**: Probatio ships `validate`, the voluptuous-compatible decorator: you
+name a schema per argument by hand (`@validate(width=int, __return__=int)`), it
+validates the bound arguments against a dict schema, and it is sync-only. That
+serves the drop-in promise, but it repeats type information a caller has usually
+already written as annotations, and it cannot wrap a coroutine function.
+
+The annotation engine that `create_dataclass_schema` and `create_typeddict_schema`
+use (`_annotation_to_schema`) already turns a single type annotation into a schema
+fragment, including `Annotated[int, Range(...)]`, unions, and nested dataclasses. A
+function signature is just another source of annotations, so the same inference
+applies: read each parameter's validator from its annotation, coerce as the
+annotation says, validate the arguments before the body runs, and do it on a
+coroutine function too.
+
+**Decision**: A new decorator, `probatio`, that reads a callable's signature and
+validates each annotated parameter through the shared annotation engine, on both
+sync and coroutine functions. `validate` stays untouched for the voluptuous
+drop-in.
+
+```python
+@probatio
+async def fetch(user_id: Annotated[int, Range(min=1)], name: str) -> Response:
+    ...
+
+@probatio({"name": Length(min=2)}, returns=User)
+def make(name: str, age: int) -> User:
+    ...
+```
+
+- **Inference is the default.** Each annotated parameter becomes its inferred
+  validator. An unannotated parameter (`self`, `cls`, a bare `*args`) carries no
+  schema and is passed through, so the decorator drops onto a method with no
+  ceremony.
+- **`constraints` extends, it does not replace.** An optional `{parameter:
+validator}` first argument layers an extra rule after the inferred type with
+  `All`, the same shape and meaning as a dataclass's `additional_constraints`.
+- **`returns` is one opt-in knob.** Off by default; `True` validates the result
+  against the `-> R` annotation, any other value is used as the return schema
+  directly.
+- **The escape hatch is the standard `__wrapped__`.** `functools.wraps` already
+  sets it to the undecorated callable, so a trusted, unvalidated call needs no
+  bespoke attribute.
+
+**Rationale**:
+
+- One engine, two entry points. A function signature and a dataclass are both
+  annotation sources, so `_annotation_to_schema` serves both. The decorator adds a
+  signature-to-mapping front end, not a second validation path.
+- Distinct from `validate` on purpose. `validate` is the hand-named voluptuous
+  drop-in; `probatio` is the annotation-driven, async-aware one. Keeping both means
+  neither has to distort: the compatibility surface stays literal, and the new one
+  is free to be opinionated.
+- Named for what it is. `@probatio` reads as a stamp on a function ("validated by
+  probatio"), and stays clear of the `validate` name so the two decorators do not
+  blur together.
+
+**Consequences**:
+
+- **Coercion reaches the body.** A parameter is bound, validated, and written back
+  before the call, so a coercing annotation (`Annotated[int, Coerce(int)]`, a
+  dataclass parameter) hands the body the validated value, consistent with how the
+  rest of the library returns a normalized result. Binding goes through
+  `inspect.Signature.bind`, so positional-only, keyword-only, and `*args`/`**kwargs`
+  reconstruct correctly.
+- **Only what is validated is resolved.** Annotations are resolved per call site,
+  scoped to the parameters that are actually validated (plus the return, only when
+  `returns=True`). An unresolved forward reference on a skipped `*args`, or on the
+  return when return validation is off, cannot break decoration. The scoping narrows
+  the callable's `__annotations__` around a single `get_type_hints` call and restores
+  it, rather than reaching into private typing internals.
+- **A constraint on a variadic is a build-time error.** `constraints` may only name
+  a parameter that is actually validated; naming a `*args`/`**kwargs` (or a
+  nonexistent parameter) raises `SchemaError` when the function is decorated, so a
+  typo fails loudly instead of silently validating nothing.
+- **Return validation is off unless asked.** Unlike the parameters, a return
+  annotation is not enforced by default, so a loose return hint does not silently
+  become a runtime contract; opt in with `returns`.
+- **The failure surface matches `validate`.** Arguments are validated as a mapping,
+  so a bad argument reports as `... for dictionary value @ data['name']`, the same
+  phrasing `validate` produces. The path already names the parameter; the shared
+  wording keeps the two decorators coherent.
+- **First async-aware surface.** The decorator detects a coroutine function and
+  awaits the call before the return schema runs. It is the only place in the package
+  that branches on async; the validation engine itself stays synchronous.

--- a/adr/README.md
+++ b/adr/README.md
@@ -16,3 +16,4 @@ Each record captures what was chosen, the alternatives considered, and why.
 | [ADR-011](011-opt-in-compiled-schema.md)                    | An adaptive compiled schema variant (codegen)                  |
 | [ADR-012](012-trusted-construction-without-validation.md)   | Trusted construction without validation                        |
 | [ADR-013](013-markers-on-annotated-fields.md)               | A field-metadata spec for Annotated dataclass/TypedDict fields |
+| [ADR-014](014-annotation-driven-argument-decorator.md)      | An annotation-driven argument-validation decorator             |

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -107,6 +107,10 @@ export default defineConfig({
               slug: "guides/loading-and-dumping",
             },
             { label: "Custom validators", slug: "guides/custom-validators" },
+            {
+              label: "The probatio decorator",
+              slug: "guides/probatio-decorator",
+            },
             { label: "Recursive schemas", slug: "guides/recursive-schemas" },
             { label: "Compiled schemas", slug: "guides/compiled-schemas" },
             { label: "Schemas from dataclasses", slug: "guides/dataclasses" },

--- a/docs/src/content/docs/guides/custom-validators.md
+++ b/docs/src/content/docs/guides/custom-validators.md
@@ -342,7 +342,9 @@ decides what an absent context means. It is async- and thread-safe, and a plain
 
 `validate` is a decorator that checks a function's arguments (and, with the
 `__return__` key, its return value) against schemas, the same way a `Schema`
-checks data. A bad argument raises, so the body only runs on valid input.
+checks data. A bad argument raises, so the body only runs on valid input. For the
+annotation-driven, async-capable version that reads the schemas from the
+signature, see [the probatio decorator](/guides/probatio-decorator/).
 
 ```python
 from probatio import validate, MultipleInvalid

--- a/docs/src/content/docs/guides/probatio-decorator.md
+++ b/docs/src/content/docs/guides/probatio-decorator.md
@@ -1,0 +1,216 @@
+---
+title: The probatio decorator
+description: Validate a function's arguments straight from its type annotations, with coercion, per-parameter rules, optional return checking, and async support.
+---
+
+`@probatio` validates a callable's arguments against its type annotations before
+the body runs. It reads the signature the same way `DataclassSchema` reads a
+dataclass: each annotated parameter becomes a validator, and the body receives the
+validated (and coerced) value.
+
+It is the annotation-driven companion to [`validate`](/guides/custom-validators/#validating-function-arguments),
+the voluptuous drop-in where you name a schema per argument by hand. Reach for
+`@probatio` when your parameters are already typed and you want that typing
+enforced at the boundary.
+
+## The basics
+
+Annotate the parameters and decorate. Nothing else is required.
+
+```python
+from probatio import probatio
+
+
+@probatio
+def area(width: int, height: int) -> int:
+    return width * height
+
+
+area(3, 4)  # 12
+```
+
+A parameter that fails its type raises before the body runs, naming the parameter:
+
+<!-- verify: raises MultipleInvalid -->
+
+```python
+from probatio import probatio
+
+
+@probatio
+def area(width: int, height: int) -> int:
+    return width * height
+
+
+area("wide", 4)  # expected int for dictionary value @ data['width']
+```
+
+An unannotated parameter is left alone, so `self` and `cls` need no special
+handling and the decorator drops straight onto a method.
+
+```python
+from typing import Annotated
+
+from probatio import probatio, Range
+
+
+class Canvas:
+    @probatio
+    def scale(self, factor: Annotated[int, Range(min=1)]) -> int:
+        return factor * 2
+
+
+Canvas().scale(3)  # 6
+```
+
+## Coercion reaches the body
+
+An annotation drives the same engine the schema builders use, so a coercing
+annotation converts the value and the body receives the converted one. The
+annotation says what the parameter _is_, and the type confirms what the coercer
+produced.
+
+```python
+from typing import Annotated
+
+from probatio import probatio, Coerce
+
+
+@probatio
+def repeat(text: str, times: Annotated[int, Coerce(int)]) -> str:
+    return text * times
+
+
+repeat("ab", "3")  # 'ababab'
+```
+
+The full annotation mapping is the one
+[dataclasses use](/guides/dataclasses/#annotations-drive-the-validators): unions
+become `Any`, `X | None` becomes `Maybe`, and a parameter typed as a dataclass
+validates a mapping into an instance.
+
+```python
+from dataclasses import dataclass
+
+from probatio import probatio
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
+
+
+@probatio
+def distance(point: Point) -> int:
+    return point.x + point.y
+
+
+distance({"x": 3, "y": 4})  # 7
+```
+
+## Extra rules per parameter
+
+The annotation gives you the type check. For anything more (a length, a range, a
+pattern), pass a `{parameter: validator}` map as the first argument. It runs after
+the inferred type, exactly like a dataclass's `additional_constraints`.
+
+```python
+from probatio import probatio, Length
+
+
+@probatio({"name": Length(min=2)})
+def greet(name: str) -> str:
+    return f"hi {name}"
+
+
+greet("ada")  # 'hi ada'
+```
+
+A constraint that names no parameter, or names a `*args`/`**kwargs`, is refused
+when the function is decorated, so a typo fails loudly instead of silently doing
+nothing.
+
+## Validating the return value
+
+Return validation is off by default. Opt in with `returns`: pass `True` to check
+the result against the `-> R` annotation, or pass a schema to check against it
+directly.
+
+```python
+from typing import Annotated
+
+from probatio import probatio, Range
+
+
+@probatio(returns=True)
+def clamp(value: int) -> Annotated[int, Range(min=0)]:
+    return value
+
+
+clamp(5)  # 5
+```
+
+A map and a return schema combine, so one decorator can cover both ends:
+
+```python
+from probatio import probatio, Length
+
+
+@probatio({"name": Length(min=2)}, returns=str)
+def shout(name: str) -> str:
+    return name.upper()
+
+
+shout("ada")  # 'ADA'
+```
+
+## Async functions
+
+A coroutine function is validated the same way. The arguments are checked before
+the call, and the result schema (if any) runs on the awaited value.
+
+```python
+import asyncio
+from typing import Annotated
+
+from probatio import probatio, Coerce
+
+
+@probatio
+async def fetch(user_id: Annotated[int, Coerce(int)]) -> int:
+    return user_id + 1
+
+
+asyncio.run(fetch("41"))  # 42
+```
+
+## Skipping validation
+
+`@probatio` builds on `functools.wraps`, so the undecorated callable stays
+reachable through the standard `__wrapped__` attribute. Call it when the input is
+already trusted and you want to skip the check.
+
+```python
+from typing import Annotated
+
+from probatio import probatio, Coerce
+
+
+@probatio
+def widen(value: Annotated[int, Coerce(int)]) -> int:
+    return value
+
+
+widen("5")             # 5, validated and coerced
+widen.__wrapped__("5") # '5', straight through, no validation
+```
+
+## Where to next
+
+- [`validate`](/guides/custom-validators/#validating-function-arguments): the
+  voluptuous-compatible decorator with hand-named schemas.
+- [Schemas from dataclasses](/guides/dataclasses/): the same annotation engine,
+  building an instance from a mapping.
+- [Built-ins by role](/reference/builtins-by-role/): the validators and coercers
+  to reach for in an annotation.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -365,16 +365,23 @@ Apply these after a dict schema with `All`; they inspect the whole mapping.
 
 ## Decorators and helpers
 
+- `probatio(constraints=None, returns=None)`: decorator validating a callable's
+  arguments from their annotations (sync or async). `constraints` is a
+  `{parameter: validator}` map layered after the inferred type; `returns` opts into
+  result validation (`True` uses the `-> R` annotation, or pass a schema). See [the
+  probatio decorator](/guides/probatio-decorator/).
 - `validate(*args, **kwargs)`: decorator validating a function's arguments (and
-  `__return__`).
+  `__return__`) against hand-named schemas (the voluptuous drop-in).
 - `raises(exc, msg=None, regex=None)`: context manager asserting a block raises
   `exc`, optionally matching it.
 
 ```python
-from probatio import validate
+from typing import Annotated
 
-@validate(arg1=int, arg2=int, __return__=int)
-def multiply(arg1, arg2):
+from probatio import probatio, Range
+
+@probatio(returns=True)
+def multiply(arg1: int, arg2: int) -> Annotated[int, Range(min=0)]:
     return arg1 * arg2
 
 multiply(3, 4)  # 12

--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -32,6 +32,7 @@ from probatio.dataclass_schema import (
     create_typeddict_schema,
     is_dataclass,
 )
+from probatio.decorator import probatio
 from probatio.error import (
     AllInvalid,
     AnyInvalid,
@@ -541,6 +542,7 @@ __all__ = [
     "load_yaml",
     "load_yaml_with_locations",
     "message",
+    "probatio",
     "raises",
     "register_type",
     "serialize",

--- a/src/probatio/decorator.py
+++ b/src/probatio/decorator.py
@@ -1,0 +1,258 @@
+"""The ``probatio`` decorator: validate a callable's arguments from its annotations.
+
+Where the voluptuous-compatible ``validate`` wants a schema named per argument,
+``probatio`` reads the signature and infers a validator for each annotated
+parameter, the same way ``DataclassSchema`` reads a dataclass. An unannotated
+parameter (``self``, ``cls``, a bare ``*args``) is left alone, so it drops onto a
+method without ceremony. It works on a coroutine function too, awaiting the call
+before validating the result.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from functools import wraps
+
+from probatio.dataclass_schema import _annotation_to_schema
+from probatio.error import SchemaError
+from probatio.schema import ALLOW_EXTRA, Schema
+from probatio.validators import All
+
+# ``probatio`` preserves the decorated callable's signature for callers: the
+# wrapper forwards ``*args, **kwargs`` (so it cannot pass a ParamSpec through
+# directly), is typed ``Any`` internally, and is cast back to the callable's own
+# ``(**P) -> R``. For a coroutine function ``R`` is the awaitable it returns, so
+# one cast covers both the sync and the async wrapper.
+
+# Only these parameter kinds map to a named schema. ``*args``/``**kwargs`` carry
+# no single value to validate, so they are skipped, and a constraint cannot target
+# them.
+_VALIDATED_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.KEYWORD_ONLY,
+)
+
+_RETURN = "return"
+
+# Distinguishes "no schema for this parameter" from a schema of ``None`` (which
+# means the value must be ``None``): ``_annotation_to_schema(None)`` returns
+# ``None``, and a constraint value may legitimately be ``None`` too.
+_UNSET: typing.Any = object()
+
+
+def _identity(value: typing.Any) -> typing.Any:
+    """Return the value unchanged (the no-op schema when there is nothing to run)."""
+    return value
+
+
+def _name(func: typing.Callable[..., typing.Any]) -> str:
+    """Name ``func`` for an error message, falling back to its repr."""
+    return getattr(func, "__name__", repr(func))
+
+
+def _check_constraints(
+    func: typing.Callable[..., typing.Any],
+    constraints: dict[str, typing.Any],
+    signature: inspect.Signature,
+) -> None:
+    """Reject a constraint that names no parameter, or a variadic one."""
+    unknown = sorted(
+        repr(name) for name in constraints if name not in signature.parameters
+    )
+    if unknown:
+        message = f"probatio: constraint names no such parameter: {', '.join(unknown)}"
+        raise SchemaError(message)
+    variadic = sorted(
+        repr(name)
+        for name in constraints
+        if signature.parameters[name].kind not in _VALIDATED_KINDS
+    )
+    if variadic:
+        message = (
+            f"probatio: cannot constrain the variadic parameter {', '.join(variadic)} "
+            f"of {_name(func)!r}"
+        )
+        raise SchemaError(message)
+
+
+def _resolve_hints(
+    func: typing.Callable[..., typing.Any],
+    needed: set[str],
+) -> dict[str, typing.Any]:
+    """Resolve only the annotations that are validated.
+
+    An unrelated annotation (a skipped ``*args``, or the return when return
+    validation is off) is never resolved, so a forward reference there cannot break
+    decoration. Only ``needed`` names are resolved, by narrowing the callable's
+    ``__annotations__`` around a single ``get_type_hints`` call and restoring it.
+    """
+    annotations = getattr(func, "__annotations__", None) or {}
+    wanted = {name: value for name, value in annotations.items() if name in needed}
+    if not wanted:
+        return {}
+    try:
+        func.__annotations__ = wanted
+        return typing.get_type_hints(func, include_extras=True)
+    except Exception as exc:
+        message = f"probatio cannot resolve the annotations of {_name(func)!r}: {exc}"
+        raise SchemaError(message) from exc
+    finally:
+        func.__annotations__ = annotations
+
+
+def _parameter_schema(
+    signature: inspect.Signature,
+    constraints: dict[str, typing.Any],
+    hints: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    """Map each annotated (or constrained) parameter to the validator it runs.
+
+    A parameter's annotation becomes its validator; a matching entry in
+    ``constraints`` runs after it with ``All``, exactly as a dataclass's
+    ``additional_constraints`` layer on the field's type.
+    """
+    mapping: dict[str, typing.Any] = {}
+    for name, parameter in signature.parameters.items():
+        if parameter.kind not in _VALIDATED_KINDS:
+            continue
+        inferred = _annotation_to_schema(hints[name], {}) if name in hints else _UNSET
+        extra = constraints.get(name, _UNSET)
+        if inferred is not _UNSET and extra is not _UNSET:
+            mapping[name] = All(inferred, extra)
+        elif inferred is not _UNSET:
+            mapping[name] = inferred
+        elif extra is not _UNSET:
+            mapping[name] = extra
+    return mapping
+
+
+def _return_schema(
+    func: typing.Callable[..., typing.Any],
+    returns: typing.Any,
+    hints: dict[str, typing.Any],
+) -> typing.Callable[[typing.Any], typing.Any]:
+    """Resolve the ``returns`` argument to the validator run on the result.
+
+    ``None`` (the default) skips return validation, ``True`` validates against the
+    ``-> R`` annotation, and any other value is used as the schema directly.
+    """
+    if returns is None or returns is False:
+        return _identity
+    if returns is True:
+        if _RETURN not in hints:
+            message = (
+                f"probatio: returns=True needs a return annotation on {_name(func)!r}"
+            )
+            raise SchemaError(message)
+        return Schema(_annotation_to_schema(hints[_RETURN], {}))
+    return Schema(returns)
+
+
+@typing.overload
+def probatio[**P, R](
+    constraints: typing.Callable[P, R], /
+) -> typing.Callable[P, R]: ...
+
+
+@typing.overload
+def probatio[**P, R](
+    constraints: dict[str, typing.Any] | None = ...,
+    returns: typing.Any = ...,
+) -> typing.Callable[[typing.Callable[P, R]], typing.Callable[P, R]]: ...
+
+
+def probatio(
+    constraints: typing.Any = None,
+    returns: typing.Any = None,
+) -> typing.Any:
+    """Validate a callable's arguments (and optionally its result) from annotations.
+
+    Each annotated parameter is validated against its type, coercing where the
+    annotation says so, so the body receives the validated value::
+
+        @probatio
+        def area(width: int, height: int) -> int:
+            return width * height
+
+    ``constraints`` is an optional ``{parameter: validator}`` map that layers an
+    extra rule after the inferred type check, the same shape as a dataclass's
+    ``additional_constraints``. ``returns`` opts into result validation: ``True``
+    validates against the ``-> R`` annotation, or pass a schema to validate against
+    it directly::
+
+        @probatio({"name": Length(min=2)}, returns=User)
+        def make(name: str, age: int) -> User: ...
+
+    A coroutine function is validated the same way, awaiting the call before the
+    result schema runs. Unannotated parameters (``self``, ``cls``, a bare
+    ``*args``) are left alone. The undecorated callable stays reachable through the
+    standard ``__wrapped__`` attribute for a trusted, unvalidated call.
+    """
+    # Bare ``@probatio``: the decorated callable arrives as the first argument.
+    if callable(constraints) and not isinstance(constraints, dict):
+        return _decorate(constraints, {}, None)
+
+    def decorate[**P, R](func: typing.Callable[P, R]) -> typing.Callable[P, R]:
+        """Wrap ``func`` so its arguments and result are validated."""
+        return _decorate(func, constraints or {}, returns)
+
+    return decorate
+
+
+def _decorate[**P, R](
+    func: typing.Callable[P, R],
+    constraints: dict[str, typing.Any],
+    returns: typing.Any,
+) -> typing.Callable[P, R]:
+    """Build the validating wrapper (sync or async) around ``func``."""
+    signature = inspect.signature(func)
+    _check_constraints(func, constraints, signature)
+
+    needed = {
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind in _VALIDATED_KINDS
+    }
+    if returns is True:
+        needed.add(_RETURN)
+    hints = _resolve_hints(func, needed)
+
+    parameter_schema = _parameter_schema(signature, constraints, hints)
+    input_schema: typing.Callable[[typing.Any], typing.Any] = (
+        Schema(parameter_schema, extra=ALLOW_EXTRA) if parameter_schema else _identity
+    )
+    output_schema = _return_schema(func, returns, hints)
+
+    def bind(
+        args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
+    ) -> inspect.BoundArguments:
+        """Bind the call, validate the named arguments, and write them back."""
+        bound = signature.bind(*args, **kwargs)
+        named = {
+            name: value
+            for name, value in bound.arguments.items()
+            if signature.parameters[name].kind in _VALIDATED_KINDS
+        }
+        bound.arguments.update(input_schema(named))
+        return bound
+
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def async_wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            """Validate the arguments, await ``func``, then validate the result."""
+            bound = bind(args, kwargs)
+            result = await func(*bound.args, **bound.kwargs)
+            return output_schema(result)
+
+        return typing.cast("typing.Callable[P, R]", async_wrapper)
+
+    @wraps(func)
+    def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        """Validate the arguments, call ``func``, then validate the result."""
+        bound = bind(args, kwargs)
+        return output_schema(func(*bound.args, **bound.kwargs))
+
+    return typing.cast("typing.Callable[P, R]", wrapper)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,353 @@
+"""Tests for the ``probatio`` decorator: annotation-driven argument validation."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+import pytest
+
+from probatio import (
+    Coerce,
+    Length,
+    MultipleInvalid,
+    Range,
+    SchemaError,
+    probatio,
+)
+
+
+def test_infers_a_validator_from_each_annotation() -> None:
+    """An annotated parameter is checked against its type."""
+
+    @probatio
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(2, 3) == 5
+
+
+def test_argument_failure_raises_multiple_invalid() -> None:
+    """A parameter that fails its type raises, naming the parameter in the path."""
+
+    @probatio
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    with pytest.raises(MultipleInvalid, match=r"data\['a'\]"):
+        add("nope", 3)
+
+
+def test_coerces_the_value_the_body_receives() -> None:
+    """A coercing annotation hands the body the converted value."""
+
+    @probatio
+    def widen(value: Annotated[int, Coerce(int)]) -> int:
+        return value
+
+    assert widen("41") == 41
+
+
+def test_unannotated_parameter_passes_through() -> None:
+    """A parameter without an annotation is not validated."""
+
+    @probatio
+    def keep(value) -> object:  # type: ignore[no-untyped-def]
+        return value
+
+    marker = object()
+    assert keep(marker) is marker
+
+
+def test_self_is_skipped_on_a_method() -> None:
+    """An unannotated ``self`` is left alone, so the decorator drops onto a method."""
+
+    class Box:
+        @probatio
+        def scale(self, factor: Annotated[int, Range(min=0)]) -> int:
+            return factor * 2
+
+    assert Box().scale(3) == 6
+    with pytest.raises(MultipleInvalid):
+        Box().scale(-1)
+
+
+def test_constraints_layer_after_the_type_check() -> None:
+    """A ``constraints`` entry runs after the inferred type, like a dataclass rule."""
+
+    @probatio({"name": Length(min=2)})
+    def greet(name: str) -> str:
+        return f"hi {name}"
+
+    assert greet("ab") == "hi ab"
+    with pytest.raises(MultipleInvalid, match="length"):
+        greet("a")
+
+
+def test_constraint_on_an_unannotated_parameter() -> None:
+    """A constraint validates a parameter that has no annotation of its own."""
+
+    @probatio({"value": Range(min=0)})
+    def keep(value) -> object:  # type: ignore[no-untyped-def]
+        return value
+
+    assert keep(5) == 5
+    with pytest.raises(MultipleInvalid):
+        keep(-1)
+
+
+def test_constraint_naming_an_unknown_parameter_is_a_schema_error() -> None:
+    """A constraint for a parameter that does not exist is refused at decoration."""
+
+    with pytest.raises(SchemaError, match="no such parameter"):
+
+        @probatio({"nope": Range(min=0)})
+        def f(value: int) -> int:
+            return value
+
+
+def test_constraint_on_a_variadic_parameter_is_a_schema_error() -> None:
+    """A constraint targeting ``*args``/``**kwargs`` is refused, not silently dropped."""
+
+    with pytest.raises(SchemaError, match="variadic"):
+
+        @probatio({"rest": Range(min=0)})
+        def f(*rest: int) -> int:
+            return sum(rest)
+
+
+def test_unresolved_return_annotation_is_ignored_when_return_off() -> None:
+    """A return annotation that cannot resolve does not break decoration when off."""
+
+    @probatio
+    def f(value: int) -> Missing:  # type: ignore[name-defined]  # noqa: F821
+        return value
+
+    assert f(3) == 3
+
+
+def test_unresolved_variadic_annotation_is_ignored() -> None:
+    """An unresolved annotation on a skipped ``*args`` does not break decoration."""
+
+    @probatio
+    def f(value: int, *rest: Missing) -> int:  # type: ignore[name-defined]  # noqa: F821, ARG001
+        return value
+
+    assert f(3, "a", "b") == 3
+
+
+def test_none_annotation_requires_none() -> None:
+    """A parameter typed ``None`` must be ``None``; it is a schema, not "skip"."""
+
+    @probatio
+    def f(x: None) -> None:
+        return x
+
+    assert f(None) is None
+    with pytest.raises(MultipleInvalid):
+        f(5)
+
+
+def test_none_constraint_requires_none() -> None:
+    """A constraint of ``None`` is a real schema, not read as an absent entry."""
+
+    @probatio({"value": None})
+    def f(value) -> object:  # type: ignore[no-untyped-def]
+        return value
+
+    assert f(None) is None
+    with pytest.raises(MultipleInvalid):
+        f(5)
+
+
+def test_return_validation_is_off_by_default() -> None:
+    """Without ``returns`` the result is not validated, even with a return annotation."""
+
+    @probatio
+    def lies() -> int:
+        return "not an int"  # type: ignore[return-value]
+
+    assert lies() == "not an int"
+
+
+def test_returns_true_validates_against_the_annotation() -> None:
+    """``returns=True`` validates the result against the ``-> R`` annotation."""
+
+    @probatio(returns=True)
+    def clamp(value: int) -> Annotated[int, Range(min=0)]:
+        return value
+
+    assert clamp(5) == 5
+    with pytest.raises(MultipleInvalid):
+        clamp(-1)
+
+
+def test_returns_true_without_annotation_is_a_schema_error() -> None:
+    """``returns=True`` needs a return annotation to validate against."""
+
+    with pytest.raises(SchemaError, match="return annotation"):
+
+        @probatio(returns=True)
+        def f(value: int):  # type: ignore[no-untyped-def]
+            return value
+
+
+def test_returns_schema_validates_against_it() -> None:
+    """A schema passed as ``returns`` validates the result directly."""
+
+    @probatio({"age": Range(min=0)}, returns=int)
+    def age_of(age: int) -> int:
+        return age
+
+    assert age_of(30) == 30
+
+
+def test_returns_false_is_off() -> None:
+    """``returns=False`` skips result validation, like the default."""
+
+    @probatio(returns=False)
+    def lies() -> int:
+        return "nope"  # type: ignore[return-value]
+
+    assert lies() == "nope"
+
+
+def test_var_positional_and_keyword_pass_through() -> None:
+    """``*args`` and ``**kwargs`` carry no schema and reach the body untouched."""
+
+    @probatio
+    def collect(first: int, *rest: object, **options: object) -> tuple:
+        return first, rest, options
+
+    assert collect(1, "a", "b", x=9) == (1, ("a", "b"), {"x": 9})
+
+
+def test_positional_only_parameter() -> None:
+    """A positional-only parameter is validated and passed back positionally."""
+
+    @probatio
+    def f(value: Annotated[int, Coerce(int)], /) -> int:
+        return value
+
+    assert f("7") == 7
+
+
+def test_keyword_only_parameter() -> None:
+    """A keyword-only parameter is validated."""
+
+    @probatio
+    def f(*, value: Annotated[int, Range(min=0)]) -> int:
+        return value
+
+    assert f(value=3) == 3
+    with pytest.raises(MultipleInvalid):
+        f(value=-1)
+
+
+def test_omitted_default_is_not_validated() -> None:
+    """A parameter left to its default is not run through its schema."""
+
+    @probatio
+    def f(value: Annotated[int, Range(min=0)] = -1) -> int:
+        return value
+
+    assert f() == -1
+    with pytest.raises(MultipleInvalid):
+        f(-1)
+
+
+def test_no_annotated_parameters_is_a_no_op_input() -> None:
+    """A callable with nothing to validate still calls through cleanly."""
+
+    @probatio
+    def f(a, b) -> object:  # type: ignore[no-untyped-def]
+        return (a, b)
+
+    assert f(1, 2) == (1, 2)
+
+
+def test_wrapped_attribute_skips_validation() -> None:
+    """The original callable stays reachable through ``__wrapped__`` for trusted input."""
+
+    @probatio
+    def widen(value: Annotated[int, Coerce(int)]) -> int:
+        return value
+
+    assert widen.__wrapped__("41") == "41" * 1  # not coerced
+
+
+@dataclass
+class Point:
+    """A point, used to test that a dataclass parameter is constructed."""
+
+    x: int
+    y: int
+
+
+def test_dataclass_parameter_is_constructed() -> None:
+    """A parameter typed as a dataclass validates a mapping into an instance."""
+
+    @probatio
+    def move(point: Point) -> int:
+        return point.x + point.y
+
+    assert move({"x": 1, "y": 2}) == 3
+
+
+def test_annotation_that_cannot_resolve_is_a_schema_error() -> None:
+    """An unresolvable annotation is reported as a schema error at decoration."""
+
+    def f(value: DoesNotExist) -> int:  # type: ignore[name-defined]  # noqa: F821
+        return value  # type: ignore[return-value]
+
+    with pytest.raises(SchemaError, match="cannot resolve"):
+        probatio(f)
+
+
+def test_empty_call_form() -> None:
+    """``@probatio()`` with no arguments behaves like the bare form."""
+
+    @probatio()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(2, 3) == 5
+
+
+def test_async_function_is_validated() -> None:
+    """A coroutine function validates its arguments and coerces the same way."""
+
+    @probatio
+    async def widen(value: Annotated[int, Coerce(int)]) -> int:
+        return value + 1
+
+    assert asyncio.run(widen("9")) == 10
+
+
+def test_async_argument_failure_raises() -> None:
+    """A failing argument to a coroutine function raises before the body runs."""
+
+    ran = False
+
+    @probatio
+    async def f(value: int) -> int:
+        nonlocal ran
+        ran = True
+        return value
+
+    with pytest.raises(MultipleInvalid):
+        asyncio.run(f("nope"))
+    assert ran is False
+
+
+def test_async_return_validation() -> None:
+    """``returns`` validates the awaited result of a coroutine function."""
+
+    @probatio(returns=True)
+    async def f(value: int) -> Annotated[int, Range(min=0)]:
+        return value
+
+    assert asyncio.run(f(4)) == 4
+    with pytest.raises(MultipleInvalid):
+        asyncio.run(f(-1))


### PR DESCRIPTION
## Breaking change

None. This adds a new name (`probatio`); the existing `validate` decorator is untouched.

## Proposed change

Adds `@probatio`, a decorator that validates a callable's arguments straight from its type annotations, on both sync and async functions. Where the voluptuous-compatible `validate` wants a schema named per argument by hand, `probatio` reads the signature and infers a validator for each annotated parameter through the same engine `DataclassSchema` uses, so `Annotated[int, Range(...)]`, unions, and nested dataclasses all work, and a coercing annotation hands the body the coerced value.

```python
@probatio
async def fetch(user_id: Annotated[int, Range(min=1)], name: str) -> Response: ...

@probatio({"name": Length(min=2)}, returns=User)
def make(name: str, age: int) -> User: ...
```

- Inference is the default. Unannotated parameters (`self`, `cls`, a bare `*args`) are left alone, so it drops onto a method with no ceremony.
- `constraints` is an optional `{parameter: validator}` map layered after the inferred type with `All`, the same shape as a dataclass's `additional_constraints`. Naming a nonexistent or variadic parameter raises `SchemaError` at decoration.
- `returns` is a single opt-in knob: off by default, `True` validates against the `-> R` annotation, or pass a schema to validate against it directly.
- The escape hatch is the standard `__wrapped__` that `functools.wraps` already sets, no bespoke attribute.

Annotation resolution is scoped to exactly the parameters that get validated (plus the return, only when `returns=True`), so an unresolved forward reference on a skipped `*args`, or on the return when validation is off, does not break decoration. `None` as a schema (`x: None`, `@probatio({"x": None})`) is honored via a private sentinel, not read as "no schema".

The design and the alternatives weighed are recorded in [ADR-014](adr/014-annotation-driven-argument-decorator.md). Documentation: a new guide page, an API reference entry, and cross-links from the `validate` section.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the shared annotation engine (`DataclassSchema`, `TypedDictSchema`) and the voluptuous-compatible `validate` decorator
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
