### PR TITLE
Speed up validation, codegen, and schema compilation across the board

### DIFF
--- a/docs/public/benchmarks/dataclass-vs-mashumaro.svg
+++ b/docs/public/benchmarks/dataclass-vs-mashumaro.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="552.589687pt" height="250.485575pt" viewBox="0 0 552.589687 250.485575" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="552.589687pt" height="250.759833pt" viewBox="0 0 552.589687 250.759833" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-30T07:32:04.267552</dc:date>
+    <dc:date>2026-07-03T00:48:37.434407</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.7, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,8 +21,8 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 250.485575
-L 552.589687 250.485575
+   <path d="M 0 250.759833
+L 552.589687 250.759833
 L 552.589687 0
 L 0 0
 z
@@ -42,115 +42,93 @@ z
      <g id="line2d_1">
       <path d="M 87.829688 197.397969
 L 87.829688 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="87.829688" y="208.496406" transform="rotate(-0 87.829688 208.496406)">0.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="87.829688" y="208.495625" transform="rotate(-0 87.829688 208.495625)">0.0</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 139.702124 197.397969
-L 139.702124 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 153.410649 197.397969
+L 153.410649 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="139.702124" y="208.496406" transform="rotate(-0 139.702124 208.496406)">0.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="153.410649" y="208.495625" transform="rotate(-0 153.410649 208.495625)">0.5</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 191.574561 197.397969
-L 191.574561 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 218.991611 197.397969
+L 218.991611 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="191.574561" y="208.496406" transform="rotate(-0 191.574561 208.496406)">1.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="218.991611" y="208.495625" transform="rotate(-0 218.991611 208.495625)">1.0</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 243.446997 197.397969
-L 243.446997 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 284.572573 197.397969
+L 284.572573 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="243.446997" y="208.496406" transform="rotate(-0 243.446997 208.496406)">1.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="284.572573" y="208.495625" transform="rotate(-0 284.572573 208.495625)">1.5</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 295.319434 197.397969
-L 295.319434 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 350.153535 197.397969
+L 350.153535 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="295.319434" y="208.496406" transform="rotate(-0 295.319434 208.496406)">2.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="350.153535" y="208.495625" transform="rotate(-0 350.153535 208.495625)">2.0</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 347.191871 197.397969
-L 347.191871 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 415.734497 197.397969
+L 415.734497 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="347.191871" y="208.496406" transform="rotate(-0 347.191871 208.496406)">2.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="415.734497" y="208.495625" transform="rotate(-0 415.734497 208.495625)">2.5</text>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 399.064307 197.397969
-L 399.064307 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 481.315459 197.397969
+L 481.315459 31.077969
+" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="399.064307" y="208.496406" transform="rotate(-0 399.064307 208.496406)">3.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="481.315459" y="208.495625" transform="rotate(-0 481.315459 208.495625)">3.0</text>
      </g>
     </g>
-    <g id="xtick_8">
-     <g id="line2d_15">
-      <path d="M 450.936744 197.397969
-L 450.936744 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_16"/>
-     <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="450.936744" y="208.496406" transform="rotate(-0 450.936744 208.496406)">3.5</text>
-     </g>
-    </g>
-    <g id="xtick_9">
-     <g id="line2d_17">
-      <path d="M 502.809181 197.397969
-L 502.809181 31.077969
-" clip-path="url(#pdc58dc1ede)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_18"/>
-     <g id="text_9">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="502.809181" y="208.496406" transform="rotate(-0 502.809181 208.496406)">4.0</text>
-     </g>
-    </g>
-    <g id="text_10">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="316.609688" y="221.414688" transform="rotate(-0 316.609688 221.414688)">microseconds per construction (lower is faster)</text>
+    <g id="text_8">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="316.609688" y="221.736563" transform="rotate(-0 316.609688 221.736563)">microseconds per construction (lower is faster)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_19"/>
-     <g id="text_11">
+     <g id="line2d_15"/>
+     <g id="text_9">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="84.329688" y="160.208999" transform="rotate(-0 84.329688 160.208999)">small (4 fields)</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_20"/>
-     <g id="text_12">
+     <g id="line2d_16"/>
+     <g id="text_10">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="84.329688" y="75.865376" transform="rotate(-0 84.329688 75.865376)">wide (12 fields)</text>
      </g>
     </g>
@@ -162,27 +140,27 @@ L 545.389688 197.397969
    </g>
    <g id="patch_4">
     <path d="M 87.829688 143.730122
-L 140.800212 143.730122
-L 140.800212 122.981591
+L 155.92065 143.730122
+L 155.92065 122.981591
 L 87.829688 122.981591
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #5b626d"/>
+" clip-path="url(#p217c54a882)" style="fill: #5b626d"/>
    </g>
    <g id="patch_5">
     <path d="M 87.829688 59.3865
-L 212.346839 59.3865
-L 212.346839 38.637969
+L 248.420448 59.3865
+L 248.420448 38.637969
 L 87.829688 38.637969
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #5b626d"/>
+" clip-path="url(#p217c54a882)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
     <path d="M 87.829688 166.784045
-L 302.575434 166.784045
-L 302.575434 146.035514
+L 311.099245 166.784045
+L 311.099245 146.035514
 L 87.829688 146.035514
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #46b3ac"/>
+" clip-path="url(#p217c54a882)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_7">
     <path d="M 87.829688 82.440423
@@ -190,84 +168,84 @@ L 485.707948 82.440423
 L 485.707948 61.691892
 L 87.829688 61.691892
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #46b3ac"/>
+" clip-path="url(#p217c54a882)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_8">
     <path d="M 87.829688 189.837969
-L 172.562411 189.837969
-L 172.562411 169.089438
+L 177.640609 189.837969
+L 177.640609 169.089438
 L 87.829688 169.089438
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #24fefd"/>
+" clip-path="url(#p217c54a882)" style="fill: #24fefd"/>
    </g>
    <g id="patch_9">
     <path d="M 87.829688 105.494347
-L 247.857128 105.494347
-L 247.857128 84.745816
+L 256.398738 105.494347
+L 256.398738 84.745816
 L 87.829688 84.745816
 z
-" clip-path="url(#pdc58dc1ede)" style="fill: #24fefd"/>
+" clip-path="url(#p217c54a882)" style="fill: #24fefd"/>
+   </g>
+   <g id="text_11">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="159.855508" y="135.304099" transform="rotate(-0 159.855508 135.304099)">0.52</text>
+   </g>
+   <g id="text_12">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="252.355305" y="50.960476" transform="rotate(-0 252.355305 50.960476)">1.22</text>
    </g>
    <g id="text_13">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="143.912558" y="135.425388" transform="rotate(-0 143.912558 135.425388)">0.51</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="315.034102" y="158.358022" transform="rotate(-0 315.034102 158.358022)">1.70</text>
    </g>
    <g id="text_14">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="215.459185" y="51.081766" transform="rotate(-0 215.459185 51.081766)">1.20</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="489.642806" y="74.0144" transform="rotate(-0 489.642806 74.0144)">3.03</text>
    </g>
    <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="305.68778" y="158.479311" transform="rotate(-0 305.68778 158.479311)">2.07</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="181.575466" y="181.411945" transform="rotate(-0 181.575466 181.411945)">0.68</text>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="488.820295" y="74.135689" transform="rotate(-0 488.820295 74.135689)">3.84</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="260.333595" y="97.068323" transform="rotate(-0 260.333595 97.068323)">1.29</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="175.674757" y="181.533234" transform="rotate(-0 175.674757 181.533234)">0.82</text>
-   </g>
-   <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="250.969474" y="97.189612" transform="rotate(-0 250.969474 97.189612)">1.54</text>
-   </g>
-   <g id="text_19">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="87.829688" y="17.077969" transform="rotate(-0 87.829688 17.077969)">Dataclass construction vs mashumaro</text>
    </g>
    <g id="legend_1">
     <g id="patch_10">
-     <path d="M 179.051797 238.117841
-L 196.051797 238.117841
-L 196.051797 232.167841
-L 179.051797 232.167841
+     <path d="M 179.04582 238.117841
+L 196.04582 238.117841
+L 196.04582 232.167841
+L 179.04582 232.167841
 z
 " style="fill: #5b626d"/>
     </g>
-    <g id="text_20">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="202.851797" y="238.117841" transform="rotate(-0 202.851797 238.117841)">mashumaro</text>
+    <g id="text_18">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="202.84582" y="238.117841" transform="rotate(-0 202.84582 238.117841)">mashumaro</text>
     </g>
     <g id="patch_11">
-     <path d="M 270.534375 238.117841
-L 287.534375 238.117841
-L 287.534375 232.167841
-L 270.534375 232.167841
+     <path d="M 270.532383 238.117841
+L 287.532383 238.117841
+L 287.532383 232.167841
+L 270.532383 232.167841
 z
 " style="fill: #46b3ac"/>
     </g>
-    <g id="text_21">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="294.334375" y="238.117841" transform="rotate(-0 294.334375 238.117841)">probatio</text>
+    <g id="text_19">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="294.332383" y="238.117841" transform="rotate(-0 294.332383 238.117841)">probatio</text>
     </g>
     <g id="patch_12">
-     <path d="M 346.734219 238.117841
-L 363.734219 238.117841
-L 363.734219 232.167841
-L 346.734219 232.167841
+     <path d="M 346.736211 238.117841
+L 363.736211 238.117841
+L 363.736211 232.167841
+L 346.736211 232.167841
 z
 " style="fill: #24fefd"/>
     </g>
-    <g id="text_22">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="370.534219" y="238.117841" transform="rotate(-0 370.534219 238.117841)">probatio (compiled)</text>
+    <g id="text_20">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="370.536211" y="238.117841" transform="rotate(-0 370.536211 238.117841)">probatio (compiled)</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdc58dc1ede">
+  <clipPath id="p217c54a882">
    <rect x="87.829688" y="31.077969" width="457.56" height="166.32"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/validators.svg
+++ b/docs/public/benchmarks/validators.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.852188pt" height="391.968455pt" viewBox="0 0 573.852188 391.968455" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="588.825898pt" height="392.242713pt" viewBox="0 0 588.825898 392.242713" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-30T07:33:59.953658</dc:date>
+    <dc:date>2026-07-03T00:50:30.312272</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.7, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,37 +21,37 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 391.968455
-L 573.852188 391.968455
-L 573.852188 0
+   <path d="M 0 392.242713
+L 588.825898 392.242713
+L 588.825898 0
 L 0 0
 z
 " style="fill: #13151c"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 109.092187 319.365969
-L 566.652187 319.365969
-L 566.652187 31.077969
-L 109.092187 31.077969
+    <path d="M 109.096875 319.365969
+L 566.656875 319.365969
+L 566.656875 31.077969
+L 109.096875 31.077969
 z
 " style="fill: #13151c"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 347.935376 319.365969
-L 347.935376 31.077969
-" clip-path="url(#p28bcfae7f2)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 355.705969 319.365969
+L 355.705969 31.077969
+" clip-path="url(#p0ea0a0a56e)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(339.135376 330.464406)">
+      <g style="fill: #9aa3ad" transform="translate(346.905969 332.165969)">
        <text>
-        <tspan x="0" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
-        <tspan x="6.362305" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
-        <tspan x="12.820312" y="-3.892188" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="12.820312" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
        </text>
       </g>
      </g>
@@ -59,248 +59,344 @@ L 347.935376 31.077969
     <g id="xtick_2">
      <g id="line2d_3">
       <defs>
-       <path id="m2001ec62ad" d="M 0 0
+       <path id="m26d7966458" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2001ec62ad" x="154.059234" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="169.032882" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- $\mathdefault{2\times10^{0}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(150.932882 334.165969)">
+       <text>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">2</tspan>
+        <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2001ec62ad" x="202.90238" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="216.061365" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- $\mathdefault{3\times10^{0}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(197.961365 334.165969)">
+       <text>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">3</tspan>
+        <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2001ec62ad" x="237.557144" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="249.428604" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- $\mathdefault{4\times10^{0}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(231.328604 334.165969)">
+       <text>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">4</tspan>
+        <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2001ec62ad" x="264.437467" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="275.310246" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2001ec62ad" x="286.40029" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="296.457087" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- $\mathdefault{6\times10^{0}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(278.357087 334.165969)">
+       <text>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">6</tspan>
+        <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2001ec62ad" x="304.969592" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="314.336487" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2001ec62ad" x="321.055053" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="329.824327" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2001ec62ad" x="335.243436" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="343.48557" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2001ec62ad" x="431.433286" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="436.101692" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- $\mathdefault{2\times10^{1}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(418.001692 334.065969)">
+       <text>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">2</tspan>
+        <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2001ec62ad" x="480.276432" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="483.130175" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{3\times10^{1}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(465.030175 334.065969)">
+       <text>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">3</tspan>
+        <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m2001ec62ad" x="514.931196" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="516.497415" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{4\times10^{1}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(498.397415 334.065969)">
+       <text>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">4</tspan>
+        <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+       </text>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2001ec62ad" x="541.811519" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="542.379057" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2001ec62ad" x="563.774342" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m26d7966458" x="563.525898" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{6\times10^{1}}$ -->
+      <g style="fill: #9aa3ad" transform="translate(545.425898 334.065969)">
+       <text>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">6</tspan>
+        <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
+        <tspan x="18.637695" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="25" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="31.458008" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+       </text>
       </g>
      </g>
     </g>
-    <g id="text_2">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="337.872187" y="343.382687" transform="rotate(-0 337.872187 343.382687)">microseconds per load (log scale, lower is faster)</text>
+    <g id="text_10">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="337.876875" y="347.406906" transform="rotate(-0 337.876875 347.406906)">microseconds per load (log scale, lower is faster)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_16"/>
-     <g id="text_3">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="63.26147" transform="rotate(-0 105.592187 63.26147)">pydantic v2</text>
+     <g id="text_11">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="63.26147" transform="rotate(-0 105.596875 63.26147)">pydantic v2</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17"/>
-     <g id="text_4">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="109.565357" transform="rotate(-0 105.592187 109.565357)">probatio (compiled)</text>
+     <g id="text_12">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="109.565357" transform="rotate(-0 105.596875 109.565357)">probatio (compiled)</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_18"/>
-     <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="155.869244" transform="rotate(-0 105.592187 155.869244)">probatio</text>
+     <g id="text_13">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="155.869244" transform="rotate(-0 105.596875 155.869244)">probatio</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19"/>
-     <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="202.173131" transform="rotate(-0 105.592187 202.173131)">voluptuous</text>
+     <g id="text_14">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="202.173131" transform="rotate(-0 105.596875 202.173131)">voluptuous</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_20"/>
-     <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="248.477018" transform="rotate(-0 105.592187 248.477018)">pydantic v1</text>
+     <g id="text_15">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="248.477018" transform="rotate(-0 105.596875 248.477018)">pydantic v1</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21"/>
-     <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.592187" y="294.780905" transform="rotate(-0 105.592187 294.780905)">marshmallow</text>
+     <g id="text_16">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="105.596875" y="294.780905" transform="rotate(-0 105.596875 294.780905)">marshmallow</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 109.092188 319.365969
-L 566.652187 319.365969
+    <path d="M 109.096875 319.365969
+L 566.656875 319.365969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -277303.491285 44.181969
-L 126.357941 44.181969
-L 126.357941 74.742534
-L -277303.491285 74.742534
+    <path d="M -266980.173132 44.181969
+L 126.530665 44.181969
+L 126.530665 74.742534
+L -266980.173132 74.742534
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: url(#ha6335bb5cb)"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: url(#h6ad55a82e1)"/>
    </g>
    <g id="patch_5">
-    <path d="M -277303.491285 90.485856
-L 201.60076 90.485856
-L 201.60076 121.046421
-L -277303.491285 121.046421
+    <path d="M -266980.173132 90.485856
+L 196.623084 90.485856
+L 196.623084 121.046421
+L -266980.173132 121.046421
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: #24fefd"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: #24fefd"/>
    </g>
    <g id="patch_6">
-    <path d="M -277303.491285 136.789743
-L 261.904042 136.789743
-L 261.904042 167.350308
-L -277303.491285 167.350308
+    <path d="M -266980.173132 136.789743
+L 250.766254 136.789743
+L 250.766254 167.350308
+L -266980.173132 167.350308
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: #46b3ac"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_7">
-    <path d="M -277303.491285 183.09363
-L 330.184308 183.09363
-L 330.184308 213.654195
-L -277303.491285 213.654195
+    <path d="M -266980.173132 183.09363
+L 334.425738 183.09363
+L 334.425738 213.654195
+L -266980.173132 213.654195
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: #5b626d"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -277303.491285 229.397516
-L 351.937209 229.397516
-L 351.937209 259.958082
-L -277303.491285 259.958082
+    <path d="M -266980.173132 229.397516
+L 357.997309 229.397516
+L 357.997309 259.958082
+L -266980.173132 259.958082
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: #5b626d"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -277303.491285 275.701403
-L 471.673021 275.701403
-L 471.673021 306.261969
-L -277303.491285 306.261969
+    <path d="M -266980.173132 275.701403
+L 475.206457 275.701403
+L 475.206457 306.261969
+L -266980.173132 306.261969
 z
-" clip-path="url(#p28bcfae7f2)" style="fill: #5b626d"/>
+" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
    </g>
-   <g id="text_9">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.839198" y="61.531783" transform="rotate(-0 137.839198 61.531783)">1.59µs</text>
+   <g id="text_17">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.58536" y="61.410494" transform="rotate(-0 137.58536 61.410494)">1.39µs</text>
    </g>
-   <g id="text_10">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="213.082017" y="107.83567" transform="rotate(-0 213.082017 107.83567)">2.97µs</text>
+   <g id="text_18">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="207.677779" y="107.714381" transform="rotate(-0 207.677779 107.714381)">2.54µs</text>
    </g>
-   <g id="text_11">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="273.385299" y="154.139557" transform="rotate(-0 273.385299 154.139557)">4.90µs</text>
+   <g id="text_19">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="261.820949" y="154.018267" transform="rotate(-0 261.820949 154.018267)">4.05µs</text>
    </g>
-   <g id="text_12">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="341.665564" y="200.443443" transform="rotate(-0 341.665564 200.443443)">8.63µs</text>
+   <g id="text_20">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="345.480433" y="200.322154" transform="rotate(-0 345.480433 200.322154)">8.32µs</text>
    </g>
-   <g id="text_13">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="363.418466" y="246.74733" transform="rotate(-0 363.418466 246.74733)">10.34µs</text>
+   <g id="text_21">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="369.052004" y="246.626041" transform="rotate(-0 369.052004 246.626041)">10.20µs</text>
    </g>
-   <g id="text_14">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="483.154278" y="293.051217" transform="rotate(-0 483.154278 293.051217)">27.93µs</text>
+   <g id="text_22">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="486.261152" y="292.929928" transform="rotate(-0 486.261152 292.929928)">28.02µs</text>
    </g>
-   <g id="text_15">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="109.092187" y="17.077969" transform="rotate(-0 109.092187 17.077969)">Validators only, like for like</text>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="109.096875" y="17.077969" transform="rotate(-0 109.096875 17.077969)">Validators only, like for like</text>
    </g>
    <g id="legend_1">
     <g id="patch_10">
-     <path d="M 234.898672 379.600721
-L 251.898672 379.600721
-L 251.898672 373.650721
-L 234.898672 373.650721
+     <path d="M 234.898711 379.600721
+L 251.898711 379.600721
+L 251.898711 373.650721
+L 234.898711 373.650721
 z
 " style="fill: #5b626d"/>
     </g>
-    <g id="text_16">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="258.698672" y="379.600721" transform="rotate(-0 258.698672 379.600721)">pure Python</text>
+    <g id="text_24">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="258.698711" y="379.600721" transform="rotate(-0 258.698711 379.600721)">pure Python</text>
     </g>
     <g id="patch_11">
-     <path d="M 327.179453 379.600721
-L 344.179453 379.600721
-L 344.179453 373.650721
-L 327.179453 373.650721
+     <path d="M 327.183477 379.600721
+L 344.183477 379.600721
+L 344.183477 373.650721
+L 327.183477 373.650721
 z
-" style="fill: url(#ha6335bb5cb)"/>
+" style="fill: url(#h6ad55a82e1)"/>
     </g>
-    <g id="text_17">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="350.979453" y="379.600721" transform="rotate(-0 350.979453 379.600721)">native core (Rust / C)</text>
+    <g id="text_25">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="350.983477" y="379.600721" transform="rotate(-0 350.983477 379.600721)">native core (Rust / C)</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p28bcfae7f2">
-   <rect x="109.092187" y="31.077969" width="457.56" height="288.288"/>
+  <clipPath id="p0ea0a0a56e">
+   <rect x="109.096875" y="31.077969" width="457.56" height="288.288"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="ha6335bb5cb" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h6ad55a82e1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#5b626d"/>
    <path d="M -36 36
 L 36 -36

--- a/docs/public/benchmarks/vs-voluptuous.svg
+++ b/docs/public/benchmarks/vs-voluptuous.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="532.56pt" height="385.537415pt" viewBox="0 0 532.56 385.537415" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="532.56pt" height="385.811673pt" viewBox="0 0 532.56 385.811673" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-30T07:31:59.161177</dc:date>
+    <dc:date>2026-07-03T00:48:33.123698</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.7, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,8 +21,8 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 385.537415
-L 532.56 385.537415
+   <path d="M 0 385.811673
+L 532.56 385.811673
 L 532.56 0
 L 0 0
 z
@@ -42,122 +42,133 @@ z
      <g id="line2d_1">
       <path d="M 67.8 313.821969
 L 67.8 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="67.8" y="324.920406" transform="rotate(-0 67.8 324.920406)">0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="67.8" y="324.919625" transform="rotate(-0 67.8 324.919625)">0</text>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 128.518623 313.821969
-L 128.518623 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 124.017732 313.821969
+L 124.017732 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="128.518623" y="324.920406" transform="rotate(-0 128.518623 324.920406)">1</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="124.017732" y="324.919625" transform="rotate(-0 124.017732 324.919625)">1</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 189.237245 313.821969
-L 189.237245 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 180.235464 313.821969
+L 180.235464 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="189.237245" y="324.920406" transform="rotate(-0 189.237245 324.920406)">2</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="180.235464" y="324.919625" transform="rotate(-0 180.235464 324.919625)">2</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 249.955868 313.821969
-L 249.955868 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 236.453197 313.821969
+L 236.453197 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="249.955868" y="324.920406" transform="rotate(-0 249.955868 324.920406)">3</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="236.453197" y="324.919625" transform="rotate(-0 236.453197 324.919625)">3</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 310.674491 313.821969
-L 310.674491 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 292.670929 313.821969
+L 292.670929 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="310.674491" y="324.920406" transform="rotate(-0 310.674491 324.920406)">4</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="292.670929" y="324.919625" transform="rotate(-0 292.670929 324.919625)">4</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 371.393114 313.821969
-L 371.393114 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 348.888661 313.821969
+L 348.888661 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="371.393114" y="324.920406" transform="rotate(-0 371.393114 324.920406)">5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="348.888661" y="324.919625" transform="rotate(-0 348.888661 324.919625)">5</text>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 432.111736 313.821969
-L 432.111736 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 405.106393 313.821969
+L 405.106393 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="432.111736" y="324.920406" transform="rotate(-0 432.111736 324.920406)">6</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="405.106393" y="324.919625" transform="rotate(-0 405.106393 324.919625)">6</text>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 492.830359 313.821969
-L 492.830359 31.077969
-" clip-path="url(#p933a69282b)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 461.324126 313.821969
+L 461.324126 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="492.830359" y="324.920406" transform="rotate(-0 492.830359 324.920406)">7</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="461.324126" y="324.919625" transform="rotate(-0 461.324126 324.919625)">7</text>
      </g>
     </g>
-    <g id="text_9">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="296.58" y="337.838687" transform="rotate(-0 296.58 337.838687)">times faster than voluptuous (higher is better)</text>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 517.541858 313.821969
+L 517.541858 31.077969
+" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18"/>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="517.541858" y="324.919625" transform="rotate(-0 517.541858 324.919625)">8</text>
+     </g>
+    </g>
+    <g id="text_10">
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="296.58" y="338.160562" transform="rotate(-0 296.58 338.160562)">times faster than voluptuous (higher is better)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_17"/>
-     <g id="text_10">
+     <g id="line2d_19"/>
+     <g id="text_11">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="64.3" y="283.513063" transform="rotate(-0 64.3 283.513063)">flat types</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_18"/>
-     <g id="text_11">
+     <g id="line2d_20"/>
+     <g id="text_12">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="64.3" y="229.881125" transform="rotate(-0 64.3 229.881125)">config</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_19"/>
-     <g id="text_12">
+     <g id="line2d_21"/>
+     <g id="text_13">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="64.3" y="176.249187" transform="rotate(-0 64.3 176.249187)">combinator</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_20"/>
-     <g id="text_13">
+     <g id="line2d_22"/>
+     <g id="text_14">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="64.3" y="122.61725" transform="rotate(-0 64.3 122.61725)">number list</text>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_21"/>
-     <g id="text_14">
+     <g id="line2d_23"/>
+     <g id="text_15">
       <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="64.3" y="68.985312" transform="rotate(-0 64.3 68.985312)">nested</text>
      </g>
     </g>
@@ -169,194 +180,194 @@ L 525.36 313.821969
    </g>
    <g id="patch_4">
     <path d="M 67.8 271.651176
-L 128.518623 271.651176
-L 128.518623 258.457719
+L 124.017732 271.651176
+L 124.017732 258.457719
 L 67.8 258.457719
 z
-" clip-path="url(#p933a69282b)" style="fill: #5b626d"/>
+" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
    </g>
    <g id="patch_5">
     <path d="M 67.8 218.019238
-L 128.518623 218.019238
-L 128.518623 204.825782
+L 124.017732 218.019238
+L 124.017732 204.825782
 L 67.8 204.825782
 z
-" clip-path="url(#p933a69282b)" style="fill: #5b626d"/>
+" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
     <path d="M 67.8 164.387301
-L 128.518623 164.387301
-L 128.518623 151.193844
+L 124.017732 164.387301
+L 124.017732 151.193844
 L 67.8 151.193844
 z
-" clip-path="url(#p933a69282b)" style="fill: #5b626d"/>
+" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
     <path d="M 67.8 110.755363
-L 128.518623 110.755363
-L 128.518623 97.561906
+L 124.017732 110.755363
+L 124.017732 97.561906
 L 67.8 97.561906
 z
-" clip-path="url(#p933a69282b)" style="fill: #5b626d"/>
+" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
     <path d="M 67.8 57.123425
-L 128.518623 57.123425
-L 128.518623 43.929969
+L 124.017732 57.123425
+L 124.017732 43.929969
 L 67.8 43.929969
 z
-" clip-path="url(#p933a69282b)" style="fill: #5b626d"/>
+" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
     <path d="M 67.8 286.310572
-L 286.445296 286.310572
-L 286.445296 273.117116
+L 262.821244 286.310572
+L 262.821244 273.117116
 L 67.8 273.117116
 z
-" clip-path="url(#p933a69282b)" style="fill: #46b3ac"/>
+" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_10">
     <path d="M 67.8 232.678635
-L 236.159613 232.678635
-L 236.159613 219.485178
+L 220.156577 232.678635
+L 220.156577 219.485178
 L 67.8 219.485178
 z
-" clip-path="url(#p933a69282b)" style="fill: #46b3ac"/>
+" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_11">
     <path d="M 67.8 179.046697
-L 194.563161 179.046697
-L 194.563161 165.85324
+L 185.556345 179.046697
+L 185.556345 165.85324
 L 67.8 165.85324
 z
-" clip-path="url(#p933a69282b)" style="fill: #46b3ac"/>
+" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_12">
     <path d="M 67.8 125.414759
-L 159.686432 125.414759
-L 159.686432 112.221303
+L 159.038301 125.414759
+L 159.038301 112.221303
 L 67.8 112.221303
 z
-" clip-path="url(#p933a69282b)" style="fill: #46b3ac"/>
+" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_13">
     <path d="M 67.8 71.782822
-L 206.732582 71.782822
-L 206.732582 58.589365
+L 199.533454 71.782822
+L 199.533454 58.589365
 L 67.8 58.589365
 z
-" clip-path="url(#p933a69282b)" style="fill: #46b3ac"/>
+" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_14">
     <path d="M 67.8 300.969969
-L 452.359197 300.969969
-L 452.359197 287.776512
+L 427.613022 300.969969
+L 427.613022 287.776512
 L 67.8 287.776512
 z
-" clip-path="url(#p933a69282b)" style="fill: #24fefd"/>
+" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
    </g>
    <g id="patch_15">
     <path d="M 67.8 247.338031
-L 455.562712 247.338031
-L 455.562712 234.144574
+L 439.124317 247.338031
+L 439.124317 234.144574
 L 67.8 234.144574
 z
-" clip-path="url(#p933a69282b)" style="fill: #24fefd"/>
+" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
    </g>
    <g id="patch_16">
     <path d="M 67.8 193.706093
-L 386.589402 193.706093
-L 386.589402 180.512637
+L 413.819277 193.706093
+L 413.819277 180.512637
 L 67.8 180.512637
 z
-" clip-path="url(#p933a69282b)" style="fill: #24fefd"/>
+" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
    </g>
    <g id="patch_17">
     <path d="M 67.8 140.074156
-L 291.610055 140.074156
-L 291.610055 126.880699
+L 325.262965 140.074156
+L 325.262965 126.880699
 L 67.8 126.880699
 z
-" clip-path="url(#p933a69282b)" style="fill: #24fefd"/>
+" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
    </g>
    <g id="patch_18">
     <path d="M 67.8 86.442218
-L 431.689812 86.442218
-L 431.689812 73.248761
+L 455.562712 86.442218
+L 455.562712 73.248761
 L 67.8 73.248761
 z
-" clip-path="url(#p933a69282b)" style="fill: #24fefd"/>
-   </g>
-   <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="132.768926" y="267.123979" transform="rotate(-0 132.768926 267.123979)">1.0x</text>
+" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="132.768926" y="213.492041" transform="rotate(-0 132.768926 213.492041)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="267.00269" transform="rotate(-0 127.952973 267.00269)">1.0x</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="132.768926" y="159.860104" transform="rotate(-0 132.768926 159.860104)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="213.370752" transform="rotate(-0 127.952973 213.370752)">1.0x</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="132.768926" y="106.228166" transform="rotate(-0 132.768926 106.228166)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="159.738815" transform="rotate(-0 127.952973 159.738815)">1.0x</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="132.768926" y="52.596228" transform="rotate(-0 132.768926 52.596228)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="106.106877" transform="rotate(-0 127.952973 106.106877)">1.0x</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="290.6956" y="281.783375" transform="rotate(-0 290.6956 281.783375)">3.6x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="52.474939" transform="rotate(-0 127.952973 52.474939)">1.0x</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="240.409916" y="228.151438" transform="rotate(-0 240.409916 228.151438)">2.8x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="266.756485" y="281.662086" transform="rotate(-0 266.756485 281.662086)">3.5x</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="198.813465" y="174.5195" transform="rotate(-0 198.813465 174.5195)">2.1x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="224.091818" y="228.030149" transform="rotate(-0 224.091818 228.030149)">2.7x</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="163.936735" y="120.887562" transform="rotate(-0 163.936735 120.887562)">1.5x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="189.491586" y="174.398211" transform="rotate(-0 189.491586 174.398211)">2.1x</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="210.982885" y="67.255625" transform="rotate(-0 210.982885 67.255625)">2.3x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="162.973542" y="120.766273" transform="rotate(-0 162.973542 120.766273)">1.6x</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="456.609501" y="296.442772" transform="rotate(-0 456.609501 296.442772)">6.3x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="203.468695" y="67.134336" transform="rotate(-0 203.468695 67.134336)">2.3x</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="459.813015" y="242.810834" transform="rotate(-0 459.813015 242.810834)">6.4x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="431.548263" y="296.321483" transform="rotate(-0 431.548263 296.321483)">6.4x</text>
    </g>
    <g id="text_27">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="390.839706" y="189.178896" transform="rotate(-0 390.839706 189.178896)">5.3x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="443.059558" y="242.689545" transform="rotate(-0 443.059558 242.689545)">6.6x</text>
    </g>
    <g id="text_28">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="295.860359" y="135.546959" transform="rotate(-0 295.860359 135.546959)">3.7x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="417.754518" y="189.057607" transform="rotate(-0 417.754518 189.057607)">6.2x</text>
    </g>
    <g id="text_29">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="435.940115" y="81.915021" transform="rotate(-0 435.940115 81.915021)">6.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="329.198206" y="135.42567" transform="rotate(-0 329.198206 135.42567)">4.6x</text>
    </g>
    <g id="text_30">
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="459.497953" y="81.793732" transform="rotate(-0 459.497953 81.793732)">6.9x</text>
+   </g>
+   <g id="text_31">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="67.8" y="17.077969" transform="rotate(-0 67.8 17.077969)">Validation throughput vs voluptuous</text>
    </g>
    <g id="legend_1">
     <g id="patch_19">
-     <path d="M 160.807773 373.169681
-L 177.807773 373.169681
-L 177.807773 367.219681
-L 160.807773 367.219681
+     <path d="M 160.803789 373.169681
+L 177.803789 373.169681
+L 177.803789 367.219681
+L 160.803789 367.219681
 z
 " style="fill: #5b626d"/>
     </g>
-    <g id="text_31">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="184.607773" y="373.169681" transform="rotate(-0 184.607773 373.169681)">voluptuous</text>
+    <g id="text_32">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="184.603789" y="373.169681" transform="rotate(-0 184.603789 373.169681)">voluptuous</text>
     </g>
     <g id="patch_20">
-     <path d="M 248.719023 373.169681
-L 265.719023 373.169681
-L 265.719023 367.219681
-L 248.719023 367.219681
+     <path d="M 248.715039 373.169681
+L 265.715039 373.169681
+L 265.715039 367.219681
+L 248.715039 367.219681
 z
 " style="fill: #46b3ac"/>
     </g>
-    <g id="text_32">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="272.519023" y="373.169681" transform="rotate(-0 272.519023 373.169681)">probatio</text>
+    <g id="text_33">
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="272.515039" y="373.169681" transform="rotate(-0 272.515039 373.169681)">probatio</text>
     </g>
     <g id="patch_21">
      <path d="M 324.918867 373.169681
@@ -366,14 +377,14 @@ L 324.918867 367.219681
 z
 " style="fill: #24fefd"/>
     </g>
-    <g id="text_33">
+    <g id="text_34">
      <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="348.718867" y="373.169681" transform="rotate(-0 348.718867 373.169681)">probatio (compiled)</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p933a69282b">
+  <clipPath id="p36a59b939f">
    <rect x="67.8" y="31.077969" width="457.56" height="282.744"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-world.svg
+++ b/docs/public/benchmarks/vs-world.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.039687pt" height="517.041095pt" viewBox="0 0 575.039687 517.041095" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.044375pt" height="517.315353pt" viewBox="0 0 575.044375 517.315353" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-30T07:33:00.933772</dc:date>
+    <dc:date>2026-07-03T00:49:33.638518</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.10.7, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.11.0, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -21,36 +21,36 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 517.041095
-L 575.039687 517.041095
-L 575.039687 0
-L 0 0
+   <path d="M 0 517.315353
+L 575.044375 517.315353
+L 575.044375 -0
+L 0 -0
 z
 " style="fill: #13151c"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 110.279687 441.333969
-L 567.839687 441.333969
-L 567.839687 31.077969
-L 110.279687 31.077969
+    <path d="M 110.284375 441.333969
+L 567.844375 441.333969
+L 567.844375 31.077969
+L 110.284375 31.077969
 z
 " style="fill: #13151c"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 148.171478 441.333969
-L 148.171478 31.077969
-" clip-path="url(#p594c6f56ee)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 145.569529 441.333969
+L 145.569529 31.077969
+" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(139.371478 452.432406)">
+      <g style="fill: #9aa3ad" transform="translate(136.769529 454.233969)">
        <text>
-        <tspan x="0" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
-        <tspan x="6.362305" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
         <tspan x="12.820312" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
        </text>
       </g>
@@ -58,35 +58,35 @@ L 148.171478 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 315.28936 441.333969
-L 315.28936 31.077969
-" clip-path="url(#p594c6f56ee)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 313.761545 441.333969
+L 313.761545 31.077969
+" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(306.48936 452.432406)">
+      <g style="fill: #9aa3ad" transform="translate(304.961545 454.133969)">
        <text>
-        <tspan x="0" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
-        <tspan x="6.362305" y="-0.064063" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
-        <tspan x="12.820312" y="-3.892188" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="12.820312" y="-4.892187" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
        </text>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 482.407243 441.333969
-L 482.407243 31.077969
-" clip-path="url(#p594c6f56ee)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 481.953561 441.333969
+L 481.953561 31.077969
+" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(473.607243 452.432406)">
+      <g style="fill: #9aa3ad" transform="translate(473.153561 454.233969)">
        <text>
-        <tspan x="0" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
-        <tspan x="6.362305" y="-0.976562" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
+        <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
+        <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
         <tspan x="12.820312" y="-4.804688" style="font-size: 7px; font-family: 'DejaVu Sans'; fill: #9aa3ad">2</tspan>
        </text>
       </g>
@@ -95,396 +95,389 @@ L 482.407243 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="m77218c5bf6" d="M 0 0
+       <path id="ma858843902" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m77218c5bf6" x="111.096584" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="119.516256" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m77218c5bf6" x="122.28459" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="129.270038" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m77218c5bf6" x="131.976082" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="137.873484" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m77218c5bf6" x="140.524583" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="196.20037" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m77218c5bf6" x="198.478973" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="225.817514" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m77218c5bf6" x="227.906972" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="246.831212" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m77218c5bf6" x="248.786469" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="263.130703" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m77218c5bf6" x="264.981865" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="276.448356" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m77218c5bf6" x="278.214467" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="287.708272" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m77218c5bf6" x="289.402473" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="297.462054" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m77218c5bf6" x="299.093964" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="306.0655" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m77218c5bf6" x="307.642465" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="364.392387" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m77218c5bf6" x="365.596856" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="394.009531" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m77218c5bf6" x="395.024854" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="415.023229" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m77218c5bf6" x="415.904351" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="431.322719" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m77218c5bf6" x="432.099747" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="444.640372" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m77218c5bf6" x="445.33235" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="455.900288" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m77218c5bf6" x="456.520355" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="465.65407" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m77218c5bf6" x="466.211847" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="474.257516" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m77218c5bf6" x="474.760348" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="532.584403" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m77218c5bf6" x="532.714738" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_25">
-     <g id="line2d_28">
-      <g>
-       <use xlink:href="#m77218c5bf6" x="562.142737" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#ma858843902" x="562.201547" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_4">
-     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="339.059687" y="465.350688" transform="rotate(-0 339.059687 465.350688)">microseconds per load (log scale, lower is faster)</text>
+     <text style="font-size: 9px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="339.064375" y="467.474906" transform="rotate(-0 339.064375 467.474906)">microseconds per load (log scale, lower is faster)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_29"/>
+     <g id="line2d_28"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="66.049964" transform="rotate(-0 106.779687 66.049964)">probatio (construct)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="66.049964" transform="rotate(-0 106.784375 66.049964)">probatio (construct)</text>
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_30"/>
+     <g id="line2d_29"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="100.841008" transform="rotate(-0 106.779687 100.841008)">mashumaro</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="100.841008" transform="rotate(-0 106.784375 100.841008)">mashumaro</text>
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_31"/>
+     <g id="line2d_30"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="135.632053" transform="rotate(-0 106.779687 135.632053)">cattrs</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="135.631663" transform="rotate(-0 106.784375 135.631663)">cattrs</text>
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_32"/>
+     <g id="line2d_31"/>
      <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="170.423098" transform="rotate(-0 106.779687 170.423098)">pydantic v2</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="170.423098" transform="rotate(-0 106.784375 170.423098)">pydantic v2</text>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_33"/>
+     <g id="line2d_32"/>
      <g id="text_9">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="205.214143" transform="rotate(-0 106.779687 205.214143)">probatio (compiled)</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="205.214143" transform="rotate(-0 106.784375 205.214143)">probatio (compiled)</text>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_34"/>
+     <g id="line2d_33"/>
      <g id="text_10">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="240.005188" transform="rotate(-0 106.779687 240.005188)">probatio</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="240.005187" transform="rotate(-0 106.784375 240.005187)">probatio</text>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_35"/>
+     <g id="line2d_34"/>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="274.796232" transform="rotate(-0 106.779687 274.796232)">voluptuous</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="274.796232" transform="rotate(-0 106.784375 274.796232)">voluptuous</text>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_36"/>
+     <g id="line2d_35"/>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="309.587277" transform="rotate(-0 106.779687 309.587277)">pydantic v1</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="309.587277" transform="rotate(-0 106.784375 309.587277)">pydantic v1</text>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_37"/>
+     <g id="line2d_36"/>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="344.378322" transform="rotate(-0 106.779687 344.378322)">dacite</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="344.378322" transform="rotate(-0 106.784375 344.378322)">dacite</text>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_38"/>
+     <g id="line2d_37"/>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="379.169367" transform="rotate(-0 106.779687 379.169367)">marshmallow</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="379.169367" transform="rotate(-0 106.784375 379.169367)">marshmallow</text>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_39"/>
+     <g id="line2d_38"/>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.779687" y="413.960411" transform="rotate(-0 106.779687 413.960411)">dataclasses-json</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: end; fill: #e6edf3" x="106.784375" y="413.960411" transform="rotate(-0 106.784375 413.960411)">dataclasses-json</text>
      </g>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 110.279687 441.333969
-L 567.839687 441.333969
+    <path d="M 110.284375 441.333969
+L 567.844375 441.333969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -166969.711098 49.725969
-L 129.343261 49.725969
-L 129.343261 74.775521
-L -166969.711098 74.775521
+    <path d="M -168046.44665 49.725969
+L 129.330434 49.725969
+L 129.330434 74.775521
+L -168046.44665 74.775521
 z
-" clip-path="url(#p594c6f56ee)" style="fill: url(#hbcdf086a27)"/>
+" clip-path="url(#p5529b08340)" style="fill: url(#hf84c0436f1)"/>
    </g>
    <g id="patch_5">
-    <path d="M -166969.711098 84.517014
-L 161.538056 84.517014
-L 161.538056 109.566566
-L -166969.711098 109.566566
+    <path d="M -168046.44665 84.517014
+L 155.003732 84.517014
+L 155.003732 109.566566
+L -168046.44665 109.566566
 z
-" clip-path="url(#p594c6f56ee)" style="fill: url(#h279670525c)"/>
+" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
    </g>
    <g id="patch_6">
-    <path d="M -166969.711098 119.308058
-L 170.613434 119.308058
-L 170.613434 144.357611
-L -166969.711098 144.357611
+    <path d="M -168046.44665 119.308058
+L 167.573667 119.308058
+L 167.573667 144.357611
+L -168046.44665 144.357611
 z
-" clip-path="url(#p594c6f56ee)" style="fill: url(#h279670525c)"/>
+" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
    </g>
    <g id="patch_7">
-    <path d="M -166969.711098 154.099103
-L 179.472502 154.099103
-L 179.472502 179.148655
-L -166969.711098 179.148655
+    <path d="M -168046.44665 154.099103
+L 169.327366 154.099103
+L 169.327366 179.148655
+L -168046.44665 179.148655
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #5b626d"/>
+" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -166969.711098 188.890148
-L 226.476705 188.890148
-L 226.476705 213.9397
-L -166969.711098 213.9397
+    <path d="M -168046.44665 188.890148
+L 212.132895 188.890148
+L 212.132895 213.9397
+L -168046.44665 213.9397
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #24fefd"/>
+" clip-path="url(#p5529b08340)" style="fill: #24fefd"/>
    </g>
    <g id="patch_9">
-    <path d="M -166969.711098 223.681193
-L 263.225791 223.681193
-L 263.225791 248.730745
-L -166969.711098 248.730745
+    <path d="M -168046.44665 223.681193
+L 247.367365 223.681193
+L 247.367365 248.730745
+L -168046.44665 248.730745
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #46b3ac"/>
+" clip-path="url(#p5529b08340)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_10">
-    <path d="M -166969.711098 258.472237
-L 304.158197 258.472237
-L 304.158197 283.52179
-L -166969.711098 283.52179
+    <path d="M -168046.44665 258.472237
+L 299.558735 258.472237
+L 299.558735 283.52179
+L -168046.44665 283.52179
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #5b626d"/>
+" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -166969.711098 293.263282
-L 316.459955 293.263282
-L 316.459955 318.312834
-L -166969.711098 318.312834
+    <path d="M -168046.44665 293.263282
+L 316.448118 293.263282
+L 316.448118 318.312834
+L -168046.44665 318.312834
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #5b626d"/>
+" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -166969.711098 328.054327
-L 358.945539 328.054327
-L 358.945539 353.103879
-L -166969.711098 353.103879
+    <path d="M -168046.44665 328.054327
+L 358.06942 328.054327
+L 358.06942 353.103879
+L -168046.44665 353.103879
 z
-" clip-path="url(#p594c6f56ee)" style="fill: url(#h279670525c)"/>
+" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
    </g>
    <g id="patch_13">
-    <path d="M -166969.711098 362.845372
-L 389.651643 362.845372
-L 389.651643 387.894924
-L -166969.711098 387.894924
+    <path d="M -168046.44665 362.845372
+L 389.309559 362.845372
+L 389.309559 387.894924
+L -168046.44665 387.894924
 z
-" clip-path="url(#p594c6f56ee)" style="fill: #5b626d"/>
+" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
    </g>
    <g id="patch_14">
-    <path d="M -166969.711098 397.636417
-L 510.614734 397.636417
-L 510.614734 422.685969
-L -166969.711098 422.685969
+    <path d="M -168046.44665 397.636417
+L 510.251614 397.636417
+L 510.251614 422.685969
+L -168046.44665 422.685969
 z
-" clip-path="url(#p594c6f56ee)" style="fill: url(#h279670525c)"/>
+" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.568473" y="64.320276" transform="rotate(-0 137.568473 64.320276)">0.77µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.608512" y="64.198987" transform="rotate(-0 137.608512 64.198987)">0.80µs</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="169.763267" y="99.111321" transform="rotate(-0 169.763267 99.111321)">1.20µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="163.28181" y="98.990032" transform="rotate(-0 163.28181 98.990032)">1.14µs</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="178.838646" y="133.902366" transform="rotate(-0 178.838646 133.902366)">1.36µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="175.851745" y="133.781077" transform="rotate(-0 175.851745 133.781077)">1.35µs</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="187.697714" y="168.69341" transform="rotate(-0 187.697714 168.69341)">1.54µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.605444" y="168.572121" transform="rotate(-0 177.605444 168.572121)">1.38µs</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="234.701917" y="203.484455" transform="rotate(-0 234.701917 203.484455)">2.94µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="220.410974" y="203.363166" transform="rotate(-0 220.410974 203.363166)">2.49µs</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="271.451002" y="238.2755" transform="rotate(-0 271.451002 238.2755)">4.88µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="255.645443" y="238.154211" transform="rotate(-0 255.645443 238.154211)">4.03µs</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="312.383409" y="273.066545" transform="rotate(-0 312.383409 273.066545)">8.58µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="307.836814" y="272.945256" transform="rotate(-0 307.836814 272.945256)">8.23µs</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="324.685166" y="307.85759" transform="rotate(-0 324.685166 307.85759)">10.16µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="324.726197" y="307.7363" transform="rotate(-0 324.726197 307.7363)">10.37µs</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="367.170751" y="342.648634" transform="rotate(-0 367.170751 342.648634)">18.25µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="366.347499" y="342.527345" transform="rotate(-0 366.347499 342.527345)">18.34µs</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.876854" y="377.439679" transform="rotate(-0 397.876854 377.439679)">27.86µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.587638" y="377.31839" transform="rotate(-0 397.587638 377.31839)">28.13µs</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="518.839946" y="412.230724" transform="rotate(-0 518.839946 412.230724)">147.50µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="518.529692" y="412.109435" transform="rotate(-0 518.529692 412.109435)">147.32µs</text>
    </g>
    <g id="text_27">
-    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="110.279687" y="17.077969" transform="rotate(-0 110.279687 17.077969)">dict to object, across libraries</text>
+    <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="110.284375" y="17.077969" transform="rotate(-0 110.284375 17.077969)">dict to object, across libraries</text>
    </g>
    <g id="legend_1">
     <g id="patch_15">
-     <path d="M 180.927812 504.673361
-L 197.927812 504.673361
-L 197.927812 498.723361
-L 180.927812 498.723361
+     <path d="M 180.9325 504.673361
+L 197.9325 504.673361
+L 197.9325 498.723361
+L 180.9325 498.723361
 z
 " style="fill: #5b626d"/>
     </g>
     <g id="text_28">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="204.727812" y="504.673361" transform="rotate(-0 204.727812 504.673361)">validates (checks every field)</text>
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="204.7325" y="504.673361" transform="rotate(-0 204.7325 504.673361)">validates (checks every field)</text>
     </g>
     <g id="patch_16">
-     <path d="M 346.695078 504.673361
-L 363.695078 504.673361
-L 363.695078 498.723361
-L 346.695078 498.723361
+     <path d="M 346.699766 504.673361
+L 363.699766 504.673361
+L 363.699766 498.723361
+L 346.699766 498.723361
 z
-" style="fill: url(#h279670525c)"/>
+" style="fill: url(#hed66c801f2)"/>
     </g>
     <g id="text_29">
-     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="370.495078" y="504.673361" transform="rotate(-0 370.495078 504.673361)">deserializes (trusts the types)</text>
+     <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="370.499766" y="504.673361" transform="rotate(-0 370.499766 504.673361)">deserializes (trusts the types)</text>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p594c6f56ee">
-   <rect x="110.279687" y="31.077969" width="457.56" height="410.256"/>
+  <clipPath id="p5529b08340">
+   <rect x="110.284375" y="31.077969" width="457.56" height="410.256"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hbcdf086a27" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf84c0436f1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#46b3ac"/>
    <path d="M -36 36
 L 36 -36
@@ -538,7 +531,7 @@ M 36 108
 L 108 36
 " style="fill: #13151c; stroke: #13151c; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="h279670525c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hed66c801f2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#5b626d"/>
    <path d="M -36 36
 L 36 -36

--- a/docs/src/content/docs/guides/compiled-schemas.md
+++ b/docs/src/content/docs/guides/compiled-schemas.md
@@ -155,7 +155,7 @@ not need to think about this.
 
 ## Numbers
 
-On the bundled benchmarks, compiled validation runs up to roughly six times faster
+On the bundled benchmarks, compiled validation runs up to roughly seven times faster
 than the same schema in voluptuous, and the interpreted engine already runs about
 one and a half to three and a half times faster. The exact ratio moves with the
 machine, the Python version, and the schema. See [Performance](/reference/performance/)

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -145,8 +145,8 @@ The two are close on the dict-to-dataclass path, which is worth seeing precisely
 because they do different amounts of work. mashumaro deserializes and largely
 trusts the declared types; Probatio's `DataclassSchema` validates every field
 against its type and then constructs. On a small dataclass, mashumaro builds it in
-about 0.5 µs and a compiled Probatio schema in about 0.8 µs, so Probatio is within
-roughly 1.3x to 1.6x while actually validating, and the gap narrows as the field
+about 0.5 µs and a compiled Probatio schema in about 0.6 µs, so Probatio is within
+roughly 1.3x while actually validating, and the gap all but closes as the field
 count grows. That is the trade: mashumaro is faster because it trusts the input,
 Probatio costs a little more because it does not. If the input is wrong (a string
 where an int belongs), mashumaro may hand you a dataclass whose values do not match

--- a/docs/src/content/docs/reference/performance.md
+++ b/docs/src/content/docs/reference/performance.md
@@ -52,19 +52,19 @@ to turn the behavior off for an unusual workload, see
 
 On the bundled benchmark scenarios, the interpreted engine runs roughly one and a
 half to three and a half times faster than the same schema in voluptuous, and the
-compiled path reaches up to about six times faster on real config and dataclass
+compiled path reaches up to about seven times faster on real config and dataclass
 shapes. The exact ratio moves with the machine, the Python version, and the shape of
 the schema, so treat these as ballparks, not promises.
 
 | Scenario                         | voluptuous | Probatio | Probatio compiled |
 | -------------------------------- | ---------- | -------- | ----------------- |
-| Flat types (`{str, int, ...}`)   | 3.5 µs     | 1.0 µs   | 0.6 µs            |
-| Config (coerce, range, in, list) | 5.7 µs     | 2.2 µs   | 0.9 µs            |
-| Nested mapping                   | 6.8 µs     | 3.1 µs   | 1.1 µs            |
+| Flat types (`{str, int, ...}`)   | 3.6 µs     | 1.0 µs   | 0.5 µs            |
+| Config (coerce, range, in, list) | 5.7 µs     | 2.1 µs   | 0.9 µs            |
+| Nested mapping                   | 6.6 µs     | 2.8 µs   | 1.0 µs            |
 
 Microseconds per validation, lower is faster, on one machine with Python 3.13.
 
-![Validation throughput vs voluptuous: probatio is 1.5 to 3.6 times faster interpreted, and 3.7 to 6.4 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
+![Validation throughput vs voluptuous: probatio is 1.6 to 3.6 times faster interpreted, and 4.6 to 6.9 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
 
 :::caution[Read the benchmark honestly]
 `bench/bench.py` is a rough, single-machine comparison. It builds equivalent
@@ -86,15 +86,15 @@ per class. It is not a like-for-like comparison, and that is the point: mashumar
 deserializes and largely trusts the declared types, while Probatio _validates_ every
 field against its type and then constructs. mashumaro does strictly less work, so it
 is faster on already-correct input. The compiled Probatio path lands within roughly
-1.3x to 1.6x of it while still validating, and the gap narrows as the field count
-grows.
+1.3x of it on a small dataclass while still validating, and the gap all but closes
+as the field count grows (about 1.05x on a wide one).
 
 | Dataclass        | mashumaro | Probatio | Probatio compiled |
 | ---------------- | --------- | -------- | ----------------- |
-| Small (4 fields) | 0.5 µs    | 2.0 µs   | 0.8 µs            |
-| Wide (12 fields) | 1.2 µs    | 3.8 µs   | 1.5 µs            |
+| Small (4 fields) | 0.5 µs    | 1.7 µs   | 0.6 µs            |
+| Wide (12 fields) | 1.2 µs    | 2.9 µs   | 1.3 µs            |
 
-![Dataclass construction vs mashumaro: compiled probatio is within about 1.3 to 1.6 times of mashumaro while validating every field.](/benchmarks/dataclass-vs-mashumaro.svg)
+![Dataclass construction vs mashumaro: compiled probatio is within about 1.3 times of mashumaro on a small dataclass and essentially even on a wide one, while validating every field.](/benchmarks/dataclass-vs-mashumaro.svg)
 
 The two libraries pair well: validate untrusted input with Probatio, then hand
 trusted dataclasses to mashumaro to serialize. See
@@ -119,7 +119,7 @@ from trusted input without validating, the same job the deserializers do.
 
 Two honest readings. On the **validate** path, compiled Probatio lands in the
 leading group, ahead of voluptuous, pydantic v1, dacite, marshmallow, and
-dataclasses-json, and within about 2x of the Rust-cored pydantic v2, while staying
+dataclasses-json, and within about 1.8x of the Rust-cored pydantic v2, while staying
 pure Python and validating every field. On the **trust the types** path,
 `construct` is the fastest in the whole field, ahead of mashumaro and cattrs,
 because it is a purpose-built constructor generated for that one dataclass. Run it

--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -30,6 +30,7 @@ return ``None``, and the schema stays interpreted.
 
 from __future__ import annotations
 
+from enum import Enum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -47,6 +48,14 @@ if TYPE_CHECKING:
     from types import CodeType
 
     from probatio._engine import _Candidate
+    from probatio.validators.coerce import Coerce
+    from probatio.validators.combinators import All
+    from probatio.validators.combinators import Any as AnyValidator
+    from probatio.validators.comparison import In, Range
+
+    _ValidatorTypes = tuple[
+        type[Coerce[Any]], type[Range], type[In], type[AnyValidator], type[All]
+    ]
 
 # A missing key, distinct from any real value (a key whose value is ``None`` is
 # present). Module-level so every generated function shares it by identity.
@@ -152,15 +161,24 @@ def _inline_coerce(target: Any) -> list[str] | None:
     return None
 
 
-def _inline_range(schema: Any) -> list[str] | None:
-    """Inline a numeric ``Range`` with numeric bounds; ``_v`` is unchanged."""
+def _inline_range(schema: Any, *, type_checked: bool = False) -> list[str] | None:
+    """Inline a numeric ``Range`` with numeric bounds; ``_v`` is unchanged.
+
+    ``type_checked`` is the caller asserting ``_v`` is already known to be an
+    ``int`` or ``float`` (an inlined ``Coerce`` just guaranteed it), so the type
+    guard would be dead code and is skipped.
+    """
     low, high = schema.min, schema.max
     if (low is not None and not isinstance(low, (int, float))) or (
         high is not None and not isinstance(high, (int, float))
     ):
         return None
 
-    lines = ["        if type(_v) not in (int, float):", "            raise _Bail"]
+    lines = (
+        []
+        if type_checked
+        else ["        if type(_v) not in (int, float):", "            raise _Bail"]
+    )
     if low is not None:
         op = ">=" if schema.min_included else ">"
         lines += [f"        if not (_v {op} {low!r}):", "            raise _Bail"]
@@ -181,12 +199,13 @@ def _emit_membership(name: str) -> list[str]:
     ``In`` catches both and reports a miss, so the inline form catches both too and
     bails rather than letting either crash or leak.
     """
+    # The inner ``raise _Bail`` is not caught by the ``except`` (``_Bail`` is
+    # neither error); testing inline avoids a ``_hit`` store-and-load per check.
     return [
         "        try:",
-        f"            _hit = _v in {name}",
+        f"            if _v not in {name}:",
+        "                raise _Bail",
         "        except (TypeError, ArithmeticError):",
-        "            _hit = False",
-        "        if not _hit:",
         "            raise _Bail",
     ]
 
@@ -210,8 +229,6 @@ def _inline_in(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] | 
 
 def _inline_type(schema: type, namespace: dict[str, Any], tag: str) -> list[str] | None:
     """Inline an isinstance check for a plain (non-Enum) type; ``_v`` is unchanged."""
-    from enum import Enum  # noqa: PLC0415
-
     if issubclass(schema, Enum):
         return None
     namespace[f"_ty{tag}"] = schema
@@ -219,13 +236,30 @@ def _inline_type(schema: type, namespace: dict[str, Any], tag: str) -> list[str]
 
 
 def _inline_all(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] | None:
-    """Inline an ``All`` chain, bailing the whole chain if a branch is not inlinable."""
+    """Inline an ``All`` chain, bailing the whole chain if a branch is not inlinable.
+
+    The chain tracks when ``_v`` is pinned to a numeric type: after an inlined
+    ``Coerce(int)``/``Coerce(float)`` succeeds, a following ``Range``'s type guard
+    is provably dead and is elided (``All(Coerce(int), Range(...))`` is the
+    dominant hot-path composition). ``Range`` and ``In`` leave ``_v`` unchanged,
+    so the knowledge survives them; any other branch conservatively resets it.
+    """
+    coerce_cls, range_cls, in_cls, _, _ = _validator_types()
     chained: list[str] = []
+    numeric = False
     for position, sub in enumerate(schema.validators):
-        sub_lines = _inline_value(sub, namespace, f"{tag}_{position}")
+        if numeric and isinstance(sub, range_cls):
+            sub_lines = _inline_range(sub, type_checked=True)
+        else:
+            sub_lines = _inline_value(sub, namespace, f"{tag}_{position}")
         if sub_lines is None:
             return None
         chained.extend(sub_lines)
+        if isinstance(sub, coerce_cls):
+            # The lines were emitted, so ``_inline_coerce`` accepted the target.
+            numeric = sub.type is int or sub.type is float
+        elif not isinstance(sub, (range_cls, in_cls)):
+            numeric = False
     return chained
 
 
@@ -275,24 +309,42 @@ def _inline_any(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] |
     return None
 
 
+# The validator classes ``_inline_validator`` dispatches on, bound on first use: a
+# module-level import would cycle (``probatio.schema`` imports this module, and the
+# validator package imports ``probatio.schema``), and a per-call import was a
+# measurable slice of generation cost. Generation first runs long after both
+# modules are initialized, so the lazy binding always succeeds.
+_VALIDATOR_TYPES: _ValidatorTypes | None = None
+
+
+def _validator_types() -> _ValidatorTypes:
+    """Return ``(Coerce, Range, In, AnyValidator, All)``, importing them once."""
+    global _VALIDATOR_TYPES  # noqa: PLW0603 - a write-once import cache
+    if _VALIDATOR_TYPES is None:
+        from probatio.validators.coerce import Coerce  # noqa: PLC0415
+        from probatio.validators.combinators import All  # noqa: PLC0415
+        from probatio.validators.combinators import Any as AnyValidator  # noqa: PLC0415
+        from probatio.validators.comparison import In, Range  # noqa: PLC0415
+
+        _VALIDATOR_TYPES = (Coerce, Range, In, AnyValidator, All)
+    return _VALIDATOR_TYPES
+
+
 def _inline_validator(
     schema: Any, namespace: dict[str, Any], tag: str
 ) -> list[str] | None:
     """Dispatch a non-type value schema to its inline emitter, or ``None``."""
-    from probatio.validators.coerce import Coerce  # noqa: PLC0415
-    from probatio.validators.combinators import All  # noqa: PLC0415
-    from probatio.validators.combinators import Any as AnyValidator  # noqa: PLC0415
-    from probatio.validators.comparison import In, Range  # noqa: PLC0415
+    coerce_cls, range_cls, in_cls, any_cls, all_cls = _validator_types()
 
-    if isinstance(schema, Coerce):
+    if isinstance(schema, coerce_cls):
         return _inline_coerce(schema.type)
-    if isinstance(schema, Range):
+    if isinstance(schema, range_cls):
         return _inline_range(schema)
-    if isinstance(schema, In):
+    if isinstance(schema, in_cls):
         return _inline_in(schema, namespace, tag)
-    if isinstance(schema, AnyValidator):
+    if isinstance(schema, any_cls):
         return _inline_any(schema, namespace, tag)
-    if isinstance(schema, All):
+    if isinstance(schema, all_cls):
         return _inline_all(schema, namespace, tag)
     return None
 
@@ -398,6 +450,20 @@ def _emit_field(
             "            raise _Bail",
         ]
 
+    if candidate.required and isinstance(candidate.default, Undefined):
+        # A required key with no default fetches by subscript: one specialized
+        # ``BINARY_SUBSCR`` instead of a bound ``dict.get`` call plus a sentinel
+        # test per field. The ``KeyError`` fires only when the key is missing,
+        # which is the failure path and bails to the interpreted engine anyway.
+        return [
+            "    try:",
+            f"        _v = data[{krepr}]",
+            "    except KeyError:",
+            "        raise _Bail",
+            "    else:",
+            *store,
+        ]
+
     lines = [f"    _v = data.get({krepr}, _MISSING)", "    if _v is _MISSING:"]
     if not isinstance(candidate.default, Undefined):
         namespace[f"_d{index}"] = candidate.default
@@ -405,8 +471,6 @@ def _emit_field(
         lines.append("        if isinstance(_v, _UNDEFINED_CLS):")
         lines.append("            raise _Bail")
         lines.extend(store)
-    elif candidate.required:
-        lines.append("        raise _Bail")
     else:
         # Optional, no default: an absent key is simply not stored.
         lines.append("        pass")
@@ -416,13 +480,18 @@ def _emit_field(
     return lines
 
 
-def _emit_extra(extra: int) -> list[str]:
-    """Emit the extra-key handling for the given policy."""
+def _emit_extra(
+    extra: int, allowed: frozenset[Any], namespace: dict[str, Any]
+) -> list[str]:
+    """Emit the extra-key handling for the given policy, binding what it needs."""
     if extra == PREVENT_EXTRA:
-        # The keys view subset-checks against the allowed set in C; an unexpected
-        # key bails so the interpreted path reports it (with its suggestion).
-        return ["    if not (data.keys() <= _allowed):", "        raise _Bail"]
+        # The keys view superset-checks against the allowed set in C; the prebound
+        # method skips a rich-comparison dispatch per call. An unexpected key bails
+        # so the interpreted path reports it (with its suggestion).
+        namespace["_issuperset"] = allowed.issuperset
+        return ["    if not _issuperset(data.keys()):", "        raise _Bail"]
     if extra == ALLOW_EXTRA:
+        namespace["_allowed"] = allowed
         return [
             "    for _k in data:",
             "        if _k not in _allowed:",
@@ -463,18 +532,33 @@ def compile_mapping(
         "_UNDEFINED_CLS": Undefined,
         "_interpreted": validator if fallback is None else fallback,
         "_Type": construct,
-        "_allowed": frozenset(candidate.key_schema for candidate in candidates),
     }
+    allowed = frozenset(candidate.key_schema for candidate in candidates)
+    if construct is None:
+        # One ``type()`` read serves both the foreign-type guard and the out-dict
+        # setup, so the exact-dict case (nearly every call) pays one identity test.
+        # A plain dict stays plain; a dict subclass is preserved (the engine does
+        # so); a foreign Mapping or wrong type keeps the interpreted path, which
+        # accepts the Mapping superset and raises the right type error.
+        prologue = [
+            "    _dt = type(data)",
+            "    if _dt is dict:",
+            "        out = {}",
+            "    elif isinstance(data, dict):",
+            "        out = _dt()",
+            "    else:",
+            "        return _interpreted(data)",
+        ]
+    else:
+        # The fused constructor path builds no out dict; just guard the type.
+        prologue = [
+            "    if type(data) is not dict and not isinstance(data, dict):",
+            "        return _interpreted(data)",
+        ]
+
     # The field and extra-key lines are emitted at the function-body indent; they go
     # inside the ``try`` here, so they are shifted one level deeper.
     body: list[str] = []
-    if construct is None:
-        # A plain dict stays plain; a dict subclass is preserved (the engine does so).
-        body += [
-            "        _dt = type(data)",
-            "        out = {} if _dt is dict else _dt()",
-        ]
-
     kwargs: list[str] = []
     for index, candidate in enumerate(candidates):
         if construct is None:
@@ -485,21 +569,21 @@ def compile_mapping(
         body += [
             "    " + line for line in _emit_field(index, candidate, namespace, target)
         ]
-    body += ["    " + line for line in _emit_extra(validator._extra)]  # noqa: SLF001
+    body += [
+        "    " + line
+        for line in _emit_extra(validator._extra, allowed, namespace)  # noqa: SLF001
+    ]
 
     if not body:
-        # A zero-field dataclass with REMOVE_EXTRA emits nothing into the ``try``
-        # (no out-dict setup, no fields, no extra-key copy), which would be a syntax
-        # error; a bare ``pass`` keeps the block valid and still bails on a non-dict.
+        # A zero-field mapping with REMOVE_EXTRA emits nothing into the ``try``
+        # (no fields, no extra-key copy), which would be a syntax error; a bare
+        # ``pass`` keeps the block valid and still bails on a non-dict.
         body.append("        pass")
 
     tail = f"    return _Type({', '.join(kwargs)})" if construct else "    return out"
     lines = [
         "def _validate(data):",
-        # A foreign Mapping or wrong type keeps the interpreted path, which accepts
-        # the Mapping superset and raises the right type error.
-        "    if type(data) is not dict and not isinstance(data, dict):",
-        "        return _interpreted(data)",
+        *prologue,
         "    try:",
         *body,
         "    except _Bail:",

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -131,7 +131,7 @@ class _MappingValidator:
         self._literal: dict[Any, tuple[int, _Candidate]] = {}
         self._validators: list[tuple[int, _Candidate]] = []
         self._literal_fast: dict[Any, tuple[int, type | None, CompiledSchema]] = {}
-        self._key_names: list[Any] = []
+        key_names: list[str] = []
         self._finalizers: list[tuple[int, _Candidate]] = []
         exclusive: dict[str, list[int]] = defaultdict(list)
         inclusive: dict[str, list[int]] = defaultdict(list)
@@ -154,7 +154,7 @@ class _MappingValidator:
                         candidate.check_value,
                     )
                     if isinstance(key, str):
-                        self._key_names.append(key)
+                        key_names.append(key)
             else:
                 self._validators.append((index, candidate))
             if candidate.exclusive_group is not None:
@@ -173,6 +173,9 @@ class _MappingValidator:
             if candidate.alias_input_names:
                 alias_candidates.append(candidate)
 
+        # A tuple, so an error can hold it as its suggestion pool without a
+        # defensive copy per raise (the exclusion filter is applied lazily there).
+        self._key_names = tuple(key_names)
         self._secret_keys = frozenset(secret_keys) if secret_keys else _NO_SECRET_KEYS
         self._exclusive_groups = list(exclusive.items())
         self._inclusive_groups = list(inclusive.items())
@@ -488,17 +491,18 @@ class _MappingValidator:
     def _extra_key_error(self, key: Any) -> ExtraKeysInvalid:
         """Build the unmatched-key error, suggesting close schema keys when any.
 
-        The offending key is never suggested back, so a key that failed only on
-        its value (a Remove whose value did not validate) does not echo itself. The
-        suggestion match is deferred to the error, so an unknown-key error raised in
-        a discarded combinator branch never pays for difflib.
+        The offending key is never suggested back (``suggest_exclude``), so a key
+        that failed only on its value (a Remove whose value did not validate) does
+        not echo itself. Both the exclusion filter and the suggestion match are
+        deferred to the error, so an unknown-key error raised in a discarded
+        combinator branch never pays for the pool copy or difflib.
         """
-        pool = [name for name in self._key_names if name != key]
         return ExtraKeysInvalid(
             "not a valid option",
             path=[key],
             suggest_value=key,
-            suggest_pool=pool,
+            suggest_pool=self._key_names,
+            suggest_exclude=key,
         )
 
     def _finalize(
@@ -604,7 +608,12 @@ class _MappingValidator:
     ) -> None:
         """Enforce the Exclusive (at most one) and Inclusive (all or none) groups."""
         for group, members in self._exclusive_groups:
-            present = sum(seen[index] for index in members)
+            # A plain counting loop: a genexpr plus sum() would allocate a generator
+            # and a frame per group on every validation of the mapping.
+            present = 0
+            for index in members:
+                if seen[index]:
+                    present += 1
             if present > 1:
                 message = self._group_msg(members) or (
                     f"two or more values in the same group of exclusion {group!r}"
@@ -615,8 +624,13 @@ class _MappingValidator:
             elif present == 0:
                 self._empty_exclusive_group(group, members, out, errors)
         for group, members in self._inclusive_groups:
-            missing = [index for index in members if not seen[index]]
-            if missing and len(missing) != len(members):
+            # Only the count matters (the missing keys are never named), so count
+            # instead of building a list.
+            missing = 0
+            for index in members:
+                if not seen[index]:
+                    missing += 1
+            if missing and missing != len(members):
                 message = self._group_msg(members) or (
                     f"some but not all values in the same group of inclusion {group!r}"
                 )

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -46,6 +46,7 @@ from collections.abc import (
 )
 from collections.abc import Set as AbstractSet
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Literal,
     NotRequired,
@@ -77,6 +78,7 @@ from probatio.markers import (
 )
 from probatio.schema import (
     _INHERIT_CONTEXT,
+    ALLOW_EXTRA,
     PREVENT_EXTRA,
     CompiledSchema,
     Schema,
@@ -602,18 +604,27 @@ def _field_mapping(
 class _Constructor:
     """Turn a validated dict into a dataclass instance (the final ``All`` step)."""
 
-    __slots__ = ("_init_fields", "dataclass_type")
+    __slots__ = ("_filter_keys", "_init_fields", "dataclass_type")
 
     def __init__(
-        self, dataclass_type: type, remove: frozenset[TypingAny] = frozenset()
+        self,
+        dataclass_type: type,
+        remove: frozenset[TypingAny] = frozenset(),
+        *,
+        filter_keys: bool = True,
     ) -> None:
         """Remember the type and which of its fields the constructor accepts.
 
         ``remove`` names the ``Key(remove=True)`` fields, whose value is always
         dropped, so they take their dataclass default regardless of the input (even a
         value ``ALLOW_EXTRA`` kept because it failed the field's own validation).
+
+        ``filter_keys=False`` is the caller asserting the validated dict can only
+        hold init-field keys (no ``ALLOW_EXTRA``, no ``Remove`` fields), so the
+        per-call filtering comprehension is skipped.
         """
         self.dataclass_type = dataclass_type
+        self._filter_keys = filter_keys
         self._init_fields = (
             frozenset(field.name for field in _iter_init_fields(dataclass_type))
             - remove
@@ -625,6 +636,8 @@ class _Constructor:
         Extra keys (kept by ``ALLOW_EXTRA``) and dropped ``Remove`` keys are left out
         here, since a dataclass cannot take an unexpected keyword argument.
         """
+        if not self._filter_keys:
+            return self.dataclass_type(**data)
         kwargs = {key: value for key, value in data.items() if key in self._init_fields}
         return self.dataclass_type(**kwargs)
 
@@ -675,7 +688,14 @@ def create_dataclass_schema(
         for facets in map(resolve_key, mapping)
         if isinstance(facets.marker, Remove)
     )
-    schema = Schema(All(inner, _Constructor(dataclass_type, remove)))
+    # Under PREVENT_EXTRA/REMOVE_EXTRA with no Remove fields (the default and the
+    # overwhelmingly common case), the mapping is built exclusively from the init
+    # fields, so every key surviving validation is an init-field name by
+    # construction and the constructor's filter would be a per-call no-op.
+    constructor = _Constructor(
+        dataclass_type, remove, filter_keys=extra == ALLOW_EXTRA or bool(remove)
+    )
+    schema = Schema(All(inner, constructor))
     ref.bind(schema)
 
     return schema
@@ -932,16 +952,14 @@ class DataclassSchema[DataclassT](Schema):
             self._construct_fn = cached
         return cached
 
-    def __call__(
-        self, data: TypingAny, *, context: TypingAny = _INHERIT_CONTEXT
-    ) -> DataclassT:
-        """Validate ``data`` and return the constructed dataclass instance."""
-        # Call the base directly rather than through ``super()``: the zero-argument
-        # ``super()`` builds a proxy object on every validation, which is the bulk of
-        # this wrapper's cost. The annotated local narrows the base's ``Any`` return
-        # to the dataclass type without a runtime ``cast`` call.
-        validated: DataclassT = Schema.__call__(self, data, context=context)
-        return validated
+    if TYPE_CHECKING:
+        # Declared for the type checker only, to narrow the base's ``Any`` return
+        # to the dataclass type. At runtime the class uses ``Schema.__call__``
+        # directly, so a validation does not pay a delegating wrapper frame.
+        def __call__(
+            self, data: TypingAny, *, context: TypingAny = _INHERIT_CONTEXT
+        ) -> DataclassT:
+            """Validate ``data`` and return the constructed dataclass instance."""
 
     def _compilable(self) -> bool:
         """Report that a dataclass compiles via its inner mapping, under the ``All``."""
@@ -1125,14 +1143,13 @@ class TypedDictSchema[TypedDictT](Schema):
         )
         raise SchemaError(message)
 
-    def __call__(
-        self, data: TypingAny, *, context: TypingAny = _INHERIT_CONTEXT
-    ) -> TypedDictT:
-        """Validate ``data`` and return it typed as the TypedDict."""
-        # Call the base directly, not through ``super()`` (which builds a proxy each
-        # call); the annotated local narrows the base's ``Any`` return without a cast.
-        validated: TypedDictT = Schema.__call__(self, data, context=context)
-        return validated
+    if TYPE_CHECKING:
+        # Type-checker-only override, exactly like ``DataclassSchema.__call__``:
+        # narrows the return type without costing a runtime wrapper frame.
+        def __call__(
+            self, data: TypingAny, *, context: TypingAny = _INHERIT_CONTEXT
+        ) -> TypedDictT:
+            """Validate ``data`` and return it typed as the TypedDict."""
 
     def construct(self, data: TypingAny) -> TypedDictT:
         """Return **trusted** ``data`` typed as the TypedDict, skipping validation.

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -101,9 +101,14 @@ class Invalid(Error):
         self._error_type = error_type
         self._secret = False
         self._code = code
-        self._context: dict[str, Any] = dict(context) if context else {}
+        # ``None`` until read: most errors never have their context/placeholders
+        # looked at (a miss inside a combinator branch is built and discarded), so
+        # the two dict allocations are deferred to the property getters.
+        self._context: dict[str, Any] | None = dict(context) if context else None
         self._translation_key = translation_key
-        self._placeholders: dict[str, Any] = dict(placeholders) if placeholders else {}
+        self._placeholders: dict[str, Any] | None = (
+            dict(placeholders) if placeholders else None
+        )
 
     @property
     def msg(self) -> str:
@@ -153,6 +158,8 @@ class Invalid(Error):
     @property
     def context(self) -> dict[str, Any]:
         """Structured detail about the failure (for example the expected type)."""
+        if self._context is None:
+            self._context = {}
         return self._context
 
     @property
@@ -163,6 +170,8 @@ class Invalid(Error):
     @property
     def placeholders(self) -> dict[str, Any]:
         """Values to interpolate into the translated message."""
+        if self._placeholders is None:
+            self._placeholders = {}
         return self._placeholders
 
     def __str__(self) -> str:
@@ -217,15 +226,22 @@ class _SuggestionInvalid(Invalid):
         *,
         suggest_value: Any = _NO_SUGGESTION,
         suggest_pool: tuple[str, ...] | list[str] = (),
+        suggest_exclude: Any = _NO_SUGGESTION,
         suffix: bool = True,
         code: str | None = None,
         context: dict[str, Any] | None = None,
         translation_key: str | None = None,
         placeholders: dict[str, Any] | None = None,
     ) -> None:
-        """Record what to match against; the match itself happens lazily."""
+        """Record what to match against; the match itself happens lazily.
+
+        ``suggest_exclude`` names one pool entry to leave out of the match (an
+        unknown key must not suggest itself back); it is applied lazily with the
+        match, so the raiser can pass its prebuilt pool without copying it.
+        """
         self._suggest_value = suggest_value
         self._suggest_pool = suggest_pool
+        self._suggest_exclude = suggest_exclude
         self._with_suffix = suffix
         self._candidates: list[str] | None = None
         self._suffix_cache: str | None = None
@@ -246,11 +262,14 @@ class _SuggestionInvalid(Invalid):
         """The close matches among the allowed values, computed on first read."""
         if self._candidates is None:
             value = self._suggest_value
-            self._candidates = (
-                get_close_matches(value, self._suggest_pool)
-                if isinstance(value, str)
-                else []
-            )
+            if isinstance(value, str):
+                pool: tuple[str, ...] | list[str] = self._suggest_pool
+                if self._suggest_exclude is not _NO_SUGGESTION:
+                    exclude = self._suggest_exclude
+                    pool = [name for name in pool if name != exclude]
+                self._candidates = get_close_matches(value, pool)
+            else:
+                self._candidates = []
         return self._candidates
 
     def _suffix_text(self) -> str:
@@ -276,7 +295,7 @@ class _SuggestionInvalid(Invalid):
     @property
     def context(self) -> dict[str, Any]:
         """Structured detail, including the close matches when there are any."""
-        ctx = dict(self._context)
+        ctx = dict(self._context) if self._context else {}
         if self.candidates:
             ctx.setdefault("candidates", self.candidates)
         return ctx

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -254,6 +254,29 @@ class _TypeCheck:
         return data
 
 
+# One shared ``_TypeCheck`` per builtin type: these are by far the most common
+# type schemas, they cannot grow a ``__probatio_validate__`` (builtins reject
+# setattr), and a ``_TypeCheck`` is immutable (slots, never written after init),
+# so every schema can hold the same instance instead of allocating its own.
+_BUILTIN_TYPE_CHECKS: dict[type, _TypeCheck] = {
+    builtin: _TypeCheck(builtin)
+    for builtin in (
+        str,
+        int,
+        float,
+        bool,
+        bytes,
+        bytearray,
+        complex,
+        list,
+        tuple,
+        dict,
+        set,
+        frozenset,
+    )
+}
+
+
 class _EnumCheck:
     """Validate against an ``Enum``, accepting a member or one of its values.
 
@@ -918,9 +941,16 @@ class Schema:
 
         # A ``Secret`` around a type or callable key is rejected inside
         # ``resolve_key`` (the general path above), so it never reaches here.
-        is_literal = not (isinstance(key_schema, type) or callable(key_schema))
+        if type(key_schema) is str:
+            # The overwhelmingly common key shape: a plain string is a literal (not
+            # a type, not callable), so skip the classification and the ``_compile``
+            # dispatch ladder it would walk to reach the same equality check.
+            is_literal = True
+            check_key = Schema._compile_literal(key_schema)
+        else:
+            is_literal = not (isinstance(key_schema, type) or callable(key_schema))
+            check_key = self._compile(key_schema)
         check_value = self._compile(value_schema)
-        check_key = self._compile(key_schema)
 
         return _Candidate(
             key_schema=key_schema,
@@ -1002,6 +1032,13 @@ class Schema:
         read to inline the ``isinstance`` into their loops and skip a call per
         value. Called directly (when not inlined) it behaves like the closure.
         """
+        # ``type(schema) is type`` excludes metaclass instances, whose custom
+        # ``__eq__``/``__hash__`` could otherwise spoof a builtin in the lookup.
+        if (
+            type(schema) is type
+            and (cached := _BUILTIN_TYPE_CHECKS.get(schema)) is not None
+        ):
+            return cached
         protocol = getattr(schema, "__probatio_validate__", None)
         if callable(protocol):
             return Schema._compile_callable(protocol)

--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -32,6 +32,10 @@ class Coerce[T](_SafeValidator):
         self.type: typing.Any = type
         self.type_name: str = getattr(type, "__name__", str(type))
         self.msg = msg
+        # Filled on the first failure, not eagerly: building the default message
+        # (and for an enum, its value pool) walks the enum members, a cost a schema
+        # that never fails should not pay at construction either.
+        self._failure_cache: tuple[str, tuple[str, ...]] | None = None
 
     def __repr__(self) -> str:
         """Render as a constructor call, matching voluptuous."""
@@ -49,7 +53,9 @@ class Coerce[T](_SafeValidator):
         through unchanged.
         """
         try:
-            return typing.cast("T", self.type(value))
+            # A typed local instead of typing.cast: cast is a real function call in
+            # CPython, and this line runs once per coerced value on the hot path.
+            coerced: T = self.type(value)
         except Invalid:
             raise
         except Exception as exc:
@@ -59,13 +65,21 @@ class Coerce[T](_SafeValidator):
                 # is idempotent: re-validating an already-coerced value does not fail.
                 return typing.cast("T", value)
             # The suggestion match is deferred to the error, so a miss inside a
-            # combinator branch that is then discarded never pays for difflib.
+            # combinator branch that is then discarded never pays for difflib. The
+            # default message and pool depend only on ``self.type``, so they are
+            # built once on the first failure; ``self.msg`` stays raise-time.
+            cached = self._failure_cache
+            if cached is None:
+                cached = (self._default_message(), tuple(self._enum_values()))
+                self._failure_cache = cached
             raise CoerceInvalid(
-                self.msg or self._default_message(),
+                self.msg or cached[0],
                 suggest_value=value,
-                suggest_pool=self._enum_values(),
+                suggest_pool=cached[1],
                 suffix=self.msg is None,
             ) from exc
+        else:
+            return coerced
 
     def _default_message(self) -> str:
         """Build the failure message, listing an enum's values (like voluptuous)."""

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -129,7 +129,7 @@ def _run_any(
     candidates: list[typing.Any],
     value: typing.Any,
     msg: str | None,
-    expected: str | None,
+    miss_message: str | None,
 ) -> typing.Any:
     """Return the first candidate that accepts the value, else raise.
 
@@ -152,9 +152,8 @@ def _run_any(
 
     if msg is not None:
         raise AnyInvalid(msg)
-    if expected is not None:
-        message = f"expected {expected}"
-        raise AnyInvalid(message)
+    if miss_message is not None:
+        raise AnyInvalid(miss_message)
     if best is None:
         message = "no valid value found"
         raise AnyInvalid(message)
@@ -201,6 +200,10 @@ class All(_Combinator):
             compile_schema(validator, required=self.required, extra=self._extra)
             for validator in self.validators
         ]
+        # The two-validator form (``All(Coerce(int), Range(...))``) dominates real
+        # schemas, so ``__call__`` unrolls it; precompute the pair here, the single
+        # place ``self._compiled`` is (re)built.
+        self._pair = tuple(self._compiled) if len(self._compiled) == 2 else None
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Run each validator in sequence, returning the final value.
@@ -210,9 +213,12 @@ class All(_Combinator):
 
         The ``try`` wraps the whole loop rather than each step: the loop stops at
         the first failing validator either way, so one handler per call keeps the
-        hot path (every value runs through here) a tight loop.
+        hot path (every value runs through here) a tight loop. The unrolled pair
+        path shares those handlers, so a branch failure behaves identically.
         """
         try:
+            if (pair := self._pair) is not None:
+                return pair[1](pair[0](value))
             for compiled in self._compiled:
                 value = compiled(value)
         except MultipleInvalid as exc:
@@ -264,21 +270,23 @@ def _run_typed_any(
     allow_none: bool,
     value: typing.Any,
     msg: str | None,
-    expected: str | None,
+    miss_message: str | None,
 ) -> typing.Any:
     """Resolve an all-type (or None) ``Any``/``Union`` without per-branch exceptions.
 
     One ``isinstance``, plus a ``value is None`` check when a ``None`` branch is
     present, accepts on the hot path. On a miss a single ``AnyInvalid`` is raised
-    from the precomputed branch labels, without running any branch, so both the
-    match and the miss skip the try/except churn.
+    with the message precomputed at branch-compile time (every branch is a type,
+    so it always labels), without running any branch, so both the match and the
+    miss skip the try/except churn.
     """
     if (allow_none and value is None) or isinstance(value, types):
         return value
     if msg is not None:
         raise AnyInvalid(msg)
-    message = f"expected {expected}"
-    raise AnyInvalid(message)
+    # The typed path always labels (every branch is a type), so the fallback
+    # string is unreachable; it keeps the type checker honest without a cast.
+    raise AnyInvalid(miss_message or "no valid value found")
 
 
 class Any(_Combinator):
@@ -316,13 +324,18 @@ class Any(_Combinator):
         ]
         self._types = _type_tuple(self.validators, self._compiled)
         self._expected = _expected_label(self.validators)
+        # Prebuilt so a miss does not re-interpolate a message that only depends
+        # on the branch labels, which are fixed here.
+        self._miss_message = (
+            None if self._expected is None else f"expected {self._expected}"
+        )
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Try each validator, returning the first that accepts the value."""
         # All-type (or None) branches resolve by one isinstance, on match and miss.
         if self._types is not None:
-            return _run_typed_any(*self._types, value, self.msg, self._expected)
-        return _run_any(self._compiled, value, self.msg, self._expected)
+            return _run_typed_any(*self._types, value, self.msg, self._miss_message)
+        return _run_any(self._compiled, value, self.msg, self._miss_message)
 
     def __repr__(self) -> str:
         """Render as ``Any(v, ..., msg=...)``."""
@@ -378,13 +391,17 @@ class Union(_Combinator):
             else None
         )
         self._expected = _expected_label(self.validators)
+        # Prebuilt for the same reason as in ``Any._compile_branches``.
+        self._miss_message = (
+            None if self._expected is None else f"expected {self._expected}"
+        )
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Try the (possibly narrowed) candidates, returning the first match."""
         if self.discriminant is None:
             if self._types is not None:
-                return _run_typed_any(*self._types, value, self.msg, self._expected)
-            return _run_any(self._compiled, value, self.msg, self._expected)
+                return _run_typed_any(*self._types, value, self.msg, self._miss_message)
+            return _run_any(self._compiled, value, self.msg, self._miss_message)
         # A discriminant returns a subset of the raw validators; resolve each to
         # its compiled form, compiling any object it returns that was not among
         # the originals (matching voluptuous, which recompiles the chosen set).

--- a/src/probatio/validators/network.py
+++ b/src/probatio/validators/network.py
@@ -12,6 +12,7 @@ crafted input cannot hang them.
 from __future__ import annotations
 
 import ipaddress
+import re
 import typing
 
 from probatio.error import HostnameInvalid, IpInvalid, RangeInvalid
@@ -36,6 +37,12 @@ def _reject_bool(value: typing.Any) -> typing.Any:
     return value
 
 
+# The string grammar ``ipaddress.IPv4Address`` accepts: four dot-separated octets,
+# each 0-255 in ASCII digits with no leading zero. Every alternative is bounded and
+# unambiguous, so the pattern cannot backtrack pathologically on hostile input.
+_IPV4_OCTET = r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])"
+_IPV4_PATTERN = re.compile(rf"{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}")
+
 # CPython's ``ipaddress`` parsers are fragile on hostile input: besides the
 # expected ValueError/TypeError, a crafted value can reach an IndexError (an empty
 # tuple) or an AttributeError (``'NoneType' object has no attribute 'isascii'`` from
@@ -58,6 +65,14 @@ class IPv4Address(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it parses as an IPv4 address, else raise IpInvalid."""
+        if type(value) is str:
+            # The common case, matched directly: constructing an
+            # ``ipaddress.IPv4Address`` costs several times the regex match.
+            if _IPV4_PATTERN.fullmatch(value) is None:
+                raise IpInvalid(self.msg or "expected an IPv4 address")
+            return value
+        # Everything else (int, packed bytes, address objects, str subclasses)
+        # keeps the parser's exact acceptance behavior.
         try:
             ipaddress.IPv4Address(_reject_bool(value))
         except _IP_PARSE_ERRORS as exc:

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -238,10 +238,6 @@ _EMAIL_LOCAL_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
     "-!#$%&'*+/=?^_`{}|~.",
 )
-# The same set without the dot: the dot separates labels, so it is not a label
-# character. Matches voluptuous's USER_REGEX, which allows a dot only between
-# non-empty runs of these characters.
-_EMAIL_LOCAL_LABEL_CHARS = _EMAIL_LOCAL_CHARS - {"."}
 _EMAIL_LABEL_CHARS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-",
 )
@@ -253,11 +249,16 @@ def _valid_email_local(local: str) -> bool:
     The unquoted local part is dot-separated runs of allowed characters, so a
     leading, trailing, or doubled dot is rejected (``a..b``, ``.a``, ``a.``). This
     mirrors voluptuous's ``USER_REGEX`` with plain string checks rather than a
-    backtracking regular expression, so a crafted address cannot hang it.
+    backtracking regular expression, so a crafted address cannot hang it. The
+    whole-string form (one charset sweep, the dot included, plus the three dot
+    placement checks) says exactly that without splitting into labels, and runs
+    entirely in C.
     """
-    return all(
-        label and _EMAIL_LOCAL_LABEL_CHARS.issuperset(label)
-        for label in local.split(".")
+    return (
+        _EMAIL_LOCAL_CHARS.issuperset(local)
+        and local[0] != "."
+        and local[-1] != "."
+        and ".." not in local
     )
 
 
@@ -278,14 +279,17 @@ def _valid_email_domain(domain: str) -> bool:
     labels = domain.split(".")
     if len(labels) < 2 or len(labels[-1]) < 2:
         return False
-    return all(
-        label
-        and len(label) <= 63
-        and label[0] != "-"
-        and label[-1] != "-"
-        and _EMAIL_LABEL_CHARS.issuperset(label)
-        for label in labels
-    )
+    # A plain loop: the genexpr form pays a generator frame per validated address.
+    for label in labels:
+        if (
+            not label
+            or len(label) > 63
+            or label[0] == "-"
+            or label[-1] == "-"
+            or not _EMAIL_LABEL_CHARS.issuperset(label)
+        ):
+            return False
+    return True
 
 
 def Email(msg: str | None = None) -> typing.Callable[[typing.Any], str]:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A profiling-driven performance pass over every moving part of the library. Fourteen targeted changes, each measured in isolation against the CodSpeed workloads (local timeit, best of 7, pinned engines), with the full test suite, mypy, and ty green after every step. Behavior is unchanged: same values, same error messages, same paths, same validation order.

Validation hot path: drop the runtime `typing.cast` in `Coerce`, counting loops instead of genexprs in the group post-pass, a two-validator unroll in `All` that shares the existing error handlers, a regex fast path for IPv4 strings (differentially fuzzed against `ipaddress` on 20k cases, zero mismatches) with all non-str inputs still delegated to the parser, cheaper Email local/domain checks, the `DataclassSchema`/`TypedDictSchema` `__call__` overrides moved under `TYPE_CHECKING`, and the `_Constructor` filter skipped when it is provably a no-op.

Codegen engine: elide the dead Range type-check after an inlined Coerce, fetch required keys by subscript instead of `dict.get` plus sentinel, a slimmer generated prologue/epilogue, and the generator's per-call imports hoisted to a lazily bound module global.

Compile path: str literal keys skip the `_compile` dispatch ladder, and builtin types share one `_TypeCheck` instance.

Error path: lazy `Invalid` context/placeholders dicts, a cached Coerce failure message, the extra-key suggestion pool copy deferred into the lazy candidates read, and the Any/Union miss message precomputed at branch-compile time.

Every tracked benchmark improved, none regressed: leaf-heavy -29/-37% (interpreted/compiled), list -17/-19%, dataclass -18/-17%, nested -11/-15%, compile_deep -18%, generate_config -10%. Against voluptuous that puts the interpreted engine at 1.6x to 3.6x and the compiled engine at 4.6x to 6.9x. The benchmark charts and the numbers quoted in the docs are regenerated from these runs.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: ADR-004 (single validation engine) and ADR-011 (opt-in compiled schema); the changes stay within both.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
