### PR TITLE
Render errors for humans: dotted paths, structured layer as the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ try:
     schema({"port": "nope"})
 except Invalid as err:
     print(err)
-    # expected int for dictionary value @ data['port']
+    # expected int at 'port'
 ```
 
 ## Why trust it

--- a/adr/015-structured-errors-and-localization.md
+++ b/adr/015-structured-errors-and-localization.md
@@ -1,0 +1,117 @@
+# ADR-015: Structured errors, human-first messages, and localization
+
+**Date**: 2026-07-03
+**Status**: Accepted
+
+**Context**: Probatio's error messages are voluptuous heritage, and it shows in
+three ways. First, the default rendering is written for parsers, not people:
+`expected int for dictionary value @ data['server']['port']` leaks an internal
+variable name (`data`) that the user has never seen, in a syntax only a Python
+developer parses comfortably. Real-world configurations (Home Assistant is the
+canonical consumer) nest four or five levels deep, and the `data[...][...]` chain
+gets worse with every level. Second, some default wordings are wrong for what the
+engine actually accepts: "expected a dictionary" fires for any non-Mapping input,
+including the dataclass and TypedDict schema paths, where "dictionary" is not what
+the user wrote. Third, every message is an f-string baked at the raise site. By the
+time a consumer catches the error, "length of value must be at least 10" is a
+finished string: the `10`, the field, and the reason are no longer addressable. A
+consumer that wants to present errors in its own words, its own language, or its
+own UI has nothing to work with but string parsing.
+
+Half the structured layer already exists. `Invalid` carries a per-class `code`, a
+`context` dict, reserved `translation_key` and `placeholders` slots, and
+`as_dict()` for serialization. But the built-ins never populate the translation
+slots, so the structured layer is a promise without a payload.
+
+The tension is the drop-in promise (ADR-001): message text is observable behavior,
+and downstream test suites assert on `str(err)`.
+
+**Options considered**:
+
+1. Keep voluptuous message text and rendering exactly, expose structure only
+   through new attributes. Safest for compatibility, but it freezes bad messages
+   forever and the library keeps shipping a rendering nobody would design today.
+2. Ship translations as the headline: a locale catalog for every message, bundled
+   language packs, a global language switch. Rejected as the *first* step: bundled
+   translations are a maintenance treadmill, and the consumers that care most
+   (Home Assistant) will never use our strings, they need the data underneath.
+3. Structured error data first, human-first English defaults, localization as a
+   mechanism rather than bundled content (this ADR).
+
+**Decision**: Option 3, in three parts.
+
+**Part 1: every error carries its data.** Every raise site populates a stable
+`translation_key` and `placeholders` alongside the message. `LengthInvalid` carries
+`translation_key="length_min"`, `placeholders={"min": 10}`, not just the rendered
+sentence. The key is a public, documented, stable identifier: renaming one is a
+breaking change. With the keys populated, `as_dict()` becomes a complete wire
+format, and a consumer can render errors in any words, any language, any UI,
+without touching our strings.
+
+**Part 2: human-first default rendering.** This is a deliberate, documented
+deviation from voluptuous (per ADR-001, behavioral divergence is a bug unless
+documented; this is the documentation):
+
+- The path suffix `@ data['a'][0]['b']` becomes a dotted path: `at 'a[0].b'`.
+  Mapping keys join with dots, sequence indices render as `[n]`, keys that are not
+  identifier-like fall back to their `repr`. Deeply nested errors stay readable:
+  `expected str at 'automation[0].triggers[2].entity_id'`.
+- The `for dictionary value` error-type clause disappears from the default
+  rendering. The `error_type` attribute stays for compatibility; it just no longer
+  clutters `str(e)`.
+- Wordings that misdescribe the accepted input are corrected: "expected a
+  dictionary" says what the engine means (a mapping, or the specific dataclass or
+  TypedDict being validated) instead of naming one Python type.
+
+The structured attributes (`path`, `code`, `translation_key`, `placeholders`,
+`as_dict()`) are the advertised API for programmatic consumers; `str(e)` is for
+humans and makes no stability promise beyond "readable".
+
+**Part 3: localization as a mechanism.** Default English messages become a catalog
+of templates keyed by `translation_key`, rendered lazily at `str()` time, never at
+raise time (the error path is a measured hot path; see the compile-versus-validate
+split). A locale hook swaps the catalog: a contextvar with a module-level default,
+so a web application can render per-request locales without cross-request bleed.
+Probatio ships the mechanism and the English catalog. Bundled translations are
+explicitly out of scope for now; community locale packages can provide them.
+
+**Rationale**:
+
+- **The data layer serves everyone; our strings serve only some.** A better English
+  sentence helps a CLI user. `translation_key` plus `placeholders` helps the CLI
+  user, the Home Assistant frontend, a JSON API, and a future locale catalog, all
+  from one change.
+- **Error messages are product, not protocol.** Freezing them for compatibility
+  (option 1) treats prose as API. The actual API is the structured layer; that is
+  where the stability promise belongs.
+- **Lazy rendering keeps the hot path honest.** Formatting at `str()` time means a
+  caught-and-discarded error (the `Any`/`Or` happy path) never pays for template
+  rendering.
+- **Not bundling translations keeps the promise keepable.** Shipping two languages
+  is easy; keeping twenty correct is a treadmill. A mechanism plus an English
+  catalog is a commitment probatio can honor.
+
+**Consequences**:
+
+- **A documented compatibility break in `str(e)`.** Downstream suites that assert
+  on exact voluptuous message text will fail on the new rendering. The migration
+  story: assert on `code`/`translation_key`/`path` instead of prose. The
+  compatibility tests pin the new rendering; divergences from voluptuous message
+  text are recorded there as intentional. This applies under the compat shim
+  too: `install_as_voluptuous` does not restore the old rendering (one rendering
+  everywhere, no mode flag). Measured against the proof harnesses: voluptuous's
+  own suite gains 24 rendering xfails (114 passed, 51 xfailed), and Home
+  Assistant's `config_validation` suite drops from 142/142 to 136/142, the 6
+  failures all being exact-string assertions on the old rendering.
+- **Translation keys become public API.** Every key is documented, and renaming or
+  removing one is treated like renaming a public function.
+- **`humanize_error` follows the same rendering.** The humanize module keeps its
+  extras (offending value, YAML file locations) on top of the new path style.
+- **Roughly fifty raise sites change.** Mechanical, but every site needs a key and
+  placeholders chosen with care; that is where the review effort goes.
+
+**Revisit trigger**: Bundle translations if real demand shows up and a sustainable
+source of native-speaker review exists (community locale packages proving
+insufficient would be the signal). Revisit the dotted path rendering if consumers
+are found parsing `str(e)` for the path despite the structured layer; that would
+mean the structured API is not discoverable enough.

--- a/adr/README.md
+++ b/adr/README.md
@@ -17,3 +17,4 @@ Each record captures what was chosen, the alternatives considered, and why.
 | [ADR-012](012-trusted-construction-without-validation.md)   | Trusted construction without validation                        |
 | [ADR-013](013-markers-on-annotated-fields.md)               | A field-metadata spec for Annotated dataclass/TypedDict fields |
 | [ADR-014](014-annotation-driven-argument-decorator.md)      | An annotation-driven argument-validation decorator             |
+| [ADR-015](015-structured-errors-and-localization.md)        | Structured errors, human-first messages, and localization      |

--- a/compat/home_assistant/README.md
+++ b/compat/home_assistant/README.md
@@ -33,7 +33,12 @@ PYTHONPATH=/path/to/probatio/compat/home_assistant \
 
 ## Result
 
-All 142 tests in `tests/helpers/test_config_validation.py` pass against Probatio.
+136 of the 142 tests in `tests/helpers/test_config_validation.py` pass against
+Probatio. The 6 that fail all assert the exact voluptuous-rendered error string
+(`"... for dictionary value @ data[...]"`), which Probatio deliberately renders
+differently since ADR-015 (a dotted path, no error-type clause). The `path`
+segments, error classes, and bare messages still match; only the rendering
+around them differs.
 
 Getting there surfaced (and fixed) several real compatibility gaps that pure unit
 tests had not:
@@ -42,8 +47,8 @@ tests had not:
   validates is dropped, otherwise the key falls through to the extra-key policy.
 - `Email`, `Url`, and `FqdnUrl` are factories (`Url()` returns the validator),
   matching voluptuous, not direct validators.
-- A failed mapping _value_ error is tagged `error_type = "dictionary value"`, so
-  `str(error)` reads `"... for dictionary value @ data[...]"`.
+- A failed mapping _value_ error is tagged `error_type = "dictionary value"`
+  (the attribute is kept even though `str(error)` no longer renders it).
 - `All` and `Any` raise `MultipleInvalid` on failure (a bare `AllInvalid` /
   `AnyInvalid` only when a custom `msg` is given), and `Any` surfaces the branch
   error that reached the deepest path rather than a generic message.

--- a/compat/voluptuous/README.md
+++ b/compat/voluptuous/README.md
@@ -38,7 +38,7 @@ to a foreign test file.)
 
 ## Result
 
-140 passed, 27 xfailed, 0 unexpected failures.
+114 passed, 51 xfailed, 0 unexpected failures.
 
 Getting there fixed several real bugs that Probatio's own tests had not surfaced,
 each pinned with a Probatio test:
@@ -55,8 +55,13 @@ each pinned with a Probatio test:
 - Markers were not orderable; `sorted([Required("b"), Required("a")])` and
   `Optional("a") < "b"` now work (compare by the underlying key).
 
-The 27 xfails are all documented divergences, grouped in `conftest.py`:
+The 51 xfails are all documented divergences, grouped in `conftest.py`:
 
+- **The error rendering deviation (ADR-015)**: `str(error)` renders the path as
+  a dotted trail (`at 'a.b'`) instead of `@ data['a']['b']`, drops the
+  `for dictionary value` clause, and rejects a non-mapping as "expected a
+  mapping". Every test that string-matches the rendered error diverges; the
+  `path` segments and the bare message still match voluptuous.
 - **Deliberate improvements** (see the compatibility matrix): the "did you mean
   ...?" unknown-key error, lower-cased `Number` messages, the richer error wording
   for `Contains`, `In`, `NotIn`, `Maybe`, `Coerce`, and `FqdnUrl`, set and

--- a/compat/voluptuous/conftest.py
+++ b/compat/voluptuous/conftest.py
@@ -6,8 +6,13 @@ public-API proof there is: voluptuous's own test authors' notion of the contract
 at the exact version Probatio targets.
 
 Most of the suite passes unchanged. The cases that do not are *known
-divergences*, marked ``xfail`` below with a reason, in two groups:
+divergences*, marked ``xfail`` below with a reason, in three groups:
 
+- The error rendering deviation (ADR-015): ``str(error)`` renders the path as a
+  dotted trail (``at 'a.b'``) instead of ``@ data['a']['b']`` and drops the
+  ``for dictionary value`` clause, and a non-mapping is rejected as "expected a
+  mapping". Every test that string-matches the rendered error diverges; the
+  ``path`` segments and the bare message still match.
 - Deliberate improvements Probatio chose (documented in the compatibility matrix):
   the "did you mean ...?" unknown-key error, lower-cased messages, richer ``Any``
   branch errors, set/empty-container wording, a non-dict ``Mapping`` returning a
@@ -68,12 +73,48 @@ _DELIBERATE_DEVIATIONS = {
     "validator and reprs as Maybe(...), where voluptuous implements Maybe as Any",
 }
 
+# One reason covers them all: these tests assert the exact rendered error
+# string, and ADR-015 deliberately renders it differently (dotted path, no
+# error-type clause, "expected a mapping"). Path segments and bare messages
+# still match voluptuous.
+_RENDERING_REASON = "asserts the voluptuous-rendered error string (ADR-015)"
+
+_RENDERING_DEVIATIONS = dict.fromkeys(
+    [
+        "test_required",
+        "test_in",
+        "test_not_in",
+        "test_literal",
+        "test_email_validation_with_none",
+        "test_email_validation_with_empty_string",
+        "test_email_validation_without_host",
+        "test_email_validation_with_bad_data",
+        "test_url_validation_with_bad_data",
+        "test_list_validation_messages",
+        "test_nested_multiple_validation_errors",
+        "test_humanize_error",
+        "test_any_required",
+        "test_any_required_with_subschema",
+        "test_inclusive",
+        "test_inclusive_defaults",
+        "test_exclusive",
+        "test_any_with_discriminant",
+        "test_key2",
+        "test_validate_with_humanized_errors_failure",
+        "test_humanize_error_with_multiple_invalid",
+        "test_humanize_error_with_single_invalid",
+        "test_humanize_error_with_none_data",
+    ],
+    _RENDERING_REASON,
+)
+
 _OUT_OF_SCOPE = {
     "test_iterate_candidates": "tests the voluptuous internal "
     "_iterate_mapping_candidates, not the public contract",
 }
 
 _KNOWN_DIVERGENCES = {
+    **_RENDERING_DEVIATIONS,
     **_DELIBERATE_DEVIATIONS,
     **_OUT_OF_SCOPE,
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -103,6 +103,10 @@ export default defineConfig({
             { label: "Built-in validators", slug: "guides/validators" },
             { label: "Error handling", slug: "guides/error-handling" },
             {
+              label: "Custom error messages",
+              slug: "guides/custom-error-messages",
+            },
+            {
               label: "Loading and dumping",
               slug: "guides/loading-and-dumping",
             },

--- a/docs/src/content/docs/getting-started/compatibility.md
+++ b/docs/src/content/docs/getting-started/compatibility.md
@@ -50,6 +50,13 @@ your application entry point, not from a library, and call it before the first
 Compatibility is the target. A few behaviors still differ on purpose, and each
 is a deliberate improvement over a sharp edge:
 
+- `str(error)` renders a dotted path and drops the error-type clause (ADR-015).
+  voluptuous's `expected int for dictionary value @ data['server']['port']`
+  reads `expected int at 'server.port'` in Probatio, with sequence indices as
+  `[n]`. A non-mapping is rejected as "expected a mapping" rather than
+  "expected a dictionary". The attributes (`path`, `msg`, `error_message`,
+  `error_type`) are unchanged, so only code that string-matches `str(error)`
+  notices.
 - Recursive `Self` on cyclic or very deep data raises a clean `Invalid` instead
   of letting Python crash with a `RecursionError`. You get a validation error
   with a path, not a stack overflow.
@@ -59,7 +66,7 @@ is a deliberate improvement over a sharp edge:
 - A missing complex required key (`Required(Any("a", "b"))`, "at least one of
   these keys") raises one clear error. voluptuous 0.16.0 additionally emits a
   redundant `required key not provided` for the same key; Probatio reports it
-  once. The first, meaningful error is identical.
+  once. The first, meaningful error matches voluptuous.
 - Any `Mapping` is accepted, not only `dict`. A `MappingProxyType`, a multidict,
   or any custom mapping validates and returns a plain `dict`, where voluptuous
   rejects it. A genuine `dict` subclass is preserved as its own class, matching

--- a/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
+++ b/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
@@ -65,6 +65,15 @@ Imports that reach into voluptuous submodules keep working too: `voluptuous`,
 Probatio targets behavioral compatibility, so the list is short and every entry
 is a deliberate improvement, not a regression:
 
+- **The rendered error string differs (ADR-015).** voluptuous renders
+  `expected int for dictionary value @ data['server']['port']`; Probatio renders
+  the same error as `expected int at 'server.port'`. The path is a dotted trail
+  (sequence indices as `[n]`), the error-type clause is not rendered, and a
+  non-mapping is rejected as "expected a mapping" instead of "expected a
+  dictionary". The attributes (`path`, `msg`, `error_message`, `error_type`)
+  keep their voluptuous semantics, so only code that string-matches
+  `str(error)` notices; switch that code to `path` and `error_message`, or to
+  `as_dict()`.
 - **Recursive `Self` schemas fail cleanly.** Cyclic or pathologically deep data
   raises a normal `Invalid` (caught with the rest of your validation errors)
   instead of crashing with `RecursionError`, as voluptuous does. The depth limit
@@ -78,7 +87,7 @@ is a deliberate improvement, not a regression:
   `Required(Any("a", "b"))` ("at least one of these keys"), voluptuous 0.16.0
   emits both the "at least one of [...] is required" error and a redundant
   "required key not provided" for the same key. Probatio reports the single,
-  meaningful error; the first error matches voluptuous exactly.
+  meaningful error; the first error matches voluptuous.
 - **Any `Mapping` is accepted, not only `dict`.** A `MappingProxyType`, a
   multidict, or any custom type implementing the `Mapping` protocol validates
   and returns a plain `dict`, where voluptuous rejects it with "expected a

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -56,7 +56,7 @@ schema = Schema({"port": int})
 try:
     schema({"port": "nope"})
 except Invalid as err:
-    print(err)  # expected int for dictionary value @ data['port']
+    print(err)  # expected int at 'port'
 ```
 
 Catching `Invalid` catches every validation error, because everything Probatio

--- a/docs/src/content/docs/guides/custom-error-messages.md
+++ b/docs/src/content/docs/guides/custom-error-messages.md
@@ -1,0 +1,182 @@
+---
+title: Custom error messages
+description: Override a validator's message with msg, raise your own Invalid carrying structured data, and render validation errors in your own words.
+---
+
+Probatio's default messages are written for humans, but they are still
+Probatio's words. Sometimes you want your own: a schema author wants one rule
+to explain itself better, an application wants to render failures in its own
+tone, its own UI, or its own language. This guide covers both ends: changing
+the message where the schema is defined, and ignoring the message entirely to
+build your own output from the structured data every error carries.
+
+## Override the message with msg
+
+Most validators and markers accept a `msg` argument that replaces the default
+message wholesale. This is the one-line tool for the spot where the default
+wording does not fit your users:
+
+```python
+from probatio import Schema, Required, Range, MultipleInvalid
+
+schema = Schema(
+    {
+        Required("port", msg="a port is required"): Range(
+            min=1, max=65535, msg="not a valid port number"
+        ),
+    }
+)
+
+try:
+    schema({})
+except MultipleInvalid as err:
+    print(err.errors[0].error_message)  # a port is required
+
+try:
+    schema({"port": 0})
+except MultipleInvalid as err:
+    print(err.errors[0])  # not a valid port number at 'port'
+```
+
+The replacement is complete: `msg` becomes the error's message, and the path is
+still appended by `str(error)`. Everything else about the error is unchanged;
+it keeps its class (`RangeInvalid` here) and its machine-readable `code`, so
+code that branches on those keeps working no matter what the message says.
+
+`msg` changes one validator's words. If you find yourself passing `msg` to
+every validator in a schema to restyle all output, you are working at the
+wrong end: skip to
+[rendering errors your way](#render-errors-your-way) instead.
+
+## Raise your own Invalid
+
+A [custom validator](/guides/custom-validators/) rejects a value by raising
+`Invalid` (or a subclass), and the message is yours from the start. Beyond the
+message, `Invalid` accepts the structured fields, so your error carries data
+for a consumer instead of only prose:
+
+- `code`: a stable machine-readable identifier for this kind of failure.
+- `context`: a dict of structured detail, such as the limit that was exceeded.
+- `translation_key` and `placeholders`: a lookup key plus the values to
+  interpolate, for a consumer that renders localized messages.
+
+```python
+from probatio import Schema, Invalid, MultipleInvalid
+
+def quiet_hour(value):
+    if not isinstance(value, int) or not 0 <= value <= 23:
+        raise Invalid(
+            "expected an hour between 0 and 23",
+            code="quiet_hour",
+            context={"min": 0, "max": 23},
+            translation_key="quiet_hour_out_of_range",
+            placeholders={"min": 0, "max": 23},
+        )
+    return value
+
+schema = Schema({"start": quiet_hour})
+
+try:
+    schema({"start": 25})
+except MultipleInvalid as err:
+    error = err.errors[0]
+    print(error)                  # expected an hour between 0 and 23 at 'start'
+    print(error.code)             # quiet_hour
+    print(error.translation_key)  # quiet_hour_out_of_range
+    print(error.placeholders)     # {'min': 0, 'max': 23}
+```
+
+The message is the fallback for anyone who just prints the error; the
+structured fields are the contract for anyone building their own output. Fill
+both and your validator works in either world.
+
+## Render errors your way
+
+The rendered string is for humans and makes no stability promise; the
+structured attributes are the API. A consumer that wants its own output (a CLI
+with its own formatting, a web API returning JSON, a UI translating messages)
+reads those attributes and never touches Probatio's strings.
+
+The pattern: catch `MultipleInvalid`, walk `errors`, and build output from
+`path`, `code`, `context`, and `error_message`. `render_path` renders a path
+the same way `str(error)` does, so your output stays consistent with the
+library's:
+
+```python
+from probatio import Schema, MultipleInvalid
+from probatio.error import render_path
+
+schema = Schema({"server": {"port": int, "host": str}})
+data = {"server": {"port": "nope", "host": 42}}
+
+try:
+    schema(data)
+except MultipleInvalid as err:
+    for error in sorted(err.errors, key=lambda e: str(e.path)):
+        where = render_path(error.path) or "the top level"
+        print(f"Problem with option '{where}': {error.error_message}.")
+    # Problem with option 'server.host': expected str.
+    # Problem with option 'server.port': expected int.
+```
+
+For an API, `as_dict()` serializes the structured layer of every error in one
+call, ready for a JSON response body:
+
+```python
+import json
+from probatio import Schema, MultipleInvalid
+
+schema = Schema({"port": int})
+
+try:
+    schema({"port": "nope"})
+except MultipleInvalid as err:
+    body = json.dumps(err.as_dict())
+    print(body)
+    # {"errors": [{"code": "type", "message": "expected int", "path": ["port"],
+    #   "secret": false, "context": {"expected": "int"}, "translation_key": null,
+    #   "placeholders": {}}]}
+```
+
+For translations, branch on `code`. Every built-in error carries one (the
+[errors reference](/reference/errors/) lists them per class), so a lookup
+table maps failures to your own language, with `context` filling the holes and
+the original message as the fallback for codes you have not translated:
+
+```python
+from probatio import Schema, MultipleInvalid
+
+DUTCH = {
+    "type": "verwacht een waarde van type {expected}",
+    "required": "deze optie is verplicht",
+}
+
+def render_dutch(error):
+    template = DUTCH.get(error.code)
+    if template is None:
+        return error.error_message
+    return template.format(**error.context)
+
+schema = Schema({"port": int, "host": str})
+
+try:
+    schema({"port": "nope"})
+except MultipleInvalid as err:
+    print(render_dutch(err.errors[0]))  # verwacht een waarde van type int
+```
+
+Two honest notes on the current state. The built-ins fill `context` where
+there is an obvious payload (a type error carries `expected`), but not yet
+everywhere; a template that needs a value the context does not carry has to
+fall back to the original message. And `translation_key` / `placeholders` are
+populated only by errors you raise yourself; the built-ins leave them empty
+for now, so `code` is the key to branch on today.
+
+## Where to next
+
+- [Custom validators](/guides/custom-validators/): the validator side of
+  raising your own errors.
+- [Error handling](/guides/error-handling/): paths, `MultipleInvalid`, and
+  catching specific kinds.
+- [Errors reference](/reference/errors/): every error class, its `code`, and
+  the fields on `Invalid`.

--- a/docs/src/content/docs/guides/custom-validators.md
+++ b/docs/src/content/docs/guides/custom-validators.md
@@ -60,7 +60,7 @@ schema = Schema({Required("count"): even})
 try:
     schema({"count": 3})
 except MultipleInvalid as err:
-    print(err)  # must be even for dictionary value @ data['count']
+    print(err)  # must be even at 'count'
 ```
 
 ## A plain ValueError works too
@@ -208,7 +208,7 @@ schema = Schema({Required("name"): All(Strip, Lower, not_empty)})
 try:
     schema({"name": "   "})
 except MultipleInvalid as err:
-    print(err)  # must not be empty for dictionary value @ data['name']
+    print(err)  # must not be empty at 'name'
 ```
 
 ## Parameterizing a validator
@@ -358,7 +358,7 @@ area(3, 4)  # 12
 try:
     area("wide", 4)
 except MultipleInvalid as err:
-    print(err)  # expected int for dictionary value @ data['width']
+    print(err)  # expected int at 'width'
 ```
 
 The `raises` context manager is the companion test helper: it asserts a block
@@ -375,6 +375,9 @@ with raises(MultipleInvalid, "expected int"):
 
 ## Where to next
 
+- [Custom error messages](/guides/custom-error-messages/): carrying structured
+  data (`code`, `context`, localization slots) on the errors you raise, and
+  rendering errors your way as a consumer.
 - [The validation model](/guides/validation-model/): why a returned value can
   differ from the input.
 - [Combinators](/guides/combinators/): `All`, `Any`, and friends.

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -53,7 +53,7 @@ class User:
     age: int = 18
 
 
-DataclassSchema(User)({})  # required key not provided @ data['name']
+DataclassSchema(User)({})  # required key not provided at 'name'
 ```
 
 ## Annotations drive the validators

--- a/docs/src/content/docs/guides/dict-schemas-and-markers.md
+++ b/docs/src/content/docs/guides/dict-schemas-and-markers.md
@@ -36,7 +36,7 @@ schema = Schema({Required("name"): str})
 try:
     schema({})
 except Invalid as err:
-    print(err)  # required key not provided @ data['name']
+    print(err)  # required key not provided at 'name'
 ```
 
 A marker compares and hashes by its key, so `Required("name")` and `"name"` are
@@ -99,7 +99,7 @@ schema = Schema({"name": str})
 try:
     schema({"name": "app", "debug": True})
 except Invalid as err:
-    print(err)  # not a valid option @ data['debug']
+    print(err)  # not a valid option at 'debug'
 ```
 
 When a rejected key looks like a misspelling of one the schema knows, the error
@@ -116,7 +116,7 @@ try:
     schema({"nmae": "app"})
 except Invalid as err:
     error = err.errors[0]
-    print(error)            # not a valid option, did you mean 'name'? @ data['nmae']
+    print(error)            # not a valid option, did you mean 'name'? at 'nmae'
     print(error.candidates)  # ['name']
 ```
 
@@ -178,7 +178,7 @@ from probatio import Schema, Forbidden
 
 schema = Schema({Forbidden("password"): object})
 
-schema({"password": "secret"})  # key not allowed @ data['password']
+schema({"password": "secret"})  # key not allowed at 'password'
 ```
 
 It composes with `extend`, so a base schema can be tightened to forbid a key it
@@ -240,7 +240,7 @@ try:
     schema(data)
 except MultipleInvalid as err:
     print(humanize_error(data, err))
-    # expected int for dictionary value @ data['password']. Got <redacted>
+    # expected int at 'password'. Got <redacted>
 ```
 
 Secrecy is an independent facet, so it composes with the presence markers by
@@ -279,7 +279,7 @@ schema = Schema({str: int})
 try:
     schema({1: 2})
 except Invalid as err:
-    print(err)  # expected str @ data[1]
+    print(err)  # expected str at '[1]'
 ```
 
 ## Co-dependent and exclusive keys
@@ -317,7 +317,7 @@ schema = Schema(
 try:
     schema({"lat": 52.1})
 except Invalid as err:
-    print(err)  # some but not all values in the same group of inclusion 'coords' @ data[<coords>]
+    print(err)  # some but not all values in the same group of inclusion 'coords' at '<coords>'
 ```
 
 An exclusive group is optional by default (none of its keys is fine). Two flags
@@ -336,7 +336,7 @@ schema = Schema(
     }
 )
 
-schema({})  # exactly one of ['token', 'password'] is required @ data[<auth>]
+schema({})  # exactly one of ['token', 'password'] is required at '<auth>'
 ```
 
 A `default` fills its member in when the group is empty (and wins over

--- a/docs/src/content/docs/guides/error-handling.md
+++ b/docs/src/content/docs/guides/error-handling.md
@@ -29,7 +29,8 @@ is a programming mistake, not bad input. The two never overlap.
 
 ## The path to the value
 
-An error knows where in the data it happened. `str(error)` appends that path, and
+An error knows where in the data it happened. `str(error)` appends that path as
+a dotted trail (mapping keys joined with dots, sequence indices as `[n]`), and
 `error.path` is the list of keys and indices to walk:
 
 ```python
@@ -40,7 +41,7 @@ schema = Schema({"server": {"ports": [int]}})
 try:
     schema({"server": {"ports": [80, "nope"]}})
 except Invalid as err:
-    print(err)        # expected int @ data['server']['ports'][1]
+    print(err)        # expected int at 'server.ports[1]'
     print(err.path)   # ['server', 'ports', 1]
 ```
 
@@ -84,7 +85,7 @@ schema = Schema({"port": int})
 try:
     schema(data)
 except Invalid as err:
-    print(humanize_error(data, err))  # expected int for dictionary value @ data['port']. Got 'nope'
+    print(humanize_error(data, err))  # expected int at 'port'. Got 'nope'
 ```
 
 `validate_with_humanized_errors(data, schema)` (also in `probatio.humanize`) does
@@ -141,3 +142,7 @@ except Invalid as err:
 The legacy fields (`msg`, `path`, `error_message`) are untouched by this layer,
 so nothing about the voluptuous-compatible behavior changes; the structured data
 is purely additive.
+
+To override a validator's message, or to build your own output (or
+translations) from this layer, see
+[Custom error messages](/guides/custom-error-messages/).

--- a/docs/src/content/docs/guides/loading-and-dumping.md
+++ b/docs/src/content/docs/guides/loading-and-dumping.md
@@ -239,7 +239,7 @@ try:
     schema(data)
 except MultipleInvalid as err:
     print(humanize_error(data, err, locator=locator))
-# value must be at most 65535 for dictionary value @ data['server']['port']. Got 70000 (at 2:9)
+# value must be at most 65535 at 'server.port'. Got 70000 (at 2:9)
 ```
 
 The locator returns a `Location` (with `line`, `column`, and `file`) that programs

--- a/docs/src/content/docs/guides/probatio-decorator.md
+++ b/docs/src/content/docs/guides/probatio-decorator.md
@@ -42,7 +42,7 @@ def area(width: int, height: int) -> int:
     return width * height
 
 
-area("wide", 4)  # expected int for dictionary value @ data['width']
+area("wide", 4)  # expected int at 'width'
 ```
 
 An unannotated parameter is left alone, so `self` and `cls` need no special

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -54,7 +54,7 @@ its path through the data, using probatio's errors:
 
 ```text
 data does not match the probatio schema (==):
-  data['port']: expected a port number between 1 and 65535
+  port: expected a port number between 1 and 65535
 ```
 
 So a failing `assert response == Exact(...)` points at the exact offending value
@@ -119,7 +119,7 @@ wrong, the failure names the exact field, even inside the composed list:
 
 ```text
 data does not match the probatio schema (==):
-  data['users'][0]['email']: expected an email address
+  users[0].email: expected an email address
 ```
 
 ## Why a separate package

--- a/docs/src/content/docs/guides/typeddict.md
+++ b/docs/src/content/docs/guides/typeddict.md
@@ -51,7 +51,7 @@ class Config(TypedDict):
     host: str
 
 
-TypedDictSchema(Config)({"port": 8080})  # required key not provided @ data['host']
+TypedDictSchema(Config)({"port": 8080})  # required key not provided at 'host'
 ```
 
 The keys are closed: an unknown key is rejected, the same as the default dict

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -92,7 +92,7 @@ try:
     schema({"port": "nope"})
 except Invalid as err:
     print(err)
-    # expected int for dictionary value @ data['port']
+    # expected int at 'port'
 ```
 
 ## Why trust it

--- a/docs/src/content/docs/project/security.md
+++ b/docs/src/content/docs/project/security.md
@@ -179,7 +179,7 @@ try:
     schema(data)
 except MultipleInvalid as err:
     print(humanize_error(data, err))
-    # expected str for dictionary value @ data['api_token']. Got <redacted>
+    # expected str at 'api_token'. Got <redacted>
 ```
 
 The redaction is targeted: only the secret key's value is hidden, a sibling

--- a/docs/src/content/docs/recipes/config-file.md
+++ b/docs/src/content/docs/recipes/config-file.md
@@ -106,10 +106,10 @@ try:
     schema.load(Path("bad.json"))
 except Invalid as err:
     print(humanize_error(bad, err))
-    # value must be at most 65535 for dictionary value @ data['server']['port']. Got '70000'
+    # value must be at most 65535 at 'server.port'. Got '70000'
 ```
 
-The message points straight at `data['server']['port']` and shows the offending
+The message points straight at `server.port` and shows the offending
 value. The [error handling guide](/guides/error-handling/) goes deeper into
 paths, collecting every error at once, and the structured layer underneath.
 

--- a/docs/src/content/docs/recipes/cookbook.md
+++ b/docs/src/content/docs/recipes/cookbook.md
@@ -192,7 +192,7 @@ try:
     schema({"token": "abc", "password": "hunter2"})
 except Invalid as err:
     print(err)
-    # two or more values in the same group of exclusion 'auth' @ data[<auth>]
+    # two or more values in the same group of exclusion 'auth' at '<auth>'
 ```
 
 Half of an inclusive group is also an error:
@@ -211,7 +211,7 @@ try:
     schema({"host": "localhost"})
 except Invalid as err:
     print(err)
-    # some but not all values in the same group of inclusion 'server' @ data[<server>]
+    # some but not all values in the same group of inclusion 'server' at '<server>'
 ```
 
 ## At least one of a group of keys
@@ -244,7 +244,7 @@ schema = Schema({Required(Any("email", "phone")): str})
 try:
     schema({})
 except Invalid as err:
-    print(err)  # at least one of ['email', 'phone'] is required @ data[Any('email', 'phone', msg=None)]
+    print(err)  # at least one of ['email', 'phone'] is required at '[Any('email', 'phone', msg=None)]'
 ```
 
 ## Dropping deprecated keys
@@ -360,7 +360,7 @@ try:
     schema(bad)
 except Invalid as err:
     print(humanize_error(bad, err))
-    # value must be at most 65535 for dictionary value @ data['port']. Got '70000'
+    # value must be at most 65535 at 'port'. Got '70000'
 ```
 
 `validate_with_humanized_errors` does the same in one call: it validates and, on

--- a/docs/src/content/docs/recipes/home-assistant.md
+++ b/docs/src/content/docs/recipes/home-assistant.md
@@ -60,13 +60,18 @@ registers and when to call it.
 
 This is not a paraphrase of compatibility. Probatio is validated against Home
 Assistant's own `config_validation` test suite, with voluptuous swapped out for
-Probatio through `install_as_voluptuous`. The whole suite passes.
+Probatio through `install_as_voluptuous`. 136 of the 142 tests pass; the 6 that
+fail all assert the exact voluptuous-rendered error string, which Probatio
+deliberately renders differently (a dotted path instead of `@ data[...]`, see
+the [compatibility matrix](/reference/compatibility-matrix/)). The error
+attributes those tests could assert on instead (`path`, `error_message`, the
+error class) all match.
 
 Getting there surfaced real compatibility gaps that isolated unit tests had
-missed, like `Remove(key)` keeping a value that fails its schema, and the exact
-`"for dictionary value @ data[...]"` wording on a failed mapping value. Those are
-fixed. The proof harness lives in `compat/home_assistant/` in the repository, so
-you can reproduce it against a Home Assistant checkout.
+missed, like `Remove(key)` keeping a value that fails its schema, and the
+`error_type` tag on a failed mapping value. Those are fixed. The proof harness
+lives in `compat/home_assistant/` in the repository, so you can reproduce it
+against a Home Assistant checkout.
 
 ## Where to next
 

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -265,6 +265,16 @@ improvement over a sharp edge, not a regression.
 Each entry reads the same way: the behavior, then what voluptuous does, then what
 Probatio does.
 
+- **The rendered error string, `str(error)` (ADR-015).** voluptuous renders
+  `expected int for dictionary value @ data['server']['port']`. Probatio renders
+  the same error as `expected int at 'server.port'`: the path is a dotted trail
+  (sequence indices as `[n]`, so `at 'hosts[2].name'`), and the error-type clause
+  is not rendered. A non-mapping is rejected as "expected a mapping" instead of
+  "expected a dictionary" (the engine accepts any `Mapping`, and the message now
+  says so). The attributes are unchanged: `path`, `msg`, `error_message`, and
+  `error_type` keep their voluptuous semantics, so code that reads them (rather
+  than parsing the rendered string) is unaffected. Code that string-matches
+  `str(error)` should switch to `path` and `error_message`, or to `as_dict()`.
 - **Recursive `Self` on cyclic or very deep data.** voluptuous crashes with
   `RecursionError`. Probatio raises a clean `Invalid` with a path, caught with the
   rest of your errors. The depth limit tracks a fraction of the interpreter's
@@ -361,7 +371,7 @@ Probatio does.
   `Union` (alias `Switch`), not on `All`/`Any`; passing it to `All`/`Any` has no
   effect. Use `Union` for a discriminated union.
 - **An `ExactSequence` element error carries the element's index in the path**
-  (`@ data[1]`), where voluptuous reports the bare parent path. Probatio's path is
+  (`at '[1]'`), where voluptuous reports the bare parent path. Probatio's path is
   more precise; existing path-walking code sees a deeper path.
 - **The order of multiple missing-required-key errors** is the schema's definition
   order in Probatio, and hash (set) order in voluptuous. The first error still

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -28,7 +28,9 @@ So when you catch one, the individual failures live in `err.errors`, and
 
 Every `Invalid` carries two layers. The voluptuous-compatible layer (`msg`,
 `path`, `error_message`, `error_type`) keeps its original wording and behavior, so
-code that string-matches it still works. The structured layer (`code`, `context`,
+code that reads those fields still works. Only the rendered `str(error)` differs
+from voluptuous: it appends the path as a dotted trail and drops the error-type
+clause. The structured layer (`code`, `context`,
 `translation_key`, `placeholders`, `as_dict()`) is additive: it changes none of
 the legacy output.
 
@@ -36,7 +38,7 @@ the legacy output.
 - `path`: the list of keys and indices to walk to the offending value.
 - `error_message`: the bare message, without the path appended.
 - `error_type`: the kind of value that failed, such as `dictionary value` (may be
-  `None`).
+  `None`). Kept for compatibility; it is no longer rendered in `str(error)`.
 - `code`: the stable machine-readable code (the class default unless overridden).
 - `secret`: whether the offending value must be redacted, not echoed, when
   rendered. Set for an error under a
@@ -81,6 +83,16 @@ except MultipleInvalid as err:
     print(err.as_dict()["errors"][0]["code"])  # type
 ```
 
+To render a path the way `str(error)` does, use `render_path` from
+`probatio.error`. A consumer building its own error output stays consistent
+with the library's rendering:
+
+```python
+from probatio.error import render_path
+
+print(render_path(["server", "ports", 1]))  # server.ports[1]
+```
+
 ## Semantic subclasses
 
 The subclasses let callers branch on what went wrong. They mirror voluptuous, so
@@ -90,7 +102,7 @@ Each entry shows the class, its meaning, and its `default_code` in parentheses.
 
 - `RequiredFieldInvalid` (`required`): a required key was missing from the data.
 - `ObjectInvalid` (`object`): the value is not the expected object.
-- `DictInvalid` (`not_a_dictionary`): the value is not a dictionary.
+- `DictInvalid` (`not_a_dictionary`): the value is not a mapping.
 - `ExtraKeysInvalid` (`extra_keys_not_allowed`): a key matched no schema key under
   `PREVENT_EXTRA`; carries `candidates`, the close matches.
 - `SequenceTypeInvalid` (`not_a_sequence`): the value is not the expected sequence

--- a/packages/pytest-probatio/README.md
+++ b/packages/pytest-probatio/README.md
@@ -22,7 +22,7 @@ When the data does not match, the failure lists each error by its path:
 
 ```
 data does not match the probatio schema (==):
-  data['port']: expected a port number between 1 and 65535
+  port: expected a port number between 1 and 65535
 ```
 
 Install it alongside pytest; the plugin registers itself:

--- a/packages/pytest-probatio/src/pytest_probatio/plugin.py
+++ b/packages/pytest-probatio/src/pytest_probatio/plugin.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import typing
 
 from probatio import ALLOW_EXTRA, PREVENT_EXTRA, Invalid, MultipleInvalid, Schema
+from probatio.error import render_path
 
 
 def _compile(schema: typing.Any, extra: int) -> Schema:
@@ -116,10 +117,10 @@ class Partial(_Matcher):
 
 
 def _format_path(path: list[typing.Any]) -> str:
-    """Render an error path as ``data['a'][0]``, or ``<root>`` when empty."""
+    """Render an error path as ``a[0].b`` (probatio's own trail), or ``<root>``."""
     if not path:
         return "<root>"
-    return "data" + "".join(f"[{segment!r}]" for segment in path)
+    return render_path(path)
 
 
 def pytest_assertrepr_compare(

--- a/packages/pytest-probatio/tests/test_matchers.py
+++ b/packages/pytest-probatio/tests/test_matchers.py
@@ -55,7 +55,7 @@ def test_assertrepr_hook_explains_partial_match_operators() -> None:
     for op in ("<=", ">="):
         lines = pytest_assertrepr_compare(op, matcher, {"port": "nope"})
         assert lines is not None
-        assert any("data['port']" in line for line in lines)
+        assert any("port:" in line for line in lines)
 
 
 def test_matcher_records_errors_with_paths() -> None:
@@ -72,7 +72,7 @@ def test_assertrepr_hook_lists_errors_by_path() -> None:
     matcher == {"port": "nope"}  # noqa: B015 - run the comparison to record errors
     lines = pytest_assertrepr_compare("==", matcher, {"port": "nope"})
     assert lines is not None
-    assert any("data['port']" in line for line in lines)
+    assert any("port:" in line for line in lines)
 
 
 def test_assertrepr_hook_ignores_unrelated_comparisons() -> None:
@@ -118,4 +118,4 @@ def test_plugin_explains_a_failed_assertion_end_to_end(pytester) -> None:
     result.assert_outcomes(failed=1)
     output = result.stdout.str()
     assert "does not match the probatio schema" in output
-    assert "data['port']" in output
+    assert "port:" in output

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -217,7 +217,7 @@ class _MappingValidator:
         # voluptuous accepts only dict, so this is a documented superset
         # (carry-forward of voluptuous issue #299). A non-Mapping is rejected.
         if not isinstance(data, dict) and not isinstance(data, Mapping):
-            message = "expected a dictionary"
+            message = "expected a mapping"
             raise DictInvalid(message)
 
         # Preserve real dict subclasses, matching voluptuous. Other Mapping
@@ -444,9 +444,10 @@ class _MappingValidator:
         leaf = exc.errors if isinstance(exc, MultipleInvalid) else [exc]
         for error in leaf:
             # voluptuous tags a *leaf* value error "dictionary value" (or "object
-            # value" for an Object), so str() reads "... for dictionary value @
-            # ...". A leaf is recognized by its still-empty path; an error that
-            # already descended into a nested structure keeps its own type.
+            # value" for an Object) via ``error_type``. The attribute is kept for
+            # compatibility even though str() no longer renders it (ADR-015). A
+            # leaf is recognized by its still-empty path; an error that already
+            # descended into a nested structure keeps its own type.
             if not error.path and error.error_type is None:
                 error.error_type = self._invalid_msg
             error.prepend([key])

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -6,17 +6,24 @@ semantic subclasses that callers catch by type.
 
 Every error carries two layers. The voluptuous-compatible layer is ``path`` (a
 list of segments), ``msg``, ``error_message`` (the bare message, without the
-path), and ``error_type``; downstream code reads and string-matches these, so
-they keep their original behavior and wording. The structured layer is additive:
-a stable machine-readable ``code`` (defaulted per error class) and a ``context``
-dict, both filled in by the built-in validators, plus ``translation_key`` /
+path), and ``error_type``; downstream code reads these attributes, so they keep
+their voluptuous semantics. The structured layer is additive: a stable
+machine-readable ``code`` (defaulted per error class) and a ``context`` dict,
+both filled in by the built-in validators, plus ``translation_key`` /
 ``placeholders`` slots for localization that the built-ins leave empty for a
 caller raising its own error to populate. All four are surfaced together by
-``as_dict()``. Adding the structured layer changes none of the legacy output.
+``as_dict()``.
+
+``str(error)`` is for humans and deliberately deviates from voluptuous
+(ADR-015): the path renders as a dotted trail (``at 'hosts[2].name'``) instead
+of ``@ data['hosts'][2]['name']``, and the ``error_type`` clause is not
+rendered. Programmatic consumers read ``path``, ``code``, and ``as_dict()``;
+the rendered string promises readability, not stability.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from difflib import get_close_matches
 from typing import Any, cast
@@ -63,6 +70,39 @@ def _render_segment(segment: Any) -> str:
     if len(text) > _MAX_PATH_SEGMENT_LENGTH:
         return text[: _MAX_PATH_SEGMENT_LENGTH - 3] + "..."
     return text
+
+
+# A mapping key that reads cleanly bare in a dotted path: identifier-like,
+# hyphens allowed (common in configuration keys).
+_BARE_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]*\Z")
+
+
+def render_path(path: list[Any]) -> str:
+    """Render an error path as a dotted trail: ``server.port``, ``hosts[2].name``.
+
+    This is the rendering ``str(error)`` uses; it is public so a consumer
+    building its own error output renders paths the same way. Mapping keys join
+    with dots, integer segments (list indices, integer keys) render as ``[n]``,
+    and anything else (a key with spaces, a marker object) falls back to its
+    bracketed ``repr``. Group segments keep their ``<group>`` rendering (see
+    ``VirtualPathComponent``). An empty path renders as an empty string.
+    """
+    parts: list[str] = []
+    for segment in path:
+        if isinstance(segment, str):
+            # str(...) honors subclasses like VirtualPathComponent (``<group>``).
+            text = str(segment)
+            if len(text) <= _MAX_PATH_SEGMENT_LENGTH and (
+                _BARE_KEY.fullmatch(text)
+                or (text.startswith("<") and text.endswith(">"))
+            ):
+                parts.append(f".{text}" if parts else text)
+                continue
+        elif isinstance(segment, int) and not isinstance(segment, bool):
+            parts.append(f"[{segment}]")
+            continue
+        parts.append(f"[{_render_segment(segment)}]")
+    return "".join(parts)
 
 
 class Error(Exception):
@@ -190,14 +230,11 @@ class Invalid(Error):
         return self._placeholders
 
     def __str__(self) -> str:
-        """Render the message with the error type and data path appended."""
+        """Render the message with the path to the offending value appended."""
         output = Exception.__str__(self)
 
-        if self._error_type:
-            output += " for " + self._error_type
         if self._path:
-            path = "][".join(_render_segment(segment) for segment in self._path)
-            output += f" @ data[{path}]"
+            output += f" at '{render_path(self._path)}'"
 
         return output
 
@@ -316,14 +353,11 @@ class _SuggestionInvalid(Invalid):
         return ctx
 
     def __str__(self) -> str:
-        """Render the (suffixed) message with the error type and data path."""
+        """Render the (suffixed) message with the path to the offending value."""
         output = self.error_message
 
-        if self._error_type:
-            output += " for " + self._error_type
         if self._path:
-            path = "][".join(_render_segment(segment) for segment in self._path)
-            output += f" @ data[{path}]"
+            output += f" at '{render_path(self._path)}'"
 
         return output
 
@@ -427,7 +461,7 @@ class ObjectInvalid(Invalid):
 
 
 class DictInvalid(Invalid):
-    """The value is not a dictionary."""
+    """The value is not a mapping."""
 
     default_code = "not_a_dictionary"
 

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -85,7 +85,10 @@ def render_path(path: list[Any]) -> str:
     with dots, integer segments (list indices, integer keys) render as ``[n]``,
     and anything else (a key with spaces, a marker object) falls back to its
     bracketed ``repr``. Group segments keep their ``<group>`` rendering (see
-    ``VirtualPathComponent``). An empty path renders as an empty string.
+    ``VirtualPathComponent``), for identifier-like group names only: path
+    segments can be attacker-controlled mapping keys, and ``repr`` in the
+    fallback is what keeps control characters out of the rendered string. An
+    empty path renders as an empty string.
     """
     parts: list[str] = []
     for segment in path:
@@ -94,7 +97,11 @@ def render_path(path: list[Any]) -> str:
             text = str(segment)
             if len(text) <= _MAX_PATH_SEGMENT_LENGTH and (
                 _BARE_KEY.fullmatch(text)
-                or (text.startswith("<") and text.endswith(">"))
+                or (
+                    text.startswith("<")
+                    and text.endswith(">")
+                    and _BARE_KEY.fullmatch(text[1:-1])
+                )
             ):
                 parts.append(f".{text}" if parts else text)
                 continue

--- a/src/probatio/markers.py
+++ b/src/probatio/markers.py
@@ -38,7 +38,7 @@ class VirtualPathComponent(str):
     Inclusive and Exclusive group failures do not belong to any single key, so
     voluptuous points the error at a virtual path component named after the
     group. It compares equal to the bare group name but renders in angle
-    brackets, so ``str(error)`` reads ``... @ data[<group>]``.
+    brackets, so ``str(error)`` reads ``... at '<group>'``.
     """
 
     __slots__ = ()

--- a/src/probatio/validators/conditional.py
+++ b/src/probatio/validators/conditional.py
@@ -294,7 +294,7 @@ class _KeyGroup(_SafeValidator):
         if isinstance(value, Mapping):
             return value
         if self.require_mapping:
-            message = "expected a dictionary"
+            message = "expected a mapping"
             raise DictInvalid(message)
         return None
 

--- a/tests/__snapshots__/test_humanize_snapshots.ambr
+++ b/tests/__snapshots__/test_humanize_snapshots.ambr
@@ -1,34 +1,34 @@
 # serializer version: 1
 # name: test_humanize_error_snapshot[exclusive_group]
-  "two or more values in the same group of exclusion 'g' @ data[<g>]. Got None"
+  "two or more values in the same group of exclusion 'g' at '<g>'. Got None"
 # ---
 # name: test_humanize_error_snapshot[extra_key]
-  "not a valid option @ data['y']. Got 2"
+  "not a valid option at 'y'. Got 2"
 # ---
 # name: test_humanize_error_snapshot[inclusive_group]
-  "some but not all values in the same group of inclusion 'g' @ data[<g>]. Got None"
+  "some but not all values in the same group of inclusion 'g' at '<g>'. Got None"
 # ---
 # name: test_humanize_error_snapshot[list_index_path]
-  "expected int @ data['ports'][1]. Got 'x'"
+  "expected int at 'ports[1]'. Got 'x'"
 # ---
 # name: test_humanize_error_snapshot[missing_required]
-  "required key not provided @ data['name']. Got None"
+  "required key not provided at 'name'. Got None"
 # ---
 # name: test_humanize_error_snapshot[multiple]
   '''
-  expected int for dictionary value @ data['a']. Got 'x'
-  expected int for dictionary value @ data['b']. Got 'y'
+  expected int at 'a'. Got 'x'
+  expected int at 'b'. Got 'y'
   '''
 # ---
 # name: test_humanize_error_snapshot[nested_path]
-  "expected int for dictionary value @ data['a']['b']. Got 'x'"
+  "expected int at 'a.b'. Got 'x'"
 # ---
 # name: test_humanize_error_snapshot[not_in]
-  "value must be one of ['auto', 'manual'] for dictionary value @ data['mode']. Got 'off'"
+  "value must be one of ['auto', 'manual'] at 'mode'. Got 'off'"
 # ---
 # name: test_humanize_error_snapshot[out_of_range]
-  "value must be at most 10 for dictionary value @ data['n']. Got 99"
+  "value must be at most 10 at 'n'. Got 99"
 # ---
 # name: test_humanize_error_snapshot[wrong_type]
-  "expected int for dictionary value @ data['port']. Got 'nope'"
+  "expected int at 'port'. Got 'nope'"
 # ---

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -177,16 +177,24 @@ def test_matches_voluptuous(builder: Any, data: Any) -> None:
 
 
 def _detail(builder: Any, data: Any, lib: Any) -> Any:
-    """Run a schema, returning the result or each error's class name and string.
+    """Run a schema, returning the result or each error's class, message, and path.
 
     A drop-in is judged on more than the error path: downstream code reads
-    ``str(error)``, ``.msg``, and the error subclass. This pins all three.
+    ``.msg``, ``error_message``, and the error subclass. This pins all three.
+    ``str(error)`` is left out: probatio deliberately renders the path as a
+    dotted trail and drops the error-type clause (ADR-015).
     """
     try:
         return ("ok", builder(lib)(data))
     except lib.Invalid as exc:
         errors = exc.errors if isinstance(exc, lib.MultipleInvalid) else [exc]
-        return ("error", sorted((type(e).__name__, str(e)) for e in errors))
+        return (
+            "error",
+            sorted(
+                (type(e).__name__, e.error_message, [str(s) for s in e.path])
+                for e in errors
+            ),
+        )
 
 
 # Builders whose error message/class intentionally diverges from voluptuous, so

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -35,7 +35,7 @@ def test_argument_failure_raises_multiple_invalid() -> None:
     def add(a: int, b: int) -> int:
         return a + b
 
-    with pytest.raises(MultipleInvalid, match=r"data\['a'\]"):
+    with pytest.raises(MultipleInvalid, match=r"at 'a'"):
         add("nope", 3)
 
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -25,17 +25,51 @@ def test_invalid_defaults() -> None:
 
 
 def test_invalid_renders_path() -> None:
-    """The path is appended to the string form, the message stays bare."""
+    """The path is appended as a dotted trail, the message stays bare."""
     err = Invalid("expected int", path=["config", "port"])
     assert err.path == ["config", "port"]
     assert err.error_message == "expected int"
-    assert str(err) == "expected int @ data['config']['port']"
+    assert str(err) == "expected int at 'config.port'"
 
 
-def test_invalid_renders_error_type() -> None:
-    """The error type is appended after the message in the string form."""
+def test_invalid_renders_deep_path_with_indices() -> None:
+    """Sequence indices render as [n] inside the dotted trail."""
+    err = Invalid(
+        "expected str",
+        path=["automation", 0, "triggers", 2, "entity_id"],
+    )
+    assert str(err) == "expected str at 'automation[0].triggers[2].entity_id'"
+
+
+def test_invalid_renders_index_first_path_segment() -> None:
+    """A path starting at a sequence index renders without a leading dot."""
+    err = Invalid("expected str", path=[1, "name"])
+    assert str(err) == "expected str at '[1].name'"
+
+
+def test_invalid_renders_hyphenated_key_bare() -> None:
+    """A hyphenated key (common in configuration) renders without brackets."""
+    err = Invalid("expected int", path=["scan-interval"])
+    assert str(err) == "expected int at 'scan-interval'"
+
+
+def test_invalid_renders_awkward_key_bracketed() -> None:
+    """A key that does not read cleanly bare falls back to a bracketed repr."""
+    err = Invalid("expected int", path=["server", "my key"])
+    assert str(err) == "expected int at 'server['my key']'"
+
+
+def test_invalid_renders_bool_key_bracketed() -> None:
+    """A boolean key renders as its repr, not as a sequence index."""
+    err = Invalid("expected int", path=[True])
+    assert str(err) == "expected int at '[True]'"
+
+
+def test_invalid_does_not_render_error_type() -> None:
+    """The error type attribute is kept, but no longer rendered (ADR-015)."""
     err = Invalid("nope", error_type="dictionary value")
-    assert str(err) == "nope for dictionary value"
+    assert err.error_type == "dictionary value"
+    assert str(err) == "nope"
 
 
 def test_invalid_error_message_is_independent_of_message() -> None:
@@ -226,11 +260,11 @@ def test_long_path_segment_is_truncated_in_str() -> None:
     huge = "k" * 5000
     err = Invalid("bad", path=[huge])
     rendered = str(err)
-    assert rendered.endswith("...]")
+    assert rendered.endswith("...]'")
     assert len(rendered) < 600
 
 
 def test_normal_path_segment_is_not_truncated() -> None:
     """An ordinary key renders in full, with no truncation."""
     err = Invalid("bad", path=["port"])
-    assert str(err) == "bad @ data['port']"
+    assert str(err) == "bad at 'port'"

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -59,6 +59,19 @@ def test_invalid_renders_awkward_key_bracketed() -> None:
     assert str(err) == "expected int at 'server['my key']'"
 
 
+def test_invalid_renders_angle_bracket_key_with_control_chars_bracketed() -> None:
+    """An attacker-shaped <...> key falls back to repr; no raw control characters."""
+    err = Invalid("bad", path=["<bad\nkey>"])
+    assert str(err) == "bad at '['<bad\\nkey>']'"
+    assert "\n" not in str(err)
+
+
+def test_invalid_renders_group_segment_bare() -> None:
+    """An identifier-like <group> segment renders bare, keeping its brackets."""
+    err = Invalid("bad", path=["server", "<auth>"])
+    assert str(err) == "bad at 'server.<auth>'"
+
+
 def test_invalid_renders_bool_key_bracketed() -> None:
     """A boolean key renders as its repr, not as a sequence index."""
     err = Invalid("expected int", path=[True])

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,9 +1,14 @@
-"""Error-output fidelity: probatio renders errors like voluptuous.
+"""Error-output fidelity: probatio words errors like voluptuous.
 
 The conformance suite pins behavior (accept/reject and error paths) but leaves
-wording free. For a drop-in, wording matters too: downstream code string-matches
-``str(error)``, ``.msg``, and ``humanize_error``. These cases lock the rendered
+wording free. For a drop-in, wording matters too: downstream code
+string-matches ``.msg`` and ``error_message``. These cases lock the bare
 message and path to voluptuous for the spots where the two once diverged.
+
+``str(error)`` is deliberately not compared: probatio renders the path as a
+dotted trail and drops the error-type clause (ADR-015), where voluptuous
+renders ``... for dictionary value @ data['key']``. The message text and the
+path segments still match; only the rendering around them differs.
 
 voluptuous is a dev-only oracle; no code is copied from it.
 """
@@ -111,19 +116,19 @@ CASES: list[tuple[Any, Any]] = [
 
 
 def _first_error(builder: Any, data: Any, lib: Any) -> Any:
-    """Return the first error's rendered string and path from a failed validation."""
+    """Return the first error's bare message and path from a failed validation."""
     try:
         builder(lib)(data)
     except lib.Invalid as exc:
         error = exc.errors[0] if isinstance(exc, lib.MultipleInvalid) else exc
-        return (str(error), [str(segment) for segment in error.path])
+        return (error.error_message, [str(segment) for segment in error.path])
     msg = "expected the schema to reject the value"
     raise AssertionError(msg)
 
 
 @pytest.mark.parametrize(("builder", "data"), CASES)
-def test_error_string_matches_voluptuous(builder: Any, data: Any) -> None:
-    """probatio renders the same error string and path as voluptuous."""
+def test_error_message_matches_voluptuous(builder: Any, data: Any) -> None:
+    """probatio words the same error message and path as voluptuous."""
     assert _first_error(builder, data, probatio) == _first_error(
         builder,
         data,
@@ -137,6 +142,6 @@ def test_virtual_path_component_renders_in_brackets() -> None:
         exclusive_group(probatio)({"a": 1, "b": 2})
 
     error = caught.value.errors[0]
-    assert str(error).endswith("@ data[<grp>]")
+    assert str(error).endswith("at '<grp>'")
     assert error.path == ["grp"]
     assert repr(error.path[0]) == "<grp>"

--- a/tests/test_humanize.py
+++ b/tests/test_humanize.py
@@ -34,7 +34,7 @@ def test_humanize_single_error_shows_path_and_value() -> None:
     message = humanize_error({"port": "nope"}, caught.value)
 
     assert "expected int" in message
-    assert "data['port']" in message
+    assert "at 'port'" in message
     assert "Got 'nope'" in message
 
 
@@ -115,7 +115,7 @@ def test_humanize_error_without_a_locator_is_unchanged() -> None:
     except MultipleInvalid as err:
         rendered = humanize_error({"port": "nope"}, err)
 
-    assert "at " not in rendered
+    assert "(at " not in rendered
 
 
 def test_humanize_error_locator_returning_none_adds_no_location() -> None:

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -339,14 +339,14 @@ def test_remove_invalid_value_passes_through_with_allow_extra() -> None:
     assert schema({"note": "text"}) == {}
 
 
-def test_dict_value_error_reads_for_dictionary_value() -> None:
-    """A failed mapping value reads "... for dictionary value @ ...", as voluptuous."""
+def test_dict_value_error_keeps_error_type_out_of_rendering() -> None:
+    """A failed mapping value carries error_type but does not render it (ADR-015)."""
     schema = Schema({"data": int})
     with pytest.raises(MultipleInvalid) as caught:
         schema({"data": "x"})
     error = caught.value.errors[0]
     assert error.error_type == "dictionary value"
-    assert str(error) == "expected int for dictionary value @ data['data']"
+    assert str(error) == "expected int at 'data'"
 
 
 def test_dict_value_error_type_is_not_overwritten() -> None:

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -41,7 +41,7 @@ def test_object_reports_a_bad_attribute_as_object_value() -> None:
         Schema(Object({"x": int, "y": int}))(Point(1, "nope"))
     error = caught.value.errors[0]
     assert error.path == ["y"]
-    assert "for object value" in str(error)
+    assert error.error_type == "object value"
 
 
 def test_object_enforces_the_class() -> None:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -85,7 +85,7 @@ def test_self_inside_any_falls_through_to_a_sibling_branch() -> None:
 
     The recursive branch is a mapping whose values are Self; the sibling branch is
     a scalar. A string leaf fails the mapping branch and must fall through to the
-    str branch, instead of stopping at "expected a dictionary". This is Home
+    str branch, instead of stopping at "expected a mapping". This is Home
     Assistant's recursive translations schema (config_panel sections that bottom
     out in string leaves).
     """

--- a/tests/test_v0_16.py
+++ b/tests/test_v0_16.py
@@ -19,11 +19,21 @@ from probatio import All, Any, In, MultipleInvalid, Required, Schema, Union
 
 
 def _detail(lib: Typ, build: Typ, data: Typ) -> Typ:
-    """Run ``build(lib)(data)``, returning the result or each error's class/string."""
+    """Run ``build(lib)(data)``, returning the result or each error's detail.
+
+    Errors compare by class, bare message, and path; ``str(error)`` is left out
+    because probatio deliberately renders the path differently (ADR-015).
+    """
     try:
         return ("ok", build(lib)(data))
     except lib.MultipleInvalid as exc:
-        return ("err", sorted((type(e).__name__, str(e)) for e in exc.errors))
+        return (
+            "err",
+            sorted(
+                (type(e).__name__, e.error_message, [str(s) for s in e.path])
+                for e in exc.errors
+            ),
+        )
 
 
 # --- #523: In accepts a generator -------------------------------------------

--- a/tests/validators/test_conditional.py
+++ b/tests/validators/test_conditional.py
@@ -304,7 +304,7 @@ def test_key_group_rejects_a_non_mapping_by_default(validator: type) -> None:
 
     error = caught.value.errors[0]
     assert isinstance(error, DictInvalid)
-    assert error.error_message == "expected a dictionary"
+    assert error.error_message == "expected a mapping"
 
 
 @pytest.mark.parametrize("validator", [AtLeastOne, AtMostOne, ExactlyOne, AllOrNone])


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

The rendered error string, `str(error)`, changes. The path now renders as a dotted trail and the error-type clause is no longer rendered:

```text
before: expected int for dictionary value @ data['server']['port']
after:  expected int at 'server.port'
```

A non-mapping is rejected as "expected a mapping" instead of "expected a dictionary" (the engine accepts any `Mapping`, and the message now says so). Code that string-matches `str(error)` breaks; code that reads the attributes (`path`, `msg`, `error_message`, `error_type`, `code`, `context`, `as_dict()`) is unaffected, those keep their voluptuous semantics. To adapt, assert on `path` and `error_message` (or `as_dict()`) instead of the rendered string, or render paths with the new public `probatio.error.render_path`. The full deviation is recorded in ADR-015 and in the compatibility matrix.

## Proposed change

Error messages are for humans, and the voluptuous heritage rendering was not: `@ data['a'][0]['b']` leaks an internal name nobody ever wrote and reads like a parser's output, which gets worse with every nesting level of a real-world configuration. This PR makes `str(error)` human-first and makes the structured attributes the advertised API for programmatic consumers, per the new ADR-015 (structured errors, human-first messages, and localization):

- The path renders as a dotted trail: `expected str at 'automation[0].triggers[2].entity_id'`. Dots for keys (hyphens allowed bare), `[n]` for sequence indices, bracketed repr for awkward keys, `<group>` kept for marker groups, and the existing 500-character truncation guard retained.
- The `for dictionary value` clause is dropped from rendering; the `error_type` attribute stays for compatibility.
- The path renderer is public as `probatio.error.render_path`, so a consumer building its own output renders paths the same way. The pytest plugin now uses it instead of its own `data['a'][0]` format.
- The compatibility suites (fidelity, conformance, v0.16) now pin wording and paths through the attributes instead of `str(error)`, so the wording lock on voluptuous stays intact while the rendering is free.
- Measured against the proof harnesses: voluptuous's own test suite is green with 24 new rendering-only xfails (114 passed, 51 xfailed, 0 unexpected), and Home Assistant's `config_validation` suite passes 136 of 142, the 6 failures all asserting the exact old rendered string. Both harness READMEs, the compatibility matrix, the migration guide, and the Home Assistant recipe state these numbers.
- New documentation guide, "Custom error messages": `msg=` overrides, raising your own `Invalid` with structured data (`code`, `context`, `translation_key`, `placeholders`), and consumer-side rendering (own strings, JSON via `as_dict()`, a translation table keyed on `code`).

ADR-015 also lays out the follow-up phases: translation keys and placeholders on all raise sites (phase 1), catalog-based lazy message rendering (phase 2), and a locale mechanism without bundled translations (phase 3).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [x] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR is related to: ADR-015 (added in this PR)

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
