### PR TITLE
Speed up the error path, composed schemas, dataclass validation, and decorated calls

### DIFF
--- a/bench/test_benchmarks.py
+++ b/bench/test_benchmarks.py
@@ -240,6 +240,106 @@ def test_validate_nested_compiled(benchmark: Any) -> None:
     assert result["data"]["brightness"] == 200
 
 
+# A composed schema: a pre-built Schema instance reused as a mapping value, the
+# way large applications (Home Assistant among them) assemble config schemas from
+# shared pieces. The nested Schema goes through the callable-wrapping path rather
+# than compiling inline like a plain dict value does, so this tracks the cost of
+# composition itself.
+_COMPOSED_DATA = probatio.Schema(
+    {
+        probatio.Optional("brightness"): probatio.All(
+            probatio.Coerce(int),
+            probatio.Range(min=0, max=255),
+        ),
+    },
+    compile=False,
+)
+COMPOSED = probatio.Schema(
+    {
+        probatio.Required("entity_id"): str,
+        probatio.Optional("data", default=dict): _COMPOSED_DATA,
+    },
+    compile=False,
+)
+COMPOSED_PAYLOAD = {"entity_id": "light.kitchen", "data": {"brightness": "200"}}
+
+
+def test_validate_composed(benchmark: Any) -> None:
+    """Validate a mapping whose value is a nested, pre-built Schema instance."""
+    result = benchmark(COMPOSED, COMPOSED_PAYLOAD)
+    assert result["data"]["brightness"] == 200
+
+
+def _combinator_auto_schema() -> probatio.Schema:
+    """A combinator with a mapping branch, built and warmed under ``AUTO``.
+
+    Under the default ``AUTO`` policy the mapping branch arms for lazy
+    compilation, and the combinator captures the armed bootstrap at construction.
+    Warming past the compile threshold resolves the schema onto the generated
+    validator, but the combinator keeps calling through its captured (now stale)
+    reference; that steady-state delegation is exactly what real applications run
+    with, and what this benchmark tracks.
+    """
+    previous = probatio.get_compile_policy()
+    probatio.set_compile_policy(probatio.CompilePolicy.AUTO)
+    try:
+        schema = probatio.Schema(
+            probatio.Any({probatio.Required("value"): int}, str),
+        )
+        for _ in range(200):  # past the AUTO threshold, so the engine is steady
+            schema(COMBINATOR_AUTO_PAYLOAD)
+    finally:
+        probatio.set_compile_policy(previous)
+    return schema
+
+
+COMBINATOR_AUTO_PAYLOAD = {"value": 1}
+COMBINATOR_AUTO = _combinator_auto_schema()
+
+
+def test_validate_combinator_auto(benchmark: Any) -> None:
+    """Validate through a combinator's mapping branch under the AUTO policy."""
+    result = benchmark(COMBINATOR_AUTO, COMBINATOR_AUTO_PAYLOAD)
+    assert result == {"value": 1}
+
+
+@probatio.probatio
+def _decorated_scale(value: int, factor: int = 1, *, label: str = "x") -> int:
+    """A decorated function with typed annotations (the argument hot path)."""
+    del label
+    return value * factor
+
+
+@probatio.probatio
+def _decorated_forward(a, b, c=None):  # type: ignore[no-untyped-def]
+    """A decorated function with no annotations: nothing validates, only binding."""
+    return (a, b, c)
+
+
+def test_validate_decorated_call(benchmark: Any) -> None:
+    """Call a decorated function with typed, validated arguments."""
+    result = benchmark(_decorated_scale, 21, factor=2, label="y")
+    assert result == 42
+
+
+def test_validate_decorated_passthrough(benchmark: Any) -> None:
+    """Call a decorated function with nothing to validate (pure binding cost)."""
+    result = benchmark(_decorated_forward, 1, b=2)
+    assert result == (1, 2, None)
+
+
+def test_combinator_auto_measures_the_stale_bootstrap() -> None:
+    """Guard: the AUTO benchmark really runs the captured-bootstrap delegation.
+
+    The branch must still be the bound bootstrap (the capture is permanent) and
+    its schema must have resolved onto the generated validator, so the benchmark
+    measures steady-state delegation, not warmup or the interpreted engine.
+    """
+    branch = COMBINATOR_AUTO.schema._compiled[0]
+    assert getattr(branch, "__func__", None) is probatio.Schema._bootstrap
+    assert _is_compiled(branch.__self__)
+
+
 @dataclass
 class _Service:
     """A small dataclass, the clearest compiled win (validate and construct fused)."""

--- a/docs/public/benchmarks/dataclass-vs-mashumaro.svg
+++ b/docs/public/benchmarks/dataclass-vs-mashumaro.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T00:48:37.434407</dc:date>
+    <dc:date>2026-07-03T08:56:28.553653</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 87.829688 197.397969
 L 87.829688 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -51,68 +51,68 @@ L 87.829688 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 153.410649 197.397969
-L 153.410649 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 158.326798 197.397969
+L 158.326798 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="153.410649" y="208.495625" transform="rotate(-0 153.410649 208.495625)">0.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="158.326798" y="208.495625" transform="rotate(-0 158.326798 208.495625)">0.5</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 218.991611 197.397969
-L 218.991611 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 228.823909 197.397969
+L 228.823909 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="218.991611" y="208.495625" transform="rotate(-0 218.991611 208.495625)">1.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="228.823909" y="208.495625" transform="rotate(-0 228.823909 208.495625)">1.0</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 284.572573 197.397969
-L 284.572573 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 299.32102 197.397969
+L 299.32102 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="284.572573" y="208.495625" transform="rotate(-0 284.572573 208.495625)">1.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="299.32102" y="208.495625" transform="rotate(-0 299.32102 208.495625)">1.5</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 350.153535 197.397969
-L 350.153535 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 369.818131 197.397969
+L 369.818131 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="350.153535" y="208.495625" transform="rotate(-0 350.153535 208.495625)">2.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="369.818131" y="208.495625" transform="rotate(-0 369.818131 208.495625)">2.0</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 415.734497 197.397969
-L 415.734497 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 440.315242 197.397969
+L 440.315242 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="415.734497" y="208.495625" transform="rotate(-0 415.734497 208.495625)">2.5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="440.315242" y="208.495625" transform="rotate(-0 440.315242 208.495625)">2.5</text>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 481.315459 197.397969
-L 481.315459 31.077969
-" clip-path="url(#p217c54a882)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 510.812353 197.397969
+L 510.812353 31.077969
+" clip-path="url(#p2b78a239b3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="481.315459" y="208.495625" transform="rotate(-0 481.315459 208.495625)">3.0</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="510.812353" y="208.495625" transform="rotate(-0 510.812353 208.495625)">3.0</text>
      </g>
     </g>
     <g id="text_8">
@@ -140,27 +140,27 @@ L 545.389688 197.397969
    </g>
    <g id="patch_4">
     <path d="M 87.829688 143.730122
-L 155.92065 143.730122
-L 155.92065 122.981591
+L 163.626103 143.730122
+L 163.626103 122.981591
 L 87.829688 122.981591
 z
-" clip-path="url(#p217c54a882)" style="fill: #5b626d"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_5">
     <path d="M 87.829688 59.3865
-L 248.420448 59.3865
-L 248.420448 38.637969
+L 260.057474 59.3865
+L 260.057474 38.637969
 L 87.829688 38.637969
 z
-" clip-path="url(#p217c54a882)" style="fill: #5b626d"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
     <path d="M 87.829688 166.784045
-L 311.099245 166.784045
-L 311.099245 146.035514
+L 295.663209 166.784045
+L 295.663209 146.035514
 L 87.829688 146.035514
 z
-" clip-path="url(#p217c54a882)" style="fill: #46b3ac"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_7">
     <path d="M 87.829688 82.440423
@@ -168,41 +168,41 @@ L 485.707948 82.440423
 L 485.707948 61.691892
 L 87.829688 61.691892
 z
-" clip-path="url(#p217c54a882)" style="fill: #46b3ac"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_8">
     <path d="M 87.829688 189.837969
-L 177.640609 189.837969
-L 177.640609 169.089438
+L 187.40088 189.837969
+L 187.40088 169.089438
 L 87.829688 169.089438
 z
-" clip-path="url(#p217c54a882)" style="fill: #24fefd"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #24fefd"/>
    </g>
    <g id="patch_9">
     <path d="M 87.829688 105.494347
-L 256.398738 105.494347
-L 256.398738 84.745816
+L 271.392169 105.494347
+L 271.392169 84.745816
 L 87.829688 84.745816
 z
-" clip-path="url(#p217c54a882)" style="fill: #24fefd"/>
+" clip-path="url(#p2b78a239b3)" style="fill: #24fefd"/>
    </g>
    <g id="text_11">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="159.855508" y="135.304099" transform="rotate(-0 159.855508 135.304099)">0.52</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="167.85593" y="135.304099" transform="rotate(-0 167.85593 135.304099)">0.54</text>
    </g>
    <g id="text_12">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="252.355305" y="50.960476" transform="rotate(-0 252.355305 50.960476)">1.22</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="264.287301" y="50.960476" transform="rotate(-0 264.287301 50.960476)">1.22</text>
    </g>
    <g id="text_13">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="315.034102" y="158.358022" transform="rotate(-0 315.034102 158.358022)">1.70</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="299.893035" y="158.358022" transform="rotate(-0 299.893035 158.358022)">1.47</text>
    </g>
    <g id="text_14">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="489.642806" y="74.0144" transform="rotate(-0 489.642806 74.0144)">3.03</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="489.937775" y="74.0144" transform="rotate(-0 489.937775 74.0144)">2.82</text>
    </g>
    <g id="text_15">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="181.575466" y="181.411945" transform="rotate(-0 181.575466 181.411945)">0.68</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="191.630707" y="181.411945" transform="rotate(-0 191.630707 181.411945)">0.71</text>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="260.333595" y="97.068323" transform="rotate(-0 260.333595 97.068323)">1.29</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="275.621995" y="97.068323" transform="rotate(-0 275.621995 97.068323)">1.30</text>
    </g>
    <g id="text_17">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="87.829688" y="17.077969" transform="rotate(-0 87.829688 17.077969)">Dataclass construction vs mashumaro</text>
@@ -245,7 +245,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p217c54a882">
+  <clipPath id="p2b78a239b3">
    <rect x="87.829688" y="31.077969" width="457.56" height="166.32"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/validators.svg
+++ b/docs/public/benchmarks/validators.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="588.825898pt" height="392.242713pt" viewBox="0 0 588.825898 392.242713" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="587.519399pt" height="392.242713pt" viewBox="0 0 587.519399 392.242713" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T00:50:30.312272</dc:date>
+    <dc:date>2026-07-03T08:58:23.076969</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,8 +22,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 392.242713
-L 588.825898 392.242713
-L 588.825898 0
+L 587.519399 392.242713
+L 587.519399 0
 L 0 0
 z
 " style="fill: #13151c"/>
@@ -40,14 +40,14 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 355.705969 319.365969
-L 355.705969 31.077969
-" clip-path="url(#p0ea0a0a56e)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 354.550121 319.365969
+L 354.550121 31.077969
+" clip-path="url(#pa98b50b79e)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(346.905969 332.165969)">
+      <g style="fill: #9aa3ad" transform="translate(345.750121 332.165969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -59,17 +59,17 @@ L 355.705969 31.077969
     <g id="xtick_2">
      <g id="line2d_3">
       <defs>
-       <path id="m26d7966458" d="M 0 0
+       <path id="m5e37f54fa0" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m26d7966458" x="169.032882" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="168.012353" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{2\times10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(150.932882 334.165969)">
+      <g style="fill: #9aa3ad" transform="translate(149.912353 334.165969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">2</tspan>
         <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -83,12 +83,12 @@ L 0 2
     <g id="xtick_3">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m26d7966458" x="216.061365" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="215.006745" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_3">
       <!-- $\mathdefault{3\times10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(197.961365 334.165969)">
+      <g style="fill: #9aa3ad" transform="translate(196.906745 334.165969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">3</tspan>
         <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -102,12 +102,12 @@ L 0 2
     <g id="xtick_4">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m26d7966458" x="249.428604" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="248.349797" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_4">
       <!-- $\mathdefault{4\times10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(231.328604 334.165969)">
+      <g style="fill: #9aa3ad" transform="translate(230.249797 334.165969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">4</tspan>
         <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -121,19 +121,19 @@ L 0 2
     <g id="xtick_5">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m26d7966458" x="275.310246" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="274.212677" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m26d7966458" x="296.457087" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="295.344189" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_5">
       <!-- $\mathdefault{6\times10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(278.357087 334.165969)">
+      <g style="fill: #9aa3ad" transform="translate(277.244189 334.165969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">6</tspan>
         <tspan x="8.310547" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -147,33 +147,33 @@ L 0 2
     <g id="xtick_7">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m26d7966458" x="314.336487" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="313.210627" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m26d7966458" x="329.824327" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="328.68724" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m26d7966458" x="343.48557" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="342.338581" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m26d7966458" x="436.101692" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="434.887564" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_6">
       <!-- $\mathdefault{2\times10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(418.001692 334.065969)">
+      <g style="fill: #9aa3ad" transform="translate(416.787564 334.065969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">2</tspan>
         <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -187,12 +187,12 @@ L 0 2
     <g id="xtick_11">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m26d7966458" x="483.130175" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="481.881956" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_7">
       <!-- $\mathdefault{3\times10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(465.030175 334.065969)">
+      <g style="fill: #9aa3ad" transform="translate(463.781956 334.065969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">3</tspan>
         <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -206,12 +206,12 @@ L 0 2
     <g id="xtick_12">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m26d7966458" x="516.497415" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="515.225008" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{4\times10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(498.397415 334.065969)">
+      <g style="fill: #9aa3ad" transform="translate(497.125008 334.065969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">4</tspan>
         <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -225,19 +225,19 @@ L 0 2
     <g id="xtick_13">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m26d7966458" x="542.379057" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="541.087888" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m26d7966458" x="563.525898" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m5e37f54fa0" x="562.219399" y="319.365969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{6\times10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(545.425898 334.065969)">
+      <g style="fill: #9aa3ad" transform="translate(544.119399 334.065969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">6</tspan>
         <tspan x="8.310547" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">×</tspan>
@@ -296,70 +296,70 @@ L 566.656875 319.365969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -266980.173132 44.181969
-L 126.530665 44.181969
-L 126.530665 74.742534
-L -266980.173132 74.742534
+    <path d="M -266787.535663 44.181969
+L 126.533821 44.181969
+L 126.533821 74.742534
+L -266787.535663 74.742534
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: url(#h6ad55a82e1)"/>
+" clip-path="url(#pa98b50b79e)" style="fill: url(#h4bf641449f)"/>
    </g>
    <g id="patch_5">
-    <path d="M -266980.173132 90.485856
-L 196.623084 90.485856
-L 196.623084 121.046421
-L -266980.173132 121.046421
+    <path d="M -266787.535663 90.485856
+L 185.561103 90.485856
+L 185.561103 121.046421
+L -266787.535663 121.046421
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: #24fefd"/>
+" clip-path="url(#pa98b50b79e)" style="fill: #24fefd"/>
    </g>
    <g id="patch_6">
-    <path d="M -266980.173132 136.789743
-L 250.766254 136.789743
-L 250.766254 167.350308
-L -266980.173132 167.350308
+    <path d="M -266787.535663 136.789743
+L 236.129199 136.789743
+L 236.129199 167.350308
+L -266787.535663 167.350308
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: #46b3ac"/>
+" clip-path="url(#pa98b50b79e)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_7">
-    <path d="M -266980.173132 183.09363
-L 334.425738 183.09363
-L 334.425738 213.654195
-L -266980.173132 213.654195
+    <path d="M -266787.535663 183.09363
+L 337.912947 183.09363
+L 337.912947 213.654195
+L -266787.535663 213.654195
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
+" clip-path="url(#pa98b50b79e)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -266980.173132 229.397516
-L 357.997309 229.397516
-L 357.997309 259.958082
-L -266980.173132 259.958082
+    <path d="M -266787.535663 229.397516
+L 358.047907 229.397516
+L 358.047907 259.958082
+L -266787.535663 259.958082
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
+" clip-path="url(#pa98b50b79e)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
-    <path d="M -266980.173132 275.701403
-L 475.206457 275.701403
-L 475.206457 306.261969
-L -266980.173132 306.261969
+    <path d="M -266787.535663 275.701403
+L 475.27275 275.701403
+L 475.27275 306.261969
+L -266787.535663 306.261969
 z
-" clip-path="url(#p0ea0a0a56e)" style="fill: #5b626d"/>
+" clip-path="url(#pa98b50b79e)" style="fill: #5b626d"/>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.58536" y="61.410494" transform="rotate(-0 137.58536 61.410494)">1.39µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.580503" y="61.410494" transform="rotate(-0 137.580503 61.410494)">1.40µs</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="207.677779" y="107.714381" transform="rotate(-0 207.677779 107.714381)">2.54µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="196.607785" y="107.714381" transform="rotate(-0 196.607785 107.714381)">2.33µs</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="261.820949" y="154.018267" transform="rotate(-0 261.820949 154.018267)">4.05µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="247.17588" y="154.018267" transform="rotate(-0 247.17588 154.018267)">3.60µs</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="345.480433" y="200.322154" transform="rotate(-0 345.480433 200.322154)">8.32µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="348.959629" y="200.322154" transform="rotate(-0 348.959629 200.322154)">8.66µs</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="369.052004" y="246.626041" transform="rotate(-0 369.052004 246.626041)">10.20µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="369.094588" y="246.626041" transform="rotate(-0 369.094588 246.626041)">10.31µs</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="486.261152" y="292.929928" transform="rotate(-0 486.261152 292.929928)">28.02µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="486.319432" y="292.929928" transform="rotate(-0 486.319432 292.929928)">28.34µs</text>
    </g>
    <g id="text_23">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="109.096875" y="17.077969" transform="rotate(-0 109.096875 17.077969)">Validators only, like for like</text>
@@ -382,7 +382,7 @@ L 344.183477 379.600721
 L 344.183477 373.650721
 L 327.183477 373.650721
 z
-" style="fill: url(#h6ad55a82e1)"/>
+" style="fill: url(#h4bf641449f)"/>
     </g>
     <g id="text_25">
      <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="350.983477" y="379.600721" transform="rotate(-0 350.983477 379.600721)">native core (Rust / C)</text>
@@ -391,12 +391,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0ea0a0a56e">
+  <clipPath id="pa98b50b79e">
    <rect x="109.096875" y="31.077969" width="457.56" height="288.288"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="h6ad55a82e1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="h4bf641449f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#5b626d"/>
    <path d="M -36 36
 L 36 -36

--- a/docs/public/benchmarks/vs-voluptuous.svg
+++ b/docs/public/benchmarks/vs-voluptuous.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T00:48:33.123698</dc:date>
+    <dc:date>2026-07-03T08:56:24.438817</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -42,7 +42,7 @@ z
      <g id="line2d_1">
       <path d="M 67.8 313.821969
 L 67.8 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
@@ -51,90 +51,90 @@ L 67.8 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 124.017732 313.821969
-L 124.017732 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 123.158607 313.821969
+L 123.158607 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="124.017732" y="324.919625" transform="rotate(-0 124.017732 324.919625)">1</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="123.158607" y="324.919625" transform="rotate(-0 123.158607 324.919625)">1</text>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 180.235464 313.821969
-L 180.235464 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 178.517213 313.821969
+L 178.517213 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="180.235464" y="324.919625" transform="rotate(-0 180.235464 324.919625)">2</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="178.517213" y="324.919625" transform="rotate(-0 178.517213 324.919625)">2</text>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 236.453197 313.821969
-L 236.453197 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 233.87582 313.821969
+L 233.87582 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8"/>
      <g id="text_4">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="236.453197" y="324.919625" transform="rotate(-0 236.453197 324.919625)">3</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="233.87582" y="324.919625" transform="rotate(-0 233.87582 324.919625)">3</text>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 292.670929 313.821969
-L 292.670929 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 289.234426 313.821969
+L 289.234426 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10"/>
      <g id="text_5">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="292.670929" y="324.919625" transform="rotate(-0 292.670929 324.919625)">4</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="289.234426" y="324.919625" transform="rotate(-0 289.234426 324.919625)">4</text>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 348.888661 313.821969
-L 348.888661 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 344.593033 313.821969
+L 344.593033 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12"/>
      <g id="text_6">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="348.888661" y="324.919625" transform="rotate(-0 348.888661 324.919625)">5</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="344.593033" y="324.919625" transform="rotate(-0 344.593033 324.919625)">5</text>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 405.106393 313.821969
-L 405.106393 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 399.951639 313.821969
+L 399.951639 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14"/>
      <g id="text_7">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="405.106393" y="324.919625" transform="rotate(-0 405.106393 324.919625)">6</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="399.951639" y="324.919625" transform="rotate(-0 399.951639 324.919625)">6</text>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 461.324126 313.821969
-L 461.324126 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 455.310246 313.821969
+L 455.310246 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16"/>
      <g id="text_8">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="461.324126" y="324.919625" transform="rotate(-0 461.324126 324.919625)">7</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="455.310246" y="324.919625" transform="rotate(-0 455.310246 324.919625)">7</text>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 517.541858 313.821969
-L 517.541858 31.077969
-" clip-path="url(#p36a59b939f)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 510.668852 313.821969
+L 510.668852 31.077969
+" clip-path="url(#pf2009f1bf6)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18"/>
      <g id="text_9">
-      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="517.541858" y="324.919625" transform="rotate(-0 517.541858 324.919625)">8</text>
+      <text style="font-size: 10px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #9aa3ad" x="510.668852" y="324.919625" transform="rotate(-0 510.668852 324.919625)">8</text>
      </g>
     </g>
     <g id="text_10">
@@ -180,115 +180,115 @@ L 525.36 313.821969
    </g>
    <g id="patch_4">
     <path d="M 67.8 271.651176
-L 124.017732 271.651176
-L 124.017732 258.457719
+L 123.158607 271.651176
+L 123.158607 258.457719
 L 67.8 258.457719
 z
-" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #5b626d"/>
    </g>
    <g id="patch_5">
     <path d="M 67.8 218.019238
-L 124.017732 218.019238
-L 124.017732 204.825782
+L 123.158607 218.019238
+L 123.158607 204.825782
 L 67.8 204.825782
 z
-" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #5b626d"/>
    </g>
    <g id="patch_6">
     <path d="M 67.8 164.387301
-L 124.017732 164.387301
-L 124.017732 151.193844
+L 123.158607 164.387301
+L 123.158607 151.193844
 L 67.8 151.193844
 z
-" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #5b626d"/>
    </g>
    <g id="patch_7">
     <path d="M 67.8 110.755363
-L 124.017732 110.755363
-L 124.017732 97.561906
+L 123.158607 110.755363
+L 123.158607 97.561906
 L 67.8 97.561906
 z
-" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
     <path d="M 67.8 57.123425
-L 124.017732 57.123425
-L 124.017732 43.929969
+L 123.158607 57.123425
+L 123.158607 43.929969
 L 67.8 43.929969
 z
-" clip-path="url(#p36a59b939f)" style="fill: #5b626d"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #5b626d"/>
    </g>
    <g id="patch_9">
     <path d="M 67.8 286.310572
-L 262.821244 286.310572
-L 262.821244 273.117116
+L 255.395847 286.310572
+L 255.395847 273.117116
 L 67.8 273.117116
 z
-" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_10">
     <path d="M 67.8 232.678635
-L 220.156577 232.678635
-L 220.156577 219.485178
+L 217.729666 232.678635
+L 217.729666 219.485178
 L 67.8 219.485178
 z
-" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_11">
     <path d="M 67.8 179.046697
-L 185.556345 179.046697
-L 185.556345 165.85324
+L 185.048047 179.046697
+L 185.048047 165.85324
 L 67.8 165.85324
 z
-" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_12">
     <path d="M 67.8 125.414759
-L 159.038301 125.414759
-L 159.038301 112.221303
+L 159.981747 125.414759
+L 159.981747 112.221303
 L 67.8 112.221303
 z
-" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_13">
     <path d="M 67.8 71.782822
-L 199.533454 71.782822
-L 199.533454 58.589365
+L 198.1192 71.782822
+L 198.1192 58.589365
 L 67.8 58.589365
 z
-" clip-path="url(#p36a59b939f)" style="fill: #46b3ac"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_14">
     <path d="M 67.8 300.969969
-L 427.613022 300.969969
-L 427.613022 287.776512
+L 440.623473 300.969969
+L 440.623473 287.776512
 L 67.8 287.776512
 z
-" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #24fefd"/>
    </g>
    <g id="patch_15">
     <path d="M 67.8 247.338031
-L 439.124317 247.338031
-L 439.124317 234.144574
+L 443.911523 247.338031
+L 443.911523 234.144574
 L 67.8 234.144574
 z
-" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #24fefd"/>
    </g>
    <g id="patch_16">
     <path d="M 67.8 193.706093
-L 413.819277 193.706093
-L 413.819277 180.512637
+L 414.957642 193.706093
+L 414.957642 180.512637
 L 67.8 180.512637
 z
-" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #24fefd"/>
    </g>
    <g id="patch_17">
     <path d="M 67.8 140.074156
-L 325.262965 140.074156
-L 325.262965 126.880699
+L 325.466692 140.074156
+L 325.466692 126.880699
 L 67.8 126.880699
 z
-" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #24fefd"/>
    </g>
    <g id="patch_18">
     <path d="M 67.8 86.442218
@@ -296,52 +296,52 @@ L 455.562712 86.442218
 L 455.562712 73.248761
 L 67.8 73.248761
 z
-" clip-path="url(#p36a59b939f)" style="fill: #24fefd"/>
+" clip-path="url(#pf2009f1bf6)" style="fill: #24fefd"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="267.00269" transform="rotate(-0 127.952973 267.00269)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.033709" y="267.00269" transform="rotate(-0 127.033709 267.00269)">1.0x</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="213.370752" transform="rotate(-0 127.952973 213.370752)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.033709" y="213.370752" transform="rotate(-0 127.033709 213.370752)">1.0x</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="159.738815" transform="rotate(-0 127.952973 159.738815)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.033709" y="159.738815" transform="rotate(-0 127.033709 159.738815)">1.0x</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="106.106877" transform="rotate(-0 127.952973 106.106877)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.033709" y="106.106877" transform="rotate(-0 127.033709 106.106877)">1.0x</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.952973" y="52.474939" transform="rotate(-0 127.952973 52.474939)">1.0x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="127.033709" y="52.474939" transform="rotate(-0 127.033709 52.474939)">1.0x</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="266.756485" y="281.662086" transform="rotate(-0 266.756485 281.662086)">3.5x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="259.270949" y="281.662086" transform="rotate(-0 259.270949 281.662086)">3.4x</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="224.091818" y="228.030149" transform="rotate(-0 224.091818 228.030149)">2.7x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="221.604768" y="228.030149" transform="rotate(-0 221.604768 228.030149)">2.7x</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="189.491586" y="174.398211" transform="rotate(-0 189.491586 174.398211)">2.1x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="188.923149" y="174.398211" transform="rotate(-0 188.923149 174.398211)">2.1x</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="162.973542" y="120.766273" transform="rotate(-0 162.973542 120.766273)">1.6x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="163.856849" y="120.766273" transform="rotate(-0 163.856849 120.766273)">1.7x</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="203.468695" y="67.134336" transform="rotate(-0 203.468695 67.134336)">2.3x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="201.994303" y="67.134336" transform="rotate(-0 201.994303 67.134336)">2.4x</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="431.548263" y="296.321483" transform="rotate(-0 431.548263 296.321483)">6.4x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="444.498575" y="296.321483" transform="rotate(-0 444.498575 296.321483)">6.7x</text>
    </g>
    <g id="text_27">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="443.059558" y="242.689545" transform="rotate(-0 443.059558 242.689545)">6.6x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="447.786625" y="242.689545" transform="rotate(-0 447.786625 242.689545)">6.8x</text>
    </g>
    <g id="text_28">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="417.754518" y="189.057607" transform="rotate(-0 417.754518 189.057607)">6.2x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="418.832745" y="189.057607" transform="rotate(-0 418.832745 189.057607)">6.3x</text>
    </g>
    <g id="text_29">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="329.198206" y="135.42567" transform="rotate(-0 329.198206 135.42567)">4.6x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="329.341794" y="135.42567" transform="rotate(-0 329.341794 135.42567)">4.7x</text>
    </g>
    <g id="text_30">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="459.497953" y="81.793732" transform="rotate(-0 459.497953 81.793732)">6.9x</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="459.437814" y="81.793732" transform="rotate(-0 459.437814 81.793732)">7.0x</text>
    </g>
    <g id="text_31">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="67.8" y="17.077969" transform="rotate(-0 67.8 17.077969)">Validation throughput vs voluptuous</text>
@@ -384,7 +384,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p36a59b939f">
+  <clipPath id="pf2009f1bf6">
    <rect x="67.8" y="31.077969" width="457.56" height="282.744"/>
   </clipPath>
  </defs>

--- a/docs/public/benchmarks/vs-world.svg
+++ b/docs/public/benchmarks/vs-world.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-03T00:49:33.638518</dc:date>
+    <dc:date>2026-07-03T08:57:24.773271</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -40,14 +40,14 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 145.569529 441.333969
-L 145.569529 31.077969
-" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 145.154142 441.333969
+L 145.154142 31.077969
+" clip-path="url(#p9a5a5bb8c3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2"/>
      <g id="text_1">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(136.769529 454.233969)">
+      <g style="fill: #9aa3ad" transform="translate(136.354142 454.233969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -58,14 +58,14 @@ L 145.569529 31.077969
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 313.761545 441.333969
-L 313.761545 31.077969
-" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 313.650955 441.333969
+L 313.650955 31.077969
+" clip-path="url(#p9a5a5bb8c3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4"/>
      <g id="text_2">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(304.961545 454.133969)">
+      <g style="fill: #9aa3ad" transform="translate(304.850955 454.133969)">
        <text>
         <tspan x="0" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.762187" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -76,14 +76,14 @@ L 313.761545 31.077969
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 481.953561 441.333969
-L 481.953561 31.077969
-" clip-path="url(#p5529b08340)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 482.147769 441.333969
+L 482.147769 31.077969
+" clip-path="url(#p9a5a5bb8c3)" style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6"/>
      <g id="text_3">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g style="fill: #9aa3ad" transform="translate(473.153561 454.233969)">
+      <g style="fill: #9aa3ad" transform="translate(473.347769 454.233969)">
        <text>
         <tspan x="0" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">1</tspan>
         <tspan x="6.362305" y="-0.674688" style="font-size: 10px; font-family: 'DejaVu Sans'; fill: #9aa3ad">0</tspan>
@@ -95,152 +95,152 @@ L 481.953561 31.077969
     <g id="xtick_4">
      <g id="line2d_7">
       <defs>
-       <path id="ma858843902" d="M 0 0
+       <path id="m7489908bda" d="M 0 0
 L 0 2
 " style="stroke: #9aa3ad; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma858843902" x="119.516256" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="119.053655" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma858843902" x="129.270038" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="128.825113" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma858843902" x="137.873484" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="137.44415" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma858843902" x="196.20037" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="195.876737" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma858843902" x="225.817514" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="225.547553" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma858843902" x="246.831212" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="246.599332" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma858843902" x="263.130703" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="262.92836" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma858843902" x="276.448356" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="276.270148" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma858843902" x="287.708272" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="287.550469" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma858843902" x="297.462054" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="297.321927" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma858843902" x="306.0655" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="305.940964" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma858843902" x="364.392387" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="364.37355" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma858843902" x="394.009531" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="394.044367" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma858843902" x="415.023229" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="415.096146" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma858843902" x="431.322719" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="431.425174" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma858843902" x="444.640372" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="444.766962" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma858843902" x="455.900288" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="456.047282" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma858843902" x="465.65407" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="465.818741" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma858843902" x="474.257516" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="474.437778" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_23">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma858843902" x="532.584403" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="532.870364" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_24">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma858843902" x="562.201547" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
+       <use xlink:href="#m7489908bda" x="562.54118" y="441.333969" style="fill: #9aa3ad; stroke: #9aa3ad; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -322,125 +322,125 @@ L 567.844375 441.333969
 " style="fill: none; stroke: #2a2e38; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M -168046.44665 49.725969
-L 129.330434 49.725969
-L 129.330434 74.775521
-L -168046.44665 74.775521
+    <path d="M -168351.659639 49.725969
+L 129.325464 49.725969
+L 129.325464 74.775521
+L -168351.659639 74.775521
 z
-" clip-path="url(#p5529b08340)" style="fill: url(#hf84c0436f1)"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: url(#hf6860dab9a)"/>
    </g>
    <g id="patch_5">
-    <path d="M -168046.44665 84.517014
-L 155.003732 84.517014
-L 155.003732 109.566566
-L -168046.44665 109.566566
+    <path d="M -168351.659639 84.517014
+L 160.160557 84.517014
+L 160.160557 109.566566
+L -168351.659639 109.566566
 z
-" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: url(#hc4965c4b3c)"/>
    </g>
    <g id="patch_6">
-    <path d="M -168046.44665 119.308058
-L 167.573667 119.308058
-L 167.573667 144.357611
-L -168046.44665 144.357611
+    <path d="M -168351.659639 119.308058
+L 168.860361 119.308058
+L 168.860361 144.357611
+L -168351.659639 144.357611
 z
-" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: url(#hc4965c4b3c)"/>
    </g>
    <g id="patch_7">
-    <path d="M -168046.44665 154.099103
-L 169.327366 154.099103
-L 169.327366 179.148655
-L -168046.44665 179.148655
+    <path d="M -168351.659639 154.099103
+L 169.042741 154.099103
+L 169.042741 179.148655
+L -168351.659639 179.148655
 z
-" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_8">
-    <path d="M -168046.44665 188.890148
-L 212.132895 188.890148
-L 212.132895 213.9397
-L -168046.44665 213.9397
+    <path d="M -168351.659639 188.890148
+L 203.994933 188.890148
+L 203.994933 213.9397
+L -168351.659639 213.9397
 z
-" clip-path="url(#p5529b08340)" style="fill: #24fefd"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #24fefd"/>
    </g>
    <g id="patch_9">
-    <path d="M -168046.44665 223.681193
-L 247.367365 223.681193
-L 247.367365 248.730745
-L -168046.44665 248.730745
+    <path d="M -168351.659639 223.681193
+L 238.415725 223.681193
+L 238.415725 248.730745
+L -168351.659639 248.730745
 z
-" clip-path="url(#p5529b08340)" style="fill: #46b3ac"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #46b3ac"/>
    </g>
    <g id="patch_10">
-    <path d="M -168046.44665 258.472237
-L 299.558735 258.472237
-L 299.558735 283.52179
-L -168046.44665 283.52179
+    <path d="M -168351.659639 258.472237
+L 302.616386 258.472237
+L 302.616386 283.52179
+L -168351.659639 283.52179
 z
-" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_11">
-    <path d="M -168046.44665 293.263282
-L 316.448118 293.263282
-L 316.448118 318.312834
-L -168046.44665 318.312834
+    <path d="M -168351.659639 293.263282
+L 316.065615 293.263282
+L 316.065615 318.312834
+L -168351.659639 318.312834
 z
-" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_12">
-    <path d="M -168046.44665 328.054327
-L 358.06942 328.054327
-L 358.06942 353.103879
-L -168046.44665 353.103879
+    <path d="M -168351.659639 328.054327
+L 360.567584 328.054327
+L 360.567584 353.103879
+L -168351.659639 353.103879
 z
-" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: url(#hc4965c4b3c)"/>
    </g>
    <g id="patch_13">
-    <path d="M -168046.44665 362.845372
-L 389.309559 362.845372
-L 389.309559 387.894924
-L -168046.44665 387.894924
+    <path d="M -168351.659639 362.845372
+L 389.245714 362.845372
+L 389.245714 387.894924
+L -168351.659639 387.894924
 z
-" clip-path="url(#p5529b08340)" style="fill: #5b626d"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: #5b626d"/>
    </g>
    <g id="patch_14">
-    <path d="M -168046.44665 397.636417
-L 510.251614 397.636417
-L 510.251614 422.685969
-L -168046.44665 422.685969
+    <path d="M -168351.659639 397.636417
+L 510.147244 397.636417
+L 510.147244 422.685969
+L -168351.659639 422.685969
 z
-" clip-path="url(#p5529b08340)" style="fill: url(#hed66c801f2)"/>
+" clip-path="url(#p9a5a5bb8c3)" style="fill: url(#hc4965c4b3c)"/>
    </g>
    <g id="text_16">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.608512" y="64.198987" transform="rotate(-0 137.608512 64.198987)">0.80µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="137.618544" y="64.198987" transform="rotate(-0 137.618544 64.198987)">0.81µs</text>
    </g>
    <g id="text_17">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="163.28181" y="98.990032" transform="rotate(-0 163.28181 98.990032)">1.14µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="168.453637" y="98.990032" transform="rotate(-0 168.453637 98.990032)">1.23µs</text>
    </g>
    <g id="text_18">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="175.851745" y="133.781077" transform="rotate(-0 175.851745 133.781077)">1.35µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.153441" y="133.781077" transform="rotate(-0 177.153441 133.781077)">1.38µs</text>
    </g>
    <g id="text_19">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.605444" y="168.572121" transform="rotate(-0 177.605444 168.572121)">1.38µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="177.335821" y="168.572121" transform="rotate(-0 177.335821 168.572121)">1.39µs</text>
    </g>
    <g id="text_20">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="220.410974" y="203.363166" transform="rotate(-0 220.410974 203.363166)">2.49µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="212.288013" y="203.363166" transform="rotate(-0 212.288013 203.363166)">2.23µs</text>
    </g>
    <g id="text_21">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="255.645443" y="238.154211" transform="rotate(-0 255.645443 238.154211)">4.03µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="246.708805" y="238.154211" transform="rotate(-0 246.708805 238.154211)">3.58µs</text>
    </g>
    <g id="text_22">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="307.836814" y="272.945256" transform="rotate(-0 307.836814 272.945256)">8.23µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="310.909466" y="272.945256" transform="rotate(-0 310.909466 272.945256)">8.60µs</text>
    </g>
    <g id="text_23">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="324.726197" y="307.7363" transform="rotate(-0 324.726197 307.7363)">10.37µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="324.358695" y="307.7363" transform="rotate(-0 324.358695 307.7363)">10.34µs</text>
    </g>
    <g id="text_24">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="366.347499" y="342.527345" transform="rotate(-0 366.347499 342.527345)">18.34µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="368.860664" y="342.527345" transform="rotate(-0 368.860664 342.527345)">18.99µs</text>
    </g>
    <g id="text_25">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.587638" y="377.31839" transform="rotate(-0 397.587638 377.31839)">28.13µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="397.538794" y="377.31839" transform="rotate(-0 397.538794 377.31839)">28.10µs</text>
    </g>
    <g id="text_26">
-    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="518.529692" y="412.109435" transform="rotate(-0 518.529692 412.109435)">147.32µs</text>
+    <text style="font-size: 7.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #9aa3ad" x="518.440324" y="412.109435" transform="rotate(-0 518.440324 412.109435)">146.61µs</text>
    </g>
    <g id="text_27">
     <text style="font-weight: 700; font-size: 13px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="110.284375" y="17.077969" transform="rotate(-0 110.284375 17.077969)">dict to object, across libraries</text>
@@ -463,7 +463,7 @@ L 363.699766 504.673361
 L 363.699766 498.723361
 L 346.699766 498.723361
 z
-" style="fill: url(#hed66c801f2)"/>
+" style="fill: url(#hc4965c4b3c)"/>
     </g>
     <g id="text_29">
      <text style="font-size: 8.5px; font-family: 'Inter', 'Inter Variable', 'DejaVu Sans', sans-serif; text-anchor: start; fill: #e6edf3" x="370.499766" y="504.673361" transform="rotate(-0 370.499766 504.673361)">deserializes (trusts the types)</text>
@@ -472,12 +472,12 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5529b08340">
+  <clipPath id="p9a5a5bb8c3">
    <rect x="110.284375" y="31.077969" width="457.56" height="410.256"/>
   </clipPath>
  </defs>
  <defs>
-  <pattern id="hf84c0436f1" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hf6860dab9a" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#46b3ac"/>
    <path d="M -36 36
 L 36 -36
@@ -531,7 +531,7 @@ M 36 108
 L 108 36
 " style="fill: #13151c; stroke: #13151c; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
   </pattern>
-  <pattern id="hed66c801f2" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+  <pattern id="hc4965c4b3c" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
    <rect x="0" y="0" width="73" height="73" fill="#5b626d"/>
    <path d="M -36 36
 L 36 -36

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -145,7 +145,7 @@ The two are close on the dict-to-dataclass path, which is worth seeing precisely
 because they do different amounts of work. mashumaro deserializes and largely
 trusts the declared types; Probatio's `DataclassSchema` validates every field
 against its type and then constructs. On a small dataclass, mashumaro builds it in
-about 0.5 µs and a compiled Probatio schema in about 0.6 µs, so Probatio is within
+about 0.5 µs and a compiled Probatio schema in about 0.7 µs, so Probatio is within
 roughly 1.3x while actually validating, and the gap all but closes as the field
 count grows. That is the trade: mashumaro is faster because it trusts the input,
 Probatio costs a little more because it does not. If the input is wrong (a string

--- a/docs/src/content/docs/reference/builtins-by-role.md
+++ b/docs/src/content/docs/reference/builtins-by-role.md
@@ -37,34 +37,34 @@ decides the type every later step sees.
 Dictionary keys that carry intent. Each compares and hashes by its underlying
 key, so a marker stands in for the bare key.
 
-| Name        | Note                                          |
-| ----------- | --------------------------------------------- |
-| `Required`  | The key must be present.                      |
-| `Optional`  | The key may be present; a `default` fills in. |
-| `Remove`    | Drop matching keys from the output.           |
-| `Extra`     | Catch-all key for the rest of a mapping.      |
-| `Inclusive` | Group of keys that must appear together.      |
+| Name        | Note                                           |
+| ----------- | ---------------------------------------------- |
+| `Required`  | The key must be present.                       |
+| `Optional`  | The key may be present; a `default` fills in.  |
+| `Remove`    | Drop matching keys from the output.            |
+| `Extra`     | Catch-all key for the rest of a mapping.       |
+| `Inclusive` | Group of keys that must appear together.       |
 | `Exclusive` | Group of keys of which at most one may appear. |
-| `Self`      | A recursive reference to the schema.          |
-| `Forbidden` | The key must be absent.                       |
-| `Alias`     | Accept the key under alternate input names.   |
-| `Secret`    | Redact the key's value in error output.       |
+| `Self`      | A recursive reference to the schema.           |
+| `Forbidden` | The key must be absent.                        |
+| `Alias`     | Accept the key under alternate input names.    |
+| `Secret`    | Redact the key's value in error output.        |
 
 ## Combinators and wrappers
 
 Compose or wrap other validators.
 
-| Name     | Note                                          |
-| -------- | --------------------------------------------- |
+| Name     | Note                                                |
+| -------- | --------------------------------------------------- |
 | `All`    | Run each in turn; the output of one feeds the next. |
-| `Any`    | The first that accepts wins.                  |
-| `And`    | Alias of `All`.                               |
-| `Or`     | Alias of `Any`.                               |
-| `Union`  | `Any` with an optional discriminant.          |
-| `Switch` | Alias of `Union`.                             |
-| `SomeOf` | Between `min_valid` and `max_valid` must pass. |
-| `Maybe`  | Accept `None`, otherwise the wrapped validator. |
-| `Msg`    | Override a validator's error message.         |
+| `Any`    | The first that accepts wins.                        |
+| `And`    | Alias of `All`.                                     |
+| `Or`     | Alias of `Any`.                                     |
+| `Union`  | `Any` with an optional discriminant.                |
+| `Switch` | Alias of `Union`.                                   |
+| `SomeOf` | Between `min_valid` and `max_valid` must pass.      |
+| `Maybe`  | Accept `None`, otherwise the wrapped validator.     |
+| `Msg`    | Override a validator's error message.               |
 
 ## Validators
 
@@ -72,124 +72,124 @@ Check a value and return it unchanged.
 
 ### Value and type
 
-| Name            | Note                                       |
-| --------------- | ------------------------------------------ |
-| `Literal`       | Equal to a literal value.                  |
-| `Equal`         | Equal to a target.                         |
-| `In`            | A member of a container.                   |
-| `NotIn`         | Not a member of a container.               |
-| `Contains`      | Contains a target value.                   |
-| `Match`         | Matches a regular expression.              |
-| `IsRegex`       | A compilable regular expression.           |
-| `Object`        | Attributes validated like a mapping.       |
-| `ExactSequence` | A sequence matching a fixed shape.         |
-| `Unordered`     | A sequence in any order.                   |
-| `Unique`        | No duplicate elements.                     |
-| `Sorted`        | Already in ascending order.                |
-| `Length`        | Length within bounds.                      |
-| `NonEmpty`      | Not empty.                                 |
+| Name            | Note                                 |
+| --------------- | ------------------------------------ |
+| `Literal`       | Equal to a literal value.            |
+| `Equal`         | Equal to a target.                   |
+| `In`            | A member of a container.             |
+| `NotIn`         | Not a member of a container.         |
+| `Contains`      | Contains a target value.             |
+| `Match`         | Matches a regular expression.        |
+| `IsRegex`       | A compilable regular expression.     |
+| `Object`        | Attributes validated like a mapping. |
+| `ExactSequence` | A sequence matching a fixed shape.   |
+| `Unordered`     | A sequence in any order.             |
+| `Unique`        | No duplicate elements.               |
+| `Sorted`        | Already in ascending order.          |
+| `Length`        | Length within bounds.                |
+| `NonEmpty`      | Not empty.                           |
 
 ### Numbers
 
-| Name          | Note                                        |
-| ------------- | ------------------------------------------- |
-| `Range`       | Within a numeric range.                     |
+| Name          | Note                                                |
+| ------------- | --------------------------------------------------- |
+| `Range`       | Within a numeric range.                             |
 | `Number`      | A number; `yield_decimal=True` returns a `Decimal`. |
-| `Positive`    | Greater than zero.                          |
-| `Negative`    | Less than zero.                             |
-| `NonNegative` | Zero or greater.                            |
-| `MultipleOf`  | An exact multiple of a base.                |
-| `Byte`        | An integer from 0 to 255.                   |
-| `SmallFloat`  | A float from 0 to 1.                        |
-| `Latitude`    | A valid latitude.                           |
-| `Longitude`   | A valid longitude.                          |
-| `Percentage`  | A number or `"NN%"` string in 0 to 100.     |
+| `Positive`    | Greater than zero.                                  |
+| `Negative`    | Less than zero.                                     |
+| `NonNegative` | Zero or greater.                                    |
+| `MultipleOf`  | An exact multiple of a base.                        |
+| `Byte`        | An integer from 0 to 255.                           |
+| `SmallFloat`  | A float from 0 to 1.                                |
+| `Latitude`    | A valid latitude.                                   |
+| `Longitude`   | A valid longitude.                                  |
+| `Percentage`  | A number or `"NN%"` string in 0 to 100.             |
 
 ### Strings and formats
 
-| Name             | Note                                     |
-| ---------------- | ---------------------------------------- |
-| `Email`          | An email address.                        |
-| `Url`            | A URL.                                   |
-| `FqdnUrl`        | A URL with a fully qualified domain.     |
-| `Slug`           | A URL slug.                              |
-| `Alpha`          | Letters only.                            |
-| `Alphanumeric`   | Letters and digits only.                 |
-| `ASCII`          | ASCII characters only.                   |
-| `PrintableASCII` | Printable ASCII only.                    |
-| `NoWhitespace`   | No whitespace characters.                |
-| `StartsWith`     | Begins with a prefix.                    |
-| `EndsWith`       | Ends with a suffix.                      |
-| `ByteLength`     | UTF-8 byte length within bounds.         |
+| Name             | Note                                           |
+| ---------------- | ---------------------------------------------- |
+| `Email`          | An email address.                              |
+| `Url`            | A URL.                                         |
+| `FqdnUrl`        | A URL with a fully qualified domain.           |
+| `Slug`           | A URL slug.                                    |
+| `Alpha`          | Letters only.                                  |
+| `Alphanumeric`   | Letters and digits only.                       |
+| `ASCII`          | ASCII characters only.                         |
+| `PrintableASCII` | Printable ASCII only.                          |
+| `NoWhitespace`   | No whitespace characters.                      |
+| `StartsWith`     | Begins with a prefix.                          |
+| `EndsWith`       | Ends with a suffix.                            |
+| `ByteLength`     | UTF-8 byte length within bounds.               |
 | `HexColor`       | A hex color; compose `Lower`/`Upper` for case. |
-| `Hex`            | Hexadecimal; checks, does not decode.    |
-| `Base64`         | Base64; checks, does not decode.         |
-| `JSONString`     | A JSON string; value via `FromJSONString`. |
-| `YAMLString`     | A YAML string; value via `FromYAMLString`. |
-| `ULID`           | A ULID; compose `Upper` for canonical case. |
-| `CreditCard`     | A card number (Luhn).                    |
-| `IBAN`           | An IBAN (mod-97).                        |
-| `DataURI`        | A `data:` URI.                           |
-| `E164`           | An E.164 phone number.                   |
-| `Datetime`       | A datetime string; string in, string out. |
-| `Date`           | A date string; string in, string out.    |
-| `Time`           | A time string; string in, string out.    |
-| `Duration`       | A duration string; object via `AsTimedelta`. |
-| `TimeZone`       | A UTC offset; object via `AsTimezone`.   |
-| `TimeZoneInfo`   | An IANA name; object via `Coerce(ZoneInfo)`. |
+| `Hex`            | Hexadecimal; checks, does not decode.          |
+| `Base64`         | Base64; checks, does not decode.               |
+| `JSONString`     | A JSON string; value via `FromJSONString`.     |
+| `YAMLString`     | A YAML string; value via `FromYAMLString`.     |
+| `ULID`           | A ULID; compose `Upper` for canonical case.    |
+| `CreditCard`     | A card number (Luhn).                          |
+| `IBAN`           | An IBAN (mod-97).                              |
+| `DataURI`        | A `data:` URI.                                 |
+| `E164`           | An E.164 phone number.                         |
+| `Datetime`       | A datetime string; string in, string out.      |
+| `Date`           | A date string; string in, string out.          |
+| `Time`           | A time string; string in, string out.          |
+| `Duration`       | A duration string; object via `AsTimedelta`.   |
+| `TimeZone`       | A UTC offset; object via `AsTimezone`.         |
+| `TimeZoneInfo`   | An IANA name; object via `Coerce(ZoneInfo)`.   |
 
 ### Network and identifier
 
 Check the format and return the string unchanged. The parsed object is opt-in
 through `Coerce`, since each of these types constructs from its string.
 
-| Name          | Note                                       |
-| ------------- | ------------------------------------------ |
-| `Hostname`    | A hostname.                                |
-| `Fqdn`        | A fully qualified domain name.             |
-| `Port`        | A TCP/UDP port number.                     |
+| Name          | Note                                                     |
+| ------------- | -------------------------------------------------------- |
+| `Hostname`    | A hostname.                                              |
+| `Fqdn`        | A fully qualified domain name.                           |
+| `Port`        | A TCP/UDP port number.                                   |
 | `MacAddress`  | A MAC address; canonical form via `NormalizeMacAddress`. |
-| `UUID`        | A UUID; object via `Coerce(uuid.UUID)`.    |
-| `IPv4Address` | Object via `Coerce(ipaddress.IPv4Address)`. |
-| `IPv6Address` | Object via `Coerce(ipaddress.IPv6Address)`. |
-| `IPAddress`   | Object via `Coerce(ipaddress.ip_address)`. |
-| `IPNetwork`   | Object via `Coerce(ipaddress.ip_network)`. |
+| `UUID`        | A UUID; object via `Coerce(uuid.UUID)`.                  |
+| `IPv4Address` | Object via `Coerce(ipaddress.IPv4Address)`.              |
+| `IPv6Address` | Object via `Coerce(ipaddress.IPv6Address)`.              |
+| `IPAddress`   | Object via `Coerce(ipaddress.ip_address)`.               |
+| `IPNetwork`   | Object via `Coerce(ipaddress.ip_network)`.               |
 
 ### Filesystem
 
-| Name            | Note                          |
-| --------------- | ----------------------------- |
-| `IsDir`         | An existing directory.        |
-| `IsFile`        | An existing file.             |
-| `PathExists`    | An existing path.             |
-| `IsSymlink`     | A symbolic link.              |
-| `IsSocket`      | A socket.                     |
-| `IsFifo`        | A FIFO.                       |
-| `IsBlockDevice` | A block device.               |
+| Name            | Note                   |
+| --------------- | ---------------------- |
+| `IsDir`         | An existing directory. |
+| `IsFile`        | An existing file.      |
+| `PathExists`    | An existing path.      |
+| `IsSymlink`     | A symbolic link.       |
+| `IsSocket`      | A socket.              |
+| `IsFifo`        | A FIFO.                |
+| `IsBlockDevice` | A block device.        |
 
 ### Truthiness
 
-| Name      | Note              |
-| --------- | ----------------- |
-| `IsTrue`  | A truthy value.   |
-| `IsFalse` | A falsy value.    |
+| Name      | Note            |
+| --------- | --------------- |
+| `IsTrue`  | A truthy value. |
+| `IsFalse` | A falsy value.  |
 
 ### Cross-field and mapping rules
 
 Run over a whole mapping, usually after a dict schema with `All`.
 
-| Name              | Note                                       |
-| ----------------- | ------------------------------------------ |
-| `RequiredWith`    | Required when another key is present.      |
-| `RequiredWithout` | Required when another key is absent.       |
-| `RequiredIf`      | Required when a condition holds.           |
-| `Check`           | An arbitrary predicate over the mapping.   |
-| `AtLeastOne`      | At least one of a set of keys is present.  |
-| `AtMostOne`       | At most one of a set of keys is present.   |
-| `ExactlyOne`      | Exactly one of a set of keys is present.   |
-| `AllOrNone`       | All of a set of keys, or none.             |
-| `Immutable`       | Rejects a change against the prior value.  |
-| `WriteOnce`       | Rejects a second write.                    |
+| Name              | Note                                      |
+| ----------------- | ----------------------------------------- |
+| `RequiredWith`    | Required when another key is present.     |
+| `RequiredWithout` | Required when another key is absent.      |
+| `RequiredIf`      | Required when a condition holds.          |
+| `Check`           | An arbitrary predicate over the mapping.  |
+| `AtLeastOne`      | At least one of a set of keys is present. |
+| `AtMostOne`       | At most one of a set of keys is present.  |
+| `ExactlyOne`      | Exactly one of a set of keys is present.  |
+| `AllOrNone`       | All of a set of keys, or none.            |
+| `Immutable`       | Rejects a change against the prior value. |
+| `WriteOnce`       | Rejects a second write.                   |
 
 ## Transformers
 
@@ -199,36 +199,36 @@ Return a changed value.
 
 The type changes.
 
-| Name             | Result                              |
-| ---------------- | ----------------------------------- |
-| `Coerce`         | `type(value)`, the generic convert. |
-| `Boolean`        | A string to a `bool`.               |
-| `Set`            | An iterable to a `set`.             |
-| `EnsureList`     | A scalar to a one-element `list`.   |
-| `AsDatetime`     | A string to a `datetime`.           |
-| `AsDate`         | A string to a `date`.               |
-| `AsTime`         | A string to a `time`.               |
-| `AsTimedelta`    | A duration to a `timedelta`.        |
-| `AsTimezone`     | An offset to a `datetime.timezone`. |
-| `FromEpoch`      | A timestamp to a `datetime`.        |
-| `FromPercentage` | `"80%"` to a `float`.               |
-| `HexInt`         | A hex string to an `int`.           |
-| `FromJSONString` | A JSON string to the decoded value. |
-| `FromYAMLString` | A YAML string to the decoded value. |
-| `DefaultTo`      | `None` to a default (substitution). |
+| Name             | Result                                    |
+| ---------------- | ----------------------------------------- |
+| `Coerce`         | `type(value)`, the generic convert.       |
+| `Boolean`        | A string to a `bool`.                     |
+| `Set`            | An iterable to a `set`.                   |
+| `EnsureList`     | A scalar to a one-element `list`.         |
+| `AsDatetime`     | A string to a `datetime`.                 |
+| `AsDate`         | A string to a `date`.                     |
+| `AsTime`         | A string to a `time`.                     |
+| `AsTimedelta`    | A duration to a `timedelta`.              |
+| `AsTimezone`     | An offset to a `datetime.timezone`.       |
+| `FromEpoch`      | A timestamp to a `datetime`.              |
+| `FromPercentage` | `"80%"` to a `float`.                     |
+| `HexInt`         | A hex string to an `int`.                 |
+| `FromJSONString` | A JSON string to the decoded value.       |
+| `FromYAMLString` | A YAML string to the decoded value.       |
+| `DefaultTo`      | `None` to a default (substitution).       |
 | `SetTo`          | Anything to a fixed value (substitution). |
 
 ### Normalizers
 
 The type stays; the value is cleaned.
 
-| Name                  | Result                              |
-| --------------------- | ----------------------------------- |
-| `Lower`               | Lowercase.                          |
-| `Upper`               | Uppercase.                          |
-| `Capitalize`          | Capitalized.                        |
-| `Title`               | Title-cased.                        |
-| `Strip`               | Whitespace trimmed.                 |
-| `Replace`             | Regular-expression replace.         |
-| `Clamp`               | A number pinned into a range.       |
-| `NormalizeMacAddress` | A MAC address in canonical form.    |
+| Name                  | Result                           |
+| --------------------- | -------------------------------- |
+| `Lower`               | Lowercase.                       |
+| `Upper`               | Uppercase.                       |
+| `Capitalize`          | Capitalized.                     |
+| `Title`               | Title-cased.                     |
+| `Strip`               | Whitespace trimmed.              |
+| `Replace`             | Regular-expression replace.      |
+| `Clamp`               | A number pinned into a range.    |
+| `NormalizeMacAddress` | A MAC address in canonical form. |

--- a/docs/src/content/docs/reference/performance.md
+++ b/docs/src/content/docs/reference/performance.md
@@ -58,13 +58,13 @@ the schema, so treat these as ballparks, not promises.
 
 | Scenario                         | voluptuous | Probatio | Probatio compiled |
 | -------------------------------- | ---------- | -------- | ----------------- |
-| Flat types (`{str, int, ...}`)   | 3.6 µs     | 1.0 µs   | 0.5 µs            |
-| Config (coerce, range, in, list) | 5.7 µs     | 2.1 µs   | 0.9 µs            |
-| Nested mapping                   | 6.6 µs     | 2.8 µs   | 1.0 µs            |
+| Flat types (`{str, int, ...}`)   | 3.7 µs     | 1.1 µs   | 0.5 µs            |
+| Config (coerce, range, in, list) | 6.0 µs     | 2.2 µs   | 0.9 µs            |
+| Nested mapping                   | 7.0 µs     | 3.0 µs   | 1.0 µs            |
 
 Microseconds per validation, lower is faster, on one machine with Python 3.13.
 
-![Validation throughput vs voluptuous: probatio is 1.6 to 3.6 times faster interpreted, and 4.6 to 6.9 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
+![Validation throughput vs voluptuous: probatio is 1.7 to 3.4 times faster interpreted, and 4.7 to 7.2 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
 
 :::caution[Read the benchmark honestly]
 `bench/bench.py` is a rough, single-machine comparison. It builds equivalent
@@ -87,12 +87,12 @@ deserializes and largely trusts the declared types, while Probatio _validates_ e
 field against its type and then constructs. mashumaro does strictly less work, so it
 is faster on already-correct input. The compiled Probatio path lands within roughly
 1.3x of it on a small dataclass while still validating, and the gap all but closes
-as the field count grows (about 1.05x on a wide one).
+as the field count grows (about 1.1x on a wide one).
 
 | Dataclass        | mashumaro | Probatio | Probatio compiled |
 | ---------------- | --------- | -------- | ----------------- |
-| Small (4 fields) | 0.5 µs    | 1.7 µs   | 0.6 µs            |
-| Wide (12 fields) | 1.2 µs    | 2.9 µs   | 1.3 µs            |
+| Small (4 fields) | 0.5 µs    | 1.5 µs   | 0.7 µs            |
+| Wide (12 fields) | 1.2 µs    | 2.8 µs   | 1.3 µs            |
 
 ![Dataclass construction vs mashumaro: compiled probatio is within about 1.3 times of mashumaro on a small dataclass and essentially even on a wide one, while validating every field.](/benchmarks/dataclass-vs-mashumaro.svg)
 
@@ -115,11 +115,11 @@ appears in both groups: its normal call validates, and its opt-in
 [`construct`](/guides/dataclasses/#trusted-construction-without-validation) builds
 from trusted input without validating, the same job the deserializers do.
 
-![dict to object across libraries, log scale: probatio construct is the fastest of all, then mashumaro, cattrs, and pydantic v2; compiled probatio sits next, ahead of voluptuous, pydantic v1, dacite, marshmallow, and dataclasses-json.](/benchmarks/vs-world.svg)
+![dict to object across libraries, log scale: probatio construct is the fastest of all, then mashumaro, pydantic v2, and cattrs; compiled probatio sits next, ahead of voluptuous, pydantic v1, dacite, marshmallow, and dataclasses-json.](/benchmarks/vs-world.svg)
 
 Two honest readings. On the **validate** path, compiled Probatio lands in the
 leading group, ahead of voluptuous, pydantic v1, dacite, marshmallow, and
-dataclasses-json, and within about 1.8x of the Rust-cored pydantic v2, while staying
+dataclasses-json, and within about 1.7x of the Rust-cored pydantic v2, while staying
 pure Python and validating every field. On the **trust the types** path,
 `construct` is the fastest in the whole field, ahead of mashumaro and cattrs,
 because it is a purpose-built constructor generated for that one dataclass. Run it
@@ -177,8 +177,10 @@ just codspeed
 ```
 
 These are not part of the normal test run. They exercise the hot paths interpreted
-and compiled: validating a config-style mapping, a dataclass, a nested mapping,
-compiling a schema from scratch, and the generation step itself.
+and compiled: validating a config-style mapping, a dataclass, a nested mapping, a
+composed schema, and a combinator under the automatic compile policy; calling a
+`@probatio`-decorated function; compiling a schema from scratch; and the
+generation step itself.
 
 To dig into a hot spot, the profiler wraps cProfile (and py-spy) over the generator
 and the validators it produces:

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -38,6 +38,7 @@ import dataclasses
 import enum
 import types
 from collections.abc import (
+    Callable,
     Mapping,
     MutableMapping,
     MutableSequence,
@@ -62,7 +63,7 @@ from typing import Union as TypingUnion
 from probatio._codegen import compile_mapping
 from probatio._engine import _MappingValidator
 from probatio._type_registry import resolve_type_validator
-from probatio.error import SchemaError
+from probatio.error import Invalid, MultipleInvalid, SchemaError, ValueInvalid
 from probatio.fields import Key
 from probatio.markers import (
     UNDEFINED,
@@ -620,8 +621,9 @@ class _Constructor:
         value ``ALLOW_EXTRA`` kept because it failed the field's own validation).
 
         ``filter_keys=False`` is the caller asserting the validated dict can only
-        hold init-field keys (no ``ALLOW_EXTRA``, no ``Remove`` fields), so the
-        per-call filtering comprehension is skipped.
+        hold init-field keys (no ``ALLOW_EXTRA``, no ``Remove`` fields);
+        ``_fuse_validate_and_construct`` reads it to splat the validated dict
+        straight into the constructor, skipping both this object and its filter.
         """
         self.dataclass_type = dataclass_type
         self._filter_keys = filter_keys
@@ -634,10 +636,12 @@ class _Constructor:
         """Construct the dataclass, passing only the keys it accepts.
 
         Extra keys (kept by ``ALLOW_EXTRA``) and dropped ``Remove`` keys are left out
-        here, since a dataclass cannot take an unexpected keyword argument.
+        here, since a dataclass cannot take an unexpected keyword argument. The
+        hot paths never get here (the fused interpreted engine and the generated
+        code construct directly); this runs only through the ``All`` tower kept
+        for a ``Self``-using schema, where an always-on filter costs nothing that
+        matters.
         """
-        if not self._filter_keys:
-            return self.dataclass_type(**data)
         kwargs = {key: value for key, value in data.items() if key in self._init_fields}
         return self.dataclass_type(**kwargs)
 
@@ -696,9 +700,99 @@ def create_dataclass_schema(
         dataclass_type, remove, filter_keys=extra == ALLOW_EXTRA or bool(remove)
     )
     schema = Schema(All(inner, constructor))
+    # Fused before ``bind``, so a recursive field's captured engine is the fused
+    # one too, not the slower combinator tower.
+    _install_fused_interpreted(schema)
     ref.bind(schema)
 
     return schema
+
+
+def _fuse_validate_and_construct(
+    validate_mapping: CompiledSchema, constructor: _Constructor
+) -> CompiledSchema:
+    """Return one closure that validates the mapping and constructs the instance.
+
+    The public schema shape stays ``Schema(All(inner, _Constructor))``; this is
+    only a faster interpreted engine for it. Called generically, that ``All``
+    tower is five frames of pure delegation per validation (the callable guard,
+    ``All.__call__``, the inner ``Schema.__call__``, and the shim around the
+    constructor) around the two calls that do real work. The closure keeps just
+    those two, with the guard's ``ValueError`` normalization replicated verbatim.
+
+    Error-shape parity: the mapping engine's errors propagate untouched (a
+    ``MultipleInvalid`` passed through the tower unchanged, and its bare
+    wrong-type error reaches every consumer the same way, since
+    ``Schema.__call__`` wraps a lone ``Invalid`` itself and the enclosing engines
+    flatten a ``MultipleInvalid`` to the same leaves). A constructor failure is
+    wrapped exactly as the tower did, exception chain included: the ``ValueError``
+    normalization mirrors the callable guard, and the ``MultipleInvalid`` wrap
+    mirrors ``All``, so tracebacks keep reading identically.
+    """
+    dataclass_type = constructor.dataclass_type
+    construct: Callable[..., TypingAny] = constructor
+
+    def _constructor_error(exc: ValueError) -> MultipleInvalid:
+        """Build the tower-identical error for a constructor ``ValueError``."""
+        detail = str(exc)
+        message = f"not a valid value: {detail}" if detail else "not a valid value"
+        error = ValueInvalid(message)
+        error.__cause__ = exc
+        return MultipleInvalid([error])
+
+    if constructor._filter_keys:  # noqa: SLF001
+
+        def validate(data: TypingAny) -> TypingAny:
+            """Validate the mapping, then construct through the filter."""
+            validated = validate_mapping(data)
+            try:
+                return construct(validated)
+            except MultipleInvalid:
+                raise
+            except Invalid as exc:
+                raise MultipleInvalid([exc]) from exc
+            except ValueError as exc:
+                error = _constructor_error(exc)
+                raise error from error.errors[0]
+
+        return validate
+
+    def validate_splat(data: TypingAny) -> TypingAny:
+        """Validate the mapping, then splat it straight into the constructor."""
+        validated = validate_mapping(data)
+        try:
+            return dataclass_type(**validated)
+        except MultipleInvalid:
+            raise
+        except Invalid as exc:
+            raise MultipleInvalid([exc]) from exc
+        except ValueError as exc:
+            error = _constructor_error(exc)
+            raise error from error.errors[0]
+
+    return validate_splat
+
+
+def _install_fused_interpreted(schema: Schema) -> None:
+    """Swap ``schema``'s interpreted engine for the fused validate-and-construct.
+
+    ``schema`` wraps ``All(inner, _Constructor)``. The inner mapping schema is
+    pinned interpreted (``compile=False``), so its engine can be captured
+    directly. A ``Self``-using inner keeps the tower: its resolution runs through
+    the inner ``Schema.__call__``'s active-root bookkeeping.
+
+    The fused engine lands wherever the interpreted validator lives: in
+    ``_interpreted`` when the schema armed for lazy compilation (it then also
+    becomes the generated code's bail-out fallback), else in ``_compiled``.
+    """
+    inner, constructor = schema.schema.validators
+    if inner._uses_self:  # noqa: SLF001
+        return
+    fused = _fuse_validate_and_construct(inner._compiled, constructor)  # noqa: SLF001
+    if "_interpreted" in schema.__dict__:
+        schema._interpreted = fused  # noqa: SLF001
+    else:
+        schema._compiled = fused  # noqa: SLF001
 
 
 # Distinguishes "the fast constructor has not been built yet" from "built, and the
@@ -905,6 +999,10 @@ class DataclassSchema[DataclassT](Schema):
             extra=extra,
         )
         super().__init__(built.schema, compile=compile)
+        # ``built`` carries its own fused engine, but this instance recompiled the
+        # ``All`` from scratch in ``super().__init__``, so it fuses again for
+        # itself.
+        _install_fused_interpreted(self)
 
     def extend(self, *_args: TypingAny, **_kwargs: TypingAny) -> Schema:
         """Refuse to extend: a ``DataclassSchema`` is built from a type, not a mapping.

--- a/src/probatio/decorator.py
+++ b/src/probatio/decorator.py
@@ -228,7 +228,14 @@ def _decorate[**P, R](
     def bind(
         args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
     ) -> inspect.BoundArguments:
-        """Bind the call, validate the named arguments, and write them back."""
+        """Bind the call, validate the named arguments, and write them back.
+
+        This is the semantic reference: ``Signature.bind`` raises the exact
+        ``TypeError`` a malformed call deserves and handles every signature
+        shape. It is also slow (microseconds of ``inspect`` machinery), so
+        regular calls take the fast binder below and land here only when the
+        signature is variadic or the call is malformed.
+        """
         bound = signature.bind(*args, **kwargs)
         named = {
             name: value
@@ -238,13 +245,15 @@ def _decorate[**P, R](
         bound.arguments.update(input_schema(named))
         return bound
 
+    rebind = _build_rebind(signature, input_schema, bind)
+
     if inspect.iscoroutinefunction(func):
 
         @wraps(func)
         async def async_wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
             """Validate the arguments, await ``func``, then validate the result."""
-            bound = bind(args, kwargs)
-            result = await func(*bound.args, **bound.kwargs)
+            call_args, call_kwargs = rebind(args, kwargs)
+            result = await func(*call_args, **call_kwargs)
             return output_schema(result)
 
         return typing.cast("typing.Callable[P, R]", async_wrapper)
@@ -252,7 +261,89 @@ def _decorate[**P, R](
     @wraps(func)
     def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         """Validate the arguments, call ``func``, then validate the result."""
-        bound = bind(args, kwargs)
-        return output_schema(func(*bound.args, **bound.kwargs))
+        call_args, call_kwargs = rebind(args, kwargs)
+        return output_schema(func(*call_args, **call_kwargs))
 
     return typing.cast("typing.Callable[P, R]", wrapper)
+
+
+def _build_rebind(
+    signature: inspect.Signature,
+    input_schema: typing.Callable[[typing.Any], typing.Any],
+    bind_slow: typing.Callable[
+        [tuple[typing.Any, ...], dict[str, typing.Any]], inspect.BoundArguments
+    ],
+) -> typing.Callable[
+    [tuple[typing.Any, ...], dict[str, typing.Any]],
+    tuple[tuple[typing.Any, ...], dict[str, typing.Any]],
+]:
+    """Build the per-call binder: plain dict work for a regular call.
+
+    ``Signature.bind`` walks the parameters in pure Python on every call, which
+    dwarfs the validation the decorator exists to do. For a signature without
+    variadic parameters, a well-formed call binds with a handful of dict and set
+    operations instead: leading positionals map to the leading parameter names,
+    every keyword must name a keyword-assignable parameter it does not collide
+    with, and every parameter without a default must be supplied. Those four
+    checks are exactly the cases ``Signature.bind`` rejects on such a signature,
+    so any call failing them is handed to ``bind_slow``, which raises the exact
+    ``TypeError`` (the fast path never invents its own error), and a variadic
+    signature (``*args``/``**kwargs``) always takes ``bind_slow``.
+    """
+
+    def slow(
+        args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
+    ) -> tuple[tuple[typing.Any, ...], dict[str, typing.Any]]:
+        """Delegate to the reference binder, normalizing to (args, kwargs)."""
+        bound = bind_slow(args, kwargs)
+        return bound.args, bound.kwargs
+
+    parameters = list(signature.parameters.values())
+    if any(parameter.kind not in _VALIDATED_KINDS for parameter in parameters):
+        return slow
+
+    positional = tuple(
+        parameter.name
+        for parameter in parameters
+        if parameter.kind is not inspect.Parameter.KEYWORD_ONLY
+    )
+    position = {name: index for index, name in enumerate(positional)}
+    keyword_ok = frozenset(
+        parameter.name
+        for parameter in parameters
+        if parameter.kind is not inspect.Parameter.POSITIONAL_ONLY
+    )
+    required = frozenset(
+        parameter.name
+        for parameter in parameters
+        if parameter.default is inspect.Parameter.empty
+    )
+    max_positional = len(positional)
+
+    def rebind(
+        args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]
+    ) -> tuple[tuple[typing.Any, ...], dict[str, typing.Any]]:
+        """Bind and validate fast when the call is regular, exactly otherwise."""
+        count = len(args)
+        if count > max_positional:
+            return slow(args, kwargs)
+        named = dict(zip(positional, args, strict=False))
+        for key in kwargs:
+            # Unknown keyword, positional-only passed by name, or a keyword
+            # colliding with a filled positional slot: all bind errors.
+            if key not in keyword_ok or position.get(key, count) < count:
+                return slow(args, kwargs)
+        if kwargs:
+            named.update(kwargs)
+        if not required <= named.keys():
+            return slow(args, kwargs)
+        validated = input_schema(named)
+        if validated is named:
+            # The identity schema (nothing to validate): forward the call as-is.
+            return args, kwargs
+        return (
+            tuple(validated[name] for name in positional[:count]),
+            {key: validated[key] for key in kwargs},
+        )
+
+    return rebind

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -81,6 +81,19 @@ class Invalid(Error):
     # ``code`` argument still wins.
     default_code: str | None = None
 
+    # Class-level defaults for the rarely-passed fields, stored on the instance
+    # only when a non-default value is given. Error construction is a hot path in
+    # its own right (an ``Any`` miss builds an error per branch and discards most),
+    # and a store skipped is a store saved. The setters below still write through
+    # to the instance, shadowing the class default, so mutation works unchanged.
+    # ``_path`` stays per-instance: it is exposed as a mutable list.
+    _error_type: str | None = None
+    _secret = False
+    _code: str | None = None
+    _context: dict[str, Any] | None = None
+    _translation_key: str | None = None
+    _placeholders: dict[str, Any] | None = None
+
     def __init__(
         self,
         message: str,
@@ -98,17 +111,19 @@ class Invalid(Error):
 
         self._path = list(path) if path else []
         self._error_message = error_message or message
-        self._error_type = error_type
-        self._secret = False
-        self._code = code
+        if error_type is not None:
+            self._error_type = error_type
+        if code is not None:
+            self._code = code
         # ``None`` until read: most errors never have their context/placeholders
         # looked at (a miss inside a combinator branch is built and discarded), so
-        # the two dict allocations are deferred to the property getters.
-        self._context: dict[str, Any] | None = dict(context) if context else None
-        self._translation_key = translation_key
-        self._placeholders: dict[str, Any] | None = (
-            dict(placeholders) if placeholders else None
-        )
+        # the dict copies are deferred to the property getters.
+        if context:
+            self._context = dict(context)
+        if translation_key is not None:
+            self._translation_key = translation_key
+        if placeholders:
+            self._placeholders = dict(placeholders)
 
     @property
     def msg(self) -> str:

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -468,9 +468,13 @@ class Schema:
         """
         self._compile_requested = True
         # Resolve now. A schema armed for lazy compilation keeps the interpreted
-        # validator in ``_interpreted``; otherwise ``_compiled`` is still it.
-        interpreted = self.__dict__.pop("_interpreted", self._compiled)
+        # validator in ``_interpreted``; otherwise ``_compiled`` is still it. The
+        # swap lands before ``_interpreted`` is dropped: a combinator holding the
+        # armed bootstrap reads "``_interpreted`` gone" as "``_compiled`` is
+        # final", so the reverse order would hand it the bootstrap itself.
+        interpreted = self.__dict__.get("_interpreted", self._compiled)
         self._compiled = self._compile_from(interpreted)
+        self.__dict__.pop("_interpreted", None)
         return self
 
     def _arm_compile(self) -> None:
@@ -503,18 +507,27 @@ class Schema:
         installs the right validator: the generated one now for the flag or the ON
         policy, an adaptive counter for AUTO, or the interpreted one if the policy
         turned off since arming. A combinator may have captured this bootstrap as a
-        branch before the swap; a later call through that stale reference finds
-        ``_interpreted`` gone and just delegates to the resolved validator.
+        branch before the swap; every later call through that stale reference lands
+        here forever, so the resolved case must stay cheap: it is a lock-free
+        membership test and a delegation, not a lock acquisition per call.
 
-        The pop and the swap run under ``_BOOTSTRAP_LOCK`` so two threads racing a
-        cold schema resolve it once: the loser finds ``_interpreted`` gone and the
-        ``_compiled`` already swapped, so it delegates instead of re-entering this
-        bootstrap against a half-installed validator. The lock covers only the swap,
-        not the validation call after it.
+        The lock-free check is sound because of the resolver's write order: the
+        final validator is stored in ``_compiled`` *before* ``_interpreted`` is
+        deleted (both under ``_BOOTSTRAP_LOCK``), so "``_interpreted`` gone" always
+        means "``_compiled`` is final". Two threads racing a cold schema still
+        resolve it once: the loser blocks on the lock, finds ``_interpreted``
+        gone, and delegates. The lock covers only the swap, not the validation
+        call after it.
         """
+        if "_interpreted" not in self.__dict__:
+            return self._compiled(data)
+
         with _BOOTSTRAP_LOCK:
-            interpreted = self.__dict__.pop("_interpreted", None)
-            if interpreted is not None:
+            interpreted = self.__dict__.get("_interpreted")
+            # ``None`` only when another thread resolved the schema between the
+            # lock-free check above and taking the lock, so the false edge is
+            # reachable only under contention (the race test hits it by chance).
+            if interpreted is not None:  # pragma: no branch
                 flag = self._compile_requested
                 if flag is None and get_compile_policy() is CompilePolicy.AUTO:
                     self._compiled = self._auto_counter(interpreted)
@@ -522,6 +535,9 @@ class Schema:
                     self._compiled = self._compile_from(interpreted)
                 else:
                     self._compiled = interpreted
+                # Deleted only after the swap above, so the lock-free check can
+                # never observe the transition half-done.
+                del self.__dict__["_interpreted"]
 
         return self._compiled(data)
 
@@ -776,6 +792,10 @@ class Schema:
             return self._compile_dict(schema)
         if isinstance(schema, list | tuple | set | frozenset):
             return self._compile_sequence(schema)
+        if isinstance(schema, Schema) and (
+            (direct := _compile_nested_schema(schema)) is not None
+        ):
+            return direct
         if callable(schema):
             # A combinator compiles its branches at construction with the strict
             # default extra. When this schema sets a different policy, rebind the
@@ -1111,3 +1131,39 @@ def compile_schema(
         return Schema(schema, required=required, extra=extra)._compiled  # noqa: SLF001
     finally:
         _COMPILING_FOR_COMBINATOR.reset(token)
+
+
+def _compile_nested_schema(schema: Schema) -> CompiledSchema | None:
+    """Compile a nested ``Schema`` node to a direct engine delegation, or ``None``.
+
+    A composed schema (a prebuilt ``Schema`` reused as a mapping value or sequence
+    element, the way large applications assemble config schemas) would otherwise
+    compile as an arbitrary callable: a ValueError guard around the full
+    ``Schema.__call__``, several frames per matched value. When the inner engine
+    is the mapping or sequence validator, the wrapping adds nothing: those engines
+    raise ``MultipleInvalid`` for value failures exactly as ``__call__`` would
+    surface it, and their bare wrong-type error aggregates identically because the
+    enclosing engine flattens a ``MultipleInvalid`` to the same leaves. So
+    composition costs one delegating frame instead. Reading ``_compiled`` live
+    (not capturing it) follows the inner schema's own bootstrap and compile swaps.
+
+    ``None`` means "keep the wrapper", in two cases. Inside a combinator, because
+    voluptuous resolves ``Any(Schema(int), float)`` on a miss to the branch's own
+    error ("expected int"), and the ``MultipleInvalid`` the wrapper raises is what
+    preserves that; unwrapping would turn it into the combined ``AnyInvalid``. And
+    for a ``Self``-using inner, whose ``__call__`` records the active root that
+    ``Self`` resolves against.
+    """
+    if _COMPILING_FOR_COMBINATOR.get() or schema._uses_self:  # noqa: SLF001
+        return None
+    # An armed schema parks its engine in ``_interpreted`` (``_compiled`` is the
+    # bootstrap); an unarmed one holds it in ``_compiled``.
+    engine = schema.__dict__.get("_interpreted", schema._compiled)  # noqa: SLF001
+    if not isinstance(engine, (_MappingValidator, _SequenceValidator)):
+        return None
+
+    def validate(data: Any) -> Any:
+        """Delegate to the nested schema's live engine."""
+        return schema._compiled(data)  # noqa: SLF001
+
+    return validate

--- a/tests/test_compile_policy.py
+++ b/tests/test_compile_policy.py
@@ -9,8 +9,10 @@ from typing import TYPE_CHECKING, TypedDict
 import pytest
 
 from probatio import (
+    Any,
     CompilePolicy,
     DataclassSchema,
+    Required,
     Schema,
     TypedDictSchema,
     get_compile_policy,
@@ -99,6 +101,49 @@ def test_auto_bootstrap_is_thread_safe_on_a_cold_schema() -> None:
 
     assert not errors
     assert results == [{"a": 1}] * workers
+
+
+def test_captured_bootstrap_is_thread_safe_through_a_combinator() -> None:
+    """Threads racing a combinator's captured mapping-branch bootstrap all succeed.
+
+    A combinator branch captures the armed bootstrap at construction and keeps
+    calling through it after the schema resolves. The resolver installs the final
+    validator before dropping the interpreted one, so a racer that observes the
+    resolved state always finds a real validator, never the bootstrap itself
+    (which would recurse).
+    """
+    set_compile_policy(CompilePolicy.AUTO)
+    schema = Schema(Any({Required("value"): int}, str))
+
+    workers = 50
+    start = threading.Barrier(workers)
+    results: list[object] = []
+    errors: list[BaseException] = []
+    guard = threading.Lock()
+
+    def hammer() -> None:
+        start.wait()
+        try:
+            # Enough calls per thread to cross the AUTO threshold mid-race, so
+            # the counter-to-generated swap is exercised through the stale
+            # reference as well.
+            for _ in range(60):
+                out = schema({"value": 1})
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+            with guard:
+                errors.append(exc)
+        else:
+            with guard:
+                results.append(out)
+
+    threads = [threading.Thread(target=hammer) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert results == [{"value": 1}] * workers
 
 
 def test_explicit_true_overrides_a_policy_of_off() -> None:

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -27,14 +27,17 @@ from probatio import (
     Coerce,
     DataclassSchema,
     In,
+    Invalid,
     Key,
     Length,
     MultipleInvalid,
     Range,
     SchemaError,
+    Self,
     create_dataclass_schema,
     is_dataclass,
 )
+from probatio import Any as AnyOf
 from probatio.dataclass_schema import _build_discriminant, _literal_tags
 from probatio.humanize import humanize_error
 
@@ -1320,3 +1323,106 @@ def test_key_required_exclusive_group_is_enforced_with_defaults() -> None:
     assert schema({"token": "t"}).token == "t"  # noqa: S105
     with pytest.raises(MultipleInvalid):
         schema({"token": "t", "secret": "s"})
+
+
+@dataclass
+class _GuardedWeight:
+    """A dataclass whose __post_init__ enforces its own invariant with ValueError."""
+
+    weight: float
+
+    def __post_init__(self) -> None:
+        if self.weight < 0:
+            message = "weight must not be negative"
+            raise ValueError(message)
+
+
+@pytest.mark.parametrize("extra", [None, ALLOW_EXTRA])
+def test_post_init_valueerror_becomes_value_invalid(extra: int | None) -> None:
+    """A ValueError from __post_init__ is reported as 'not a valid value: <reason>'.
+
+    Parametrized over the default and ALLOW_EXTRA schemas, which run the two
+    fused engine variants (direct splat and constructor filter); both must
+    normalize identically, chain included: the ValueInvalid's cause is the
+    original ValueError.
+    """
+    kwargs = {} if extra is None else {"extra": extra}
+    schema = DataclassSchema(_GuardedWeight, **kwargs)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"weight": -1.0})
+
+    (error,) = caught.value.errors
+    assert error.msg == "not a valid value: weight must not be negative"
+    assert isinstance(error.__cause__, ValueError)
+    assert schema({"weight": 1.0}).weight == 1.0
+
+
+@pytest.mark.parametrize("extra", [None, ALLOW_EXTRA])
+def test_post_init_invalid_is_wrapped_not_normalized(extra: int | None) -> None:
+    """An Invalid raised by __post_init__ surfaces as itself, wrapped once."""
+
+    @dataclass
+    class Guarded:
+        value: int
+
+        def __post_init__(self) -> None:
+            if self.value == 13:
+                message = "thirteen is right out"
+                raise Invalid(message)
+
+    kwargs = {} if extra is None else {"extra": extra}
+    schema = DataclassSchema(Guarded, **kwargs)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"value": 13})
+
+    (error,) = caught.value.errors
+    assert error.msg == "thirteen is right out"
+
+
+@pytest.mark.parametrize("extra", [None, ALLOW_EXTRA])
+def test_post_init_multiple_invalid_passes_through(extra: int | None) -> None:
+    """A MultipleInvalid raised by __post_init__ is not wrapped a second time."""
+
+    @dataclass
+    class Guarded:
+        value: int
+
+        def __post_init__(self) -> None:
+            if self.value == 13:
+                raise MultipleInvalid([Invalid("a"), Invalid("b")])
+
+    kwargs = {} if extra is None else {"extra": extra}
+    schema = DataclassSchema(Guarded, **kwargs)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"value": 13})
+
+    assert [error.msg for error in caught.value.errors] == ["a", "b"]
+
+
+def test_self_constraint_keeps_the_tower_and_still_validates() -> None:
+    """A Self-using constraint skips the fused engine and validates recursively.
+
+    ``Self`` resolution rides the inner ``Schema.__call__``'s active-root
+    bookkeeping, which the fused engine bypasses, so such a schema keeps the
+    ``All`` tower. This pins that the guard triggers and the behavior matches
+    the pre-fuse engine: recursion works and a deep error carries its full path.
+    """
+
+    @dataclass
+    class Tree:
+        name: str
+        child: object = None
+
+    schema = DataclassSchema(Tree, {"child": AnyOf(Self, None)}, compile=False)
+
+    built = schema({"name": "a", "child": {"name": "b", "child": None}})
+    assert built.name == "a"
+    assert built.child == {"name": "b", "child": None}
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"name": "a", "child": {"name": 1, "child": None}})
+    (error,) = caught.value.errors
+    assert error.path == ["child", "name"]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -387,5 +387,5 @@ def test_positional_only_parameter_by_keyword_is_a_bind_error() -> None:
     # The exact wording moved between CPython versions (3.12: "'items' parameter
     # is positional only, but was passed as a keyword"; 3.13: "missing a required
     # positional-only argument: 'items'"), so match the stable part.
-    with pytest.raises(TypeError, match="positional.only"):
+    with pytest.raises(TypeError, match=r"positional.only"):
         head(items=[1])

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -351,3 +351,40 @@ def test_async_return_validation() -> None:
     assert asyncio.run(f(4)) == 4
     with pytest.raises(MultipleInvalid):
         asyncio.run(f(-1))
+
+
+def test_malformed_calls_raise_the_exact_signature_bind_errors() -> None:
+    """A malformed call raises exactly what ``Signature.bind`` raises.
+
+    The fast per-call binder detects each malformed-call class (too many
+    positionals, an unknown or colliding keyword, a missing required argument)
+    and delegates to ``Signature.bind`` for the error, so the message is the
+    inspect one, never an invented variant.
+    """
+
+    @probatio
+    def clamp(value: int, low: int = 0, *, high: int = 100) -> int:
+        return min(max(value, low), high)
+
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        clamp(1, 2, 3)
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'nope'"):
+        clamp(1, nope=2)
+    with pytest.raises(TypeError, match="multiple values for argument 'value'"):
+        clamp(1, value=2)
+    with pytest.raises(TypeError, match="missing a required argument: 'value'"):
+        clamp()
+
+
+def test_positional_only_parameter_by_keyword_is_a_bind_error() -> None:
+    """Passing a positional-only parameter by name raises the bind TypeError."""
+
+    @probatio
+    def head(items: list, /, count: int = 1) -> list:
+        return items[:count]
+
+    assert head([1, 2, 3], count=2) == [1, 2]
+    with pytest.raises(
+        TypeError, match="missing a required positional-only argument: 'items'"
+    ):
+        head(items=[1])

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -384,7 +384,8 @@ def test_positional_only_parameter_by_keyword_is_a_bind_error() -> None:
         return items[:count]
 
     assert head([1, 2, 3], count=2) == [1, 2]
-    with pytest.raises(
-        TypeError, match="missing a required positional-only argument: 'items'"
-    ):
+    # The exact wording moved between CPython versions (3.12: "'items' parameter
+    # is positional only, but was passed as a keyword"; 3.13: "missing a required
+    # positional-only argument: 'items'"), so match the stable part.
+    with pytest.raises(TypeError, match="positional.only"):
         head(items=[1])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import pytest
 
-from probatio import ALLOW_EXTRA, Invalid, MultipleInvalid, Required, Schema
+from probatio import (
+    ALLOW_EXTRA,
+    Invalid,
+    MultipleInvalid,
+    Optional,
+    Required,
+    Schema,
+    Self,
+)
+from probatio import Any as AnyOf
 from probatio.error import ScalarInvalid, TypeInvalid, ValueInvalid
 
 
@@ -179,3 +188,60 @@ def test_repr_mirrors_voluptuous_with_extra_and_required() -> None:
         "<Schema({'a': <class 'int'>}, extra=ALLOW_EXTRA, required=False) object at 0x"
     )
     assert rendered.endswith(">")
+
+
+def test_composed_schema_matches_the_inline_form() -> None:
+    """A nested Schema value validates and errors exactly like the inline dict.
+
+    Composition compiles to a direct delegation to the inner engine (skipping the
+    callable guard and the inner ``__call__``), so this pins that the observable
+    behavior did not move: same output, same error type, message, and path.
+    """
+    inner = Schema({Required("value"): int})
+    composed = Schema({Required("data"): inner})
+    inline = Schema({Required("data"): {Required("value"): int}})
+
+    payload = {"data": {"value": 1}}
+    assert composed(payload) == inline(payload) == payload
+
+    for bad in ({"data": {"value": "no"}}, {"data": 42}, {"data": {}}):
+        with pytest.raises(MultipleInvalid) as caught_composed:
+            composed(bad)
+        with pytest.raises(MultipleInvalid) as caught_inline:
+            inline(bad)
+        (composed_error,) = caught_composed.value.errors
+        (inline_error,) = caught_inline.value.errors
+        assert type(composed_error) is type(inline_error)
+        assert composed_error.msg == inline_error.msg
+        assert composed_error.path == inline_error.path
+
+
+def test_combinator_branch_schema_keeps_its_branch_error() -> None:
+    """An Any(Schema(int), ...) miss surfaces the branch error, like voluptuous.
+
+    Inside a combinator a Schema branch keeps the wrapper (it is not unwrapped to
+    the raw engine): the branch's own error ("expected int") is what voluptuous
+    reports on a miss, not the combined "expected int or float" label.
+    """
+    schema = Schema(AnyOf(Schema(int), float))
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema("nope")
+
+    (error,) = caught.value.errors
+    assert isinstance(error, TypeInvalid)
+    assert error.msg == "expected int"
+
+
+def test_composed_self_referential_schema_still_recurses() -> None:
+    """A Self-using Schema nested as a value keeps resolving its own recursion."""
+    inner = Schema({Required("name"): str, Optional("child"): Self})
+    outer = Schema({Required("tree"): inner})
+
+    payload = {"tree": {"name": "a", "child": {"name": "b"}}}
+    assert outer(payload) == payload
+
+    with pytest.raises(MultipleInvalid) as caught:
+        outer({"tree": {"name": "a", "child": {"name": 1}}})
+    (error,) = caught.value.errors
+    assert error.path == ["tree", "child", "name"]


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Round two of the performance work from #125, plus fixes for two structural costs that no benchmark saw before. Every change was measured in isolation, and behavioral parity was proven with byte-identical before/after differentials on the error shapes, not just by the suite staying green.

The changes:

- `Invalid` gets class-level defaults for its rarely-passed fields; `__init__` stores only non-default values. Error construction runs on every combinator miss, so skipped stores add up: about -8% on `test_validate_any_miss`, -4% on `test_validate_config_reject`.
- The permanent `_bootstrap` lock is gone. A combinator branch that captured an armed schema's bootstrap paid a lock acquisition on every call, forever, under the default `AUTO` policy. The resolver now installs `_compiled` before dropping `_interpreted` (both still under the lock), which makes a lock-free resolved check sound; the same swap-ordering hazard existed in `Schema.compile()` and is fixed too. A new thread-race test hammers the captured-bootstrap path across the AUTO threshold. About -20% on the new combinator benchmark.
- A prebuilt `Schema` reused as a mapping value or sequence element (the composition pattern Home Assistant uses everywhere) now compiles to a direct delegation to the inner engine instead of a ValueError guard around the full `Schema.__call__`. Deliberately narrowed: inside combinators the wrapper stays, because unwrapping there would change `Any(Schema(int), float)` misses from the branch error to the combined label, diverging from voluptuous; a `Self`-using inner keeps the wrapper as well. Errors proven byte-identical across ten composed failure shapes.
- The interpreted dataclass path is fused: the public `Schema(All(inner, _Constructor))` shape is unchanged, but its interpreted engine is now one closure that runs the mapping engine and constructs, replicating the old tower's `ValueError` normalization and `MultipleInvalid` wrapping exactly, exception chains included (14-case differential, byte-identical). It installs correctly under `AUTO` arming, eager compile, and the recursive-reference capture; a `Self`-using schema keeps the tower. `test_validate_dataclass` drops from about 1.78 to 1.49 microseconds, -27% cumulative with #125.
- The `@probatio` decorator no longer pays `inspect.Signature.bind` per call. A binder built at decoration time handles regular calls with a zip into a dict plus three set checks; the four malformed-call classes on a non-variadic signature are exactly its bail conditions, and bailing delegates to `Signature.bind`, so every `TypeError` is the genuine inspect one (tests pin the exact messages). Variadic signatures keep the reference path entirely. Typed calls are 2.1x faster, passthrough 3.8x, verified behavior-identical on a 25-case differential including all error classes and async.
- Four new CodSpeed benchmarks so these paths stay tracked: composed schemas, a combinator over a mapping under `AUTO` (with a guard test asserting it really measures the captured-bootstrap delegation), and decorated calls in both the typed and passthrough form.
- The benchmark charts and the numbers quoted in the docs are regenerated; compiled validation now reaches about 7x voluptuous on the nested shape, and compiled probatio sits within about 1.7x of the Rust-cored pydantic v2 while validating every field in pure Python.

The `builtins-by-role.md` diff is a prettier re-wrap (table column alignment only); the local hook reapplies it on every run, so it rides along here.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: #125 (round one of the performance work); ADR-004 and ADR-011 constraints are respected throughout.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
