### PR TITLE
Give every error a translation key and render messages from a catalog

### DIFF
--- a/adr/015-structured-errors-and-localization.md
+++ b/adr/015-structured-errors-and-localization.md
@@ -32,7 +32,7 @@ and downstream test suites assert on `str(err)`.
    through new attributes. Safest for compatibility, but it freezes bad messages
    forever and the library keeps shipping a rendering nobody would design today.
 2. Ship translations as the headline: a locale catalog for every message, bundled
-   language packs, a global language switch. Rejected as the *first* step: bundled
+   language packs, a global language switch. Rejected as the _first_ step: bundled
    translations are a maintenance treadmill, and the consumers that care most
    (Home Assistant) will never use our strings, they need the data underneath.
 3. Structured error data first, human-first English defaults, localization as a
@@ -67,29 +67,32 @@ The structured attributes (`path`, `code`, `translation_key`, `placeholders`,
 `as_dict()`) are the advertised API for programmatic consumers; `str(e)` is for
 humans and makes no stability promise beyond "readable".
 
-**Part 3: localization as a mechanism.** Default English messages become a catalog
-of templates keyed by `translation_key`, rendered lazily at `str()` time, never at
+**Part 3: one catalog, English only.** Default messages become a catalog of
+templates keyed by `translation_key`, rendered lazily on first read, never at
 raise time (the error path is a measured hot path; see the compile-versus-validate
-split). A locale hook swaps the catalog: a contextvar with a module-level default,
-so a web application can render per-request locales without cross-request bleed.
-Probatio ships the mechanism and the English catalog. Bundled translations are
-explicitly out of scope for now; community locale packages can provide them.
+split). The catalog is the single source of the English text and dumb data on
+purpose. That is where it stops: Probatio ships no locale switch and no bundled
+translations. Localization is the consumer's concern, and `translation_key` plus
+`placeholders` is the complete contract for it; a consumer renders its own words
+in its own language from the data, and never needs Probatio to speak that
+language for it.
 
 **Rationale**:
 
 - **The data layer serves everyone; our strings serve only some.** A better English
   sentence helps a CLI user. `translation_key` plus `placeholders` helps the CLI
-  user, the Home Assistant frontend, a JSON API, and a future locale catalog, all
-  from one change.
+  user, the Home Assistant frontend, and a JSON API, all from one change.
 - **Error messages are product, not protocol.** Freezing them for compatibility
   (option 1) treats prose as API. The actual API is the structured layer; that is
   where the stability promise belongs.
 - **Lazy rendering keeps the hot path honest.** Formatting at `str()` time means a
   caught-and-discarded error (the `Any`/`Or` happy path) never pays for template
   rendering.
-- **Not bundling translations keeps the promise keepable.** Shipping two languages
-  is easy; keeping twenty correct is a treadmill. A mechanism plus an English
-  catalog is a commitment probatio can honor.
+- **Not shipping translations keeps the promise keepable.** Shipping two languages
+  is easy; keeping twenty correct is a treadmill of native-speaker review Probatio
+  cannot staff. One English catalog plus a complete data contract is a commitment
+  Probatio can honor, and the consumers that localize (Home Assistant renders its
+  own frontend translations) never wanted our strings anyway.
 
 **Consequences**:
 
@@ -110,8 +113,10 @@ explicitly out of scope for now; community locale packages can provide them.
 - **Roughly fifty raise sites change.** Mechanical, but every site needs a key and
   placeholders chosen with care; that is where the review effort goes.
 
-**Revisit trigger**: Bundle translations if real demand shows up and a sustainable
-source of native-speaker review exists (community locale packages proving
-insufficient would be the signal). Revisit the dotted path rendering if consumers
-are found parsing `str(e)` for the path despite the structured layer; that would
-mean the structured API is not discoverable enough.
+**Revisit trigger**: Reconsider a locale mechanism (a catalog switch, not bundled
+languages) only if multiple consumers are found rebuilding the same catalog-swap
+machinery on top of the keys; bundled translations additionally need a sustainable
+source of native-speaker review before they are even on the table. Revisit the
+dotted path rendering if consumers are found parsing `str(e)` for the path despite
+the structured layer; that would mean the structured API is not discoverable
+enough.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -144,6 +144,10 @@ export default defineConfig({
             { label: "Built-ins by role", slug: "reference/builtins-by-role" },
             { label: "Errors", slug: "reference/errors" },
             {
+              label: "Translation keys",
+              slug: "reference/translation-keys",
+            },
+            {
               label: "voluptuous compatibility",
               slug: "reference/compatibility-matrix",
             },

--- a/docs/src/content/docs/guides/custom-error-messages.md
+++ b/docs/src/content/docs/guides/custom-error-messages.md
@@ -134,28 +134,32 @@ except MultipleInvalid as err:
     body = json.dumps(err.as_dict())
     print(body)
     # {"errors": [{"code": "type", "message": "expected int", "path": ["port"],
-    #   "secret": false, "context": {"expected": "int"}, "translation_key": null,
-    #   "placeholders": {}}]}
+    #   "secret": false, "context": {"expected": "int"},
+    #   "translation_key": "expected_type",
+    #   "placeholders": {"expected": "int"}}]}
 ```
 
-For translations, branch on `code`. Every built-in error carries one (the
-[errors reference](/reference/errors/) lists them per class), so a lookup
-table maps failures to your own language, with `context` filling the holes and
-the original message as the fallback for codes you have not translated:
+For translations, branch on `translation_key`. Every built-in error carries
+one, naming the exact sentence, together with `placeholders`, the raw values
+that sentence interpolates (the
+[translation keys reference](/reference/translation-keys/) lists every key and
+its English template). A lookup table maps sentences to your own language,
+with the original message as the fallback for keys you have not translated:
 
 ```python
 from probatio import Schema, MultipleInvalid
 
 DUTCH = {
-    "type": "verwacht een waarde van type {expected}",
+    "expected_type": "verwacht een waarde van type {expected}",
     "required": "deze optie is verplicht",
+    "length_min": "lengte moet minimaal {min} zijn",
 }
 
 def render_dutch(error):
-    template = DUTCH.get(error.code)
+    template = DUTCH.get(error.translation_key)
     if template is None:
         return error.error_message
-    return template.format(**error.context)
+    return template.format(**error.placeholders)
 
 schema = Schema({"port": int, "host": str})
 
@@ -165,12 +169,52 @@ except MultipleInvalid as err:
     print(render_dutch(err.errors[0]))  # verwacht een waarde van type int
 ```
 
-Two honest notes on the current state. The built-ins fill `context` where
-there is an obvious payload (a type error carries `expected`), but not yet
-everywhere; a template that needs a value the context does not carry has to
-fall back to the original message. And `translation_key` / `placeholders` are
-populated only by errors you raise yourself; the built-ins leave them empty
-for now, so `code` is the key to branch on today.
+One sentence, one key: where two validators produce the same wording (the dict
+engine and the key groups both say "expected a mapping"), they share the key,
+so one translation covers both. `code` still identifies the _kind_ of failure
+and is the better branch point for behavior; `translation_key` identifies the
+_sentence_ and is the branch point for wording.
+
+### Suggestions compose on top
+
+Some errors carry a "did you mean ...?" suggestion (an unknown key close to a
+known one, for example; the [errors reference](/reference/errors/) marks which
+classes). The suggestion is _not_ part of the base sentence: the key names the
+sentence without it, and the close matches live on `context["candidates"]` as
+a raw list. Probatio's own English output appends the fragment (its template
+is the `did_you_mean` key), and `error_message` always includes it, so the
+fallback path keeps suggestions for free. A renderer working from keys has to
+compose the fragment itself, or the suggestion is silently dropped:
+
+```python
+from probatio import Schema, MultipleInvalid
+
+DUTCH = {
+    "not_a_valid_option": "geen geldige optie",
+    "did_you_mean": ", bedoelde je {candidates}?",
+}
+
+def render_dutch(error):
+    text = DUTCH.get(error.translation_key)
+    if text is None:
+        return error.error_message
+    text = text.format(**error.placeholders)
+    candidates = error.context.get("candidates")
+    if candidates:
+        joined = " of ".join(repr(name) for name in candidates)
+        text += DUTCH["did_you_mean"].format(candidates=joined)
+    return text
+
+schema = Schema({"name": str, "email": str})
+
+try:
+    schema({"nmae": "app"})
+except MultipleInvalid as err:
+    print(render_dutch(err.errors[0]))  # geen geldige optie, bedoelde je 'name'?
+```
+
+The list joining (the "of"/"or" between candidates) is deliberately yours: it
+is language, and the raw list gives you full control over it.
 
 ## Where to next
 
@@ -180,3 +224,5 @@ for now, so `code` is the key to branch on today.
   catching specific kinds.
 - [Errors reference](/reference/errors/): every error class, its `code`, and
   the fields on `Invalid`.
+- [Translation keys](/reference/translation-keys/): every key the built-ins
+  emit, with its English template.

--- a/docs/src/content/docs/guides/error-handling.md
+++ b/docs/src/content/docs/guides/error-handling.md
@@ -119,12 +119,13 @@ The [errors reference](/reference/errors/) lists the whole hierarchy.
 ## The structured layer
 
 On top of the voluptuous-compatible fields, every error carries a structured,
-machine-readable layer: a stable `code` and a `context` dict, both filled in by
-the built-in validators, plus `translation_key` and `placeholders` slots for
-localization. The built-ins leave those two empty; they are there for code that
-raises its own `Invalid` to carry localization data through. `as_dict()`
-serializes the whole layer, which is handy for an API that returns validation
-errors as JSON.
+machine-readable layer: a stable `code`, a `context` dict, and the pair that
+identifies the message itself: `translation_key` (a stable key naming the
+sentence, like `length_min`) and `placeholders` (the raw values the message
+interpolates, like `{"min": 10}`). The built-in validators fill all of them;
+the [translation keys reference](/reference/translation-keys/) lists every key.
+`as_dict()` serializes the whole layer, which is handy for an API that returns
+validation errors as JSON.
 
 ```python
 from probatio import Schema, Invalid

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -47,8 +47,11 @@ the legacy output.
   placeholder instead of the value.
 - `context`: a dict of structured detail about the failure, such as the expected
   type.
-- `translation_key`: an optional key for localizing the message (may be `None`).
-- `placeholders`: values to interpolate into a translated message.
+- `translation_key`: the stable key naming the message's sentence, filled by
+  every built-in validator (see the
+  [translation keys reference](/reference/translation-keys/)); `None` on a
+  bare `Invalid` raised without one.
+- `placeholders`: the raw values the message interpolates, like `{"min": 10}`.
 - `as_dict()`: the structured layer rendered as a serializable dict, handy for a
   JSON API.
 

--- a/docs/src/content/docs/reference/translation-keys.md
+++ b/docs/src/content/docs/reference/translation-keys.md
@@ -1,0 +1,147 @@
+---
+title: Translation keys
+description: Every translation key the built-in validators emit, with its English template and placeholders.
+---
+
+Every error a built-in validator raises carries a `translation_key` naming the
+exact sentence of its default message, and `placeholders`, the raw values that
+sentence interpolates. Together they let a consumer render errors in its own
+words or language without parsing strings; see
+[Custom error messages](/guides/custom-error-messages/) for the pattern.
+
+The keys are public API: renaming or removing one is a breaking change, the
+same as renaming a function. Where two validators produce the same sentence,
+they share the key, so one translation covers both. A custom `msg=` on a
+validator replaces the rendered text but keeps the key.
+
+Templates are `str.format` style. The canonical source is the catalog in
+`probatio._messages`; this table mirrors it. One entry is a fragment rather
+than a sentence: `did_you_mean` is appended to a suggestion-carrying error's
+message, with the close matches also available raw on `context["candidates"]`
+(see [how suggestions compose](/guides/custom-error-messages/#suggestions-compose-on-top)).
+
+| Key | English template |
+| --- | ---------------- |
+| `allowed_at_most_one_of` | `at most one of {keys} is allowed` |
+| `allowed_one_of` | `exactly one of {keys} is allowed` |
+| `byte_length_out_of_bounds` | `byte length out of bounds` |
+| `cannot_be_changed` | `{field!r} cannot be changed` |
+| `cannot_convert_to_set` | `cannot be converted to a set: {detail}` |
+| `contains_duplicate_items` | `contains duplicate items: {items}` |
+| `contains_unhashable_elements` | `contains unhashable elements: {detail}` |
+| `did_you_mean` | `, did you mean {candidates}?` |
+| `does_not_match_pattern` | `does not match the expected pattern` |
+| `element_not_valid` | `Element #{position} ({item}) is not valid against any validator` |
+| `exclusive_group` | `two or more values in the same group of exclusion {group!r}` |
+| `expected_alpha` | `expected only ASCII letters` |
+| `expected_alphanumeric` | `expected only ASCII letters and digits` |
+| `expected_ascii` | `expected only ASCII characters` |
+| `expected_base64_string` | `expected a Base64 string` |
+| `expected_boolean` | `expected boolean` |
+| `expected_cidr` | `expected a CIDR network` |
+| `expected_collection` | `expected a collection: {detail}` |
+| `expected_credit_card_number` | `expected a credit card number` |
+| `expected_data_uri` | `expected a data URI` |
+| `expected_duration` | `expected a duration` |
+| `expected_duration_detailed` | `expected a duration like H:MM, H:MM:SS, an ISO 8601 duration like PT1H30M, or a number of seconds` |
+| `expected_email_address` | `expected an email address` |
+| `expected_fqdn` | `expected a fully-qualified domain name` |
+| `expected_hex_color` | `expected a hex color like #rrggbb` |
+| `expected_hex_string` | `expected a hex string` |
+| `expected_hexadecimal_integer` | `expected a hexadecimal integer` |
+| `expected_hostname` | `expected a hostname` |
+| `expected_iana_time_zone` | `expected an IANA time zone` |
+| `expected_iban` | `expected an IBAN` |
+| `expected_ip` | `expected an IP address` |
+| `expected_ipv4` | `expected an IPv4 address` |
+| `expected_ipv6` | `expected an IPv6 address` |
+| `expected_iso_date` | `expected an ISO 8601 date` |
+| `expected_iso_datetime` | `expected an ISO 8601 datetime` |
+| `expected_iso_time` | `expected an ISO 8601 time` |
+| `expected_json_string` | `expected a JSON string` |
+| `expected_mac_address` | `expected a MAC address` |
+| `expected_mapping` | `expected a mapping` |
+| `expected_no_whitespace` | `expected no whitespace` |
+| `expected_object` | `expected a {cls!r}` |
+| `expected_percentage` | `expected a percentage between 0 and 100` |
+| `expected_phone_number` | `expected a phone number` |
+| `expected_port` | `expected a port number between 1 and 65535` |
+| `expected_printable_ascii` | `expected only printable ASCII characters` |
+| `expected_sequence` | `expected a {expected}` |
+| `expected_sequence_of_items` | `expected a sequence of {count} items` |
+| `expected_slug` | `expected a slug` |
+| `expected_string` | `expected a string` |
+| `expected_timezone_aware_datetime` | `expected a timezone-aware datetime` |
+| `expected_type` | `expected {expected}` |
+| `expected_type_or_one_of` | `expected {expected} or one of {values}` |
+| `expected_ulid` | `expected a ULID` |
+| `expected_unix_timestamp` | `expected a Unix timestamp` |
+| `expected_url` | `expected a URL` |
+| `expected_url_with_fqdn` | `expected a URL with a fully-qualified domain name` |
+| `expected_utc_offset` | `expected a UTC offset like +01:00, Z, or UTC` |
+| `expected_uuid` | `expected a UUID` |
+| `expected_uuid_version` | `expected a version {version} UUID` |
+| `expected_valid_regex` | `expected a valid regular expression` |
+| `expected_yaml_string` | `expected a YAML string` |
+| `inclusive_group` | `some but not all values in the same group of inclusion {group!r}` |
+| `invalid_credit_card_number` | `invalid credit card number` |
+| `invalid_data_uri` | `invalid data URI` |
+| `invalid_iban` | `invalid IBAN` |
+| `invalid_json` | `invalid JSON` |
+| `invalid_phone_number` | `invalid phone number` |
+| `invalid_value` | `invalid value` |
+| `invalid_value_or_type` | `invalid value or type` |
+| `invalid_yaml` | `invalid YAML` |
+| `key_not_allowed` | `key not allowed` |
+| `length_max` | `length of value must be at most {max}` |
+| `length_min` | `length of value must be at least {min}` |
+| `list_lengths_differ` | `List lengths differ, value:{value_length} != target:{target_length}` |
+| `max_contains` | `expected at most {max} matching item(s)` |
+| `min_contains` | `expected at least {min} matching item(s)` |
+| `must_not_match_not_schema` | `value must not match the 'not' schema` |
+| `no_valid_value` | `no valid value found` |
+| `not_a_block_device` | `Not a block device` |
+| `not_a_collection` | `value is not a collection` |
+| `not_a_directory` | `Not a directory` |
+| `not_a_fifo` | `Not a FIFO` |
+| `not_a_file` | `Not a file` |
+| `not_a_path` | `Not a Path` |
+| `not_a_sequence_value` | `Value {value} is not sequence!` |
+| `not_a_socket` | `Not a socket` |
+| `not_a_symlink` | `Not a symlink` |
+| `not_a_valid_option` | `not a valid option` |
+| `not_a_valid_value` | `not a valid value` |
+| `not_a_valid_value_detail` | `not a valid value: {detail}` |
+| `path_does_not_exist` | `path does not exist` |
+| `precision_must_equal` | `precision must be equal to {precision}` |
+| `range_max` | `value must be at most {max}` |
+| `range_max_exclusive` | `value must be lower than {max}` |
+| `range_min` | `value must be at least {min}` |
+| `range_min_exclusive` | `value must be higher than {min}` |
+| `recursion_too_deep` | `data is nested too deeply for this recursive schema` |
+| `required` | `required key not provided` |
+| `required_any_of` | `at least one of {keys} is required` |
+| `required_none_or_all_of` | `either none or all of {keys} are required` |
+| `required_one_of` | `exactly one of {keys} is required` |
+| `required_when_absent` | `{key!r} is required when {triggers} is absent` |
+| `required_when_present` | `{key!r} is required when {triggers} is present` |
+| `required_when_value` | `{key!r} is required when {conditions}` |
+| `scale_must_equal` | `scale must be equal to {scale}` |
+| `value_does_not_match_format` | `value does not match expected format {format}` |
+| `value_has_no_precision` | `value has no precision` |
+| `value_multiple_of` | `value must be a multiple of {factor}` |
+| `value_must_be_number_string` | `value must be a number enclosed in a string` |
+| `value_must_contain` | `value must contain {item!r}` |
+| `value_must_end_with` | `value must end with {suffix!r}` |
+| `value_must_start_with` | `value must start with {prefix!r}` |
+| `value_no_length` | `value has no length` |
+| `value_not_allowed` | `value is not allowed` |
+| `value_not_empty` | `value must not be empty` |
+| `value_not_equal` | `value is not equal to {target!r}` |
+| `value_not_match` | `{value} not match for {lit}` |
+| `value_not_one_of` | `value must not be one of {values}` |
+| `value_not_sorted` | `value is not sorted` |
+| `value_one_of` | `value must be one of {values}` |
+| `value_was_not_false` | `value was not false` |
+| `value_was_not_true` | `value was not true` |
+| `write_once_already_set` | `{field!r} is write-once and already set` |

--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -46,10 +46,11 @@ def _type_error(expected: str, path: list[Any], error_type: str | None) -> TypeI
     produce, so inlining the isinstance is invisible to callers.
     """
     return TypeInvalid(
-        f"expected {expected}",
         path=path,
         error_type=error_type,
         context={"expected": expected},
+        translation_key="expected_type",
+        placeholders={"expected": expected},
     )
 
 
@@ -217,8 +218,7 @@ class _MappingValidator:
         # voluptuous accepts only dict, so this is a documented superset
         # (carry-forward of voluptuous issue #299). A non-Mapping is rejected.
         if not isinstance(data, dict) and not isinstance(data, Mapping):
-            message = "expected a mapping"
-            raise DictInvalid(message)
+            raise DictInvalid(translation_key="expected_mapping")
 
         # Preserve real dict subclasses, matching voluptuous. Other Mapping
         # implementations validate too, but rebuild as a plain dict.
@@ -418,9 +418,10 @@ class _MappingValidator:
     def _forbidden_error(key: Any, candidate: _Candidate) -> Invalid:
         """Build the error for a key that a Forbidden marker says must be absent."""
         return Invalid(
-            candidate.msg or "key not allowed",
+            candidate.msg,
             path=[key],
             code="forbidden_key",
+            translation_key="key_not_allowed",
         )
 
     def _store(
@@ -499,11 +500,11 @@ class _MappingValidator:
         combinator branch never pays for the pool copy or difflib.
         """
         return ExtraKeysInvalid(
-            "not a valid option",
             path=[key],
             suggest_value=key,
             suggest_pool=self._key_names,
             suggest_exclude=key,
+            translation_key="not_a_valid_option",
         )
 
     def _finalize(
@@ -540,12 +541,13 @@ class _MappingValidator:
             if candidate.complex_keys is not None:
                 # Required(Any("a", "b")): at least one of the listed keys must be
                 # present (voluptuous 0.16.0). A custom marker msg still wins.
-                message = (
-                    candidate.msg
-                    or f"at least one of {candidate.complex_keys} is required"
-                )
                 errors.append(
-                    RequiredFieldInvalid(message, path=[candidate.key_schema]),
+                    RequiredFieldInvalid(
+                        candidate.msg,
+                        path=[candidate.key_schema],
+                        translation_key="required_any_of",
+                        placeholders={"keys": candidate.complex_keys},
+                    ),
                 )
             else:
                 # A finalizer reaching here is required and unfilled: it had no
@@ -553,8 +555,9 @@ class _MappingValidator:
                 # own ``msg`` wins, matching voluptuous.
                 errors.append(
                     RequiredFieldInvalid(
-                        candidate.msg or "required key not provided",
+                        candidate.msg,
                         path=[candidate.key_schema],
+                        translation_key="required",
                     ),
                 )
 
@@ -589,9 +592,12 @@ class _MappingValidator:
 
         if any(self._candidates[index].exclusive_required for index in members):
             keys = [self._candidates[index].key_schema for index in members]
-            message = f"exactly one of {keys} is required"
             errors.append(
-                RequiredFieldInvalid(message, path=[VirtualPathComponent(group)]),
+                RequiredFieldInvalid(
+                    path=[VirtualPathComponent(group)],
+                    translation_key="required_one_of",
+                    placeholders={"keys": keys},
+                ),
             )
 
     def _group_msg(self, members: list[int]) -> str | None:
@@ -616,11 +622,13 @@ class _MappingValidator:
                 if seen[index]:
                     present += 1
             if present > 1:
-                message = self._group_msg(members) or (
-                    f"two or more values in the same group of exclusion {group!r}"
-                )
                 errors.append(
-                    ExclusiveInvalid(message, path=[VirtualPathComponent(group)]),
+                    ExclusiveInvalid(
+                        self._group_msg(members),
+                        path=[VirtualPathComponent(group)],
+                        translation_key="exclusive_group",
+                        placeholders={"group": group},
+                    ),
                 )
             elif present == 0:
                 self._empty_exclusive_group(group, members, out, errors)
@@ -632,11 +640,13 @@ class _MappingValidator:
                 if not seen[index]:
                     missing += 1
             if missing and missing != len(members):
-                message = self._group_msg(members) or (
-                    f"some but not all values in the same group of inclusion {group!r}"
-                )
                 errors.append(
-                    InclusiveInvalid(message, path=[VirtualPathComponent(group)]),
+                    InclusiveInvalid(
+                        self._group_msg(members),
+                        path=[VirtualPathComponent(group)],
+                        translation_key="inclusive_group",
+                        placeholders={"group": group},
+                    ),
                 )
 
 
@@ -664,8 +674,10 @@ class _ObjectValidator:
     def __call__(self, data: Any) -> Any:
         """Validate the attributes and reconstruct an object of the same type."""
         if self._cls is not UNDEFINED and not isinstance(data, self._cls):
-            message = f"expected a {self._cls!r}"
-            raise ObjectInvalid(message)
+            raise ObjectInvalid(
+                translation_key="expected_object",
+                placeholders={"cls": self._cls},
+            )
 
         # voluptuous skips attributes that are None, so they fall to their schema
         # default (or are simply absent) rather than failing a typed value check.
@@ -705,8 +717,10 @@ class _SequenceValidator:
     def __call__(self, data: Any) -> Any:  # noqa: PLR0912
         """Validate each item, rebuilding the sequence of the original type."""
         if not isinstance(data, self._base_type):
-            message = f"expected a {self._base_type.__name__}"
-            raise SequenceTypeInvalid(message)
+            raise SequenceTypeInvalid(
+                translation_key="expected_sequence",
+                placeholders={"expected": self._base_type.__name__},
+            )
 
         result: list[Any] = []
         errors: list[Invalid] = []
@@ -722,9 +736,10 @@ class _SequenceValidator:
                 else:
                     errors.append(
                         TypeInvalid(
-                            f"expected {expected}",
                             path=[index],
                             context={"expected": expected},
+                            translation_key="expected_type",
+                            placeholders={"expected": expected},
                         ),
                     )
         elif (check := self._single) is not None:
@@ -786,7 +801,7 @@ class _SequenceValidator:
 
         if last_error is None:
             # No element schemas at all: nothing can match this item.
-            errors.append(Invalid("invalid value", path=[index]))
+            errors.append(Invalid(path=[index], translation_key="invalid_value"))
             return
 
         last_error.prepend([index])

--- a/src/probatio/_messages.py
+++ b/src/probatio/_messages.py
@@ -1,0 +1,160 @@
+"""The English message catalog: one template per translation key.
+
+Every default error message the built-in validators produce lives here, keyed
+by the error's ``translation_key``. A raise site passes the key and the
+placeholders; the message text is rendered from the template lazily, on the
+first read of ``msg`` / ``error_message`` / ``str(error)``, so an error that
+is built and discarded (a miss inside a combinator branch) never pays for
+string formatting.
+
+The keys are public API (ADR-015): a consumer branches on them to render its
+own messages or translations, so renaming or removing one is a breaking
+change. The templates are ``str.format`` style, dumb data on purpose. This
+catalog is English and stays English: Probatio ships no translations, the key
+plus placeholders is the contract a consumer localizes against.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# One entry per distinct sentence. Where several validators share a sentence
+# (like "expected a mapping" from the dict engine and the key groups), they
+# share the key, so a translation covers both.
+CATALOG: dict[str, str] = {
+    "allowed_at_most_one_of": "at most one of {keys} is allowed",
+    "allowed_one_of": "exactly one of {keys} is allowed",
+    "byte_length_out_of_bounds": "byte length out of bounds",
+    "cannot_be_changed": "{field!r} cannot be changed",
+    "cannot_convert_to_set": "cannot be converted to a set: {detail}",
+    "contains_duplicate_items": "contains duplicate items: {items}",
+    "contains_unhashable_elements": "contains unhashable elements: {detail}",
+    # A fragment, not a sentence: appended to a suggestion-carrying error's
+    # message. ``candidates`` arrives pre-joined ("'a', 'b' or 'c'"); the raw
+    # list is on the error's ``context["candidates"]`` for consumers that need
+    # to join it themselves.
+    "did_you_mean": ", did you mean {candidates}?",
+    "does_not_match_pattern": "does not match the expected pattern",
+    "element_not_valid": "Element #{position} ({item}) is not valid against any validator",
+    "exclusive_group": "two or more values in the same group of exclusion {group!r}",
+    "expected_alpha": "expected only ASCII letters",
+    "expected_alphanumeric": "expected only ASCII letters and digits",
+    "expected_ascii": "expected only ASCII characters",
+    "expected_base64_string": "expected a Base64 string",
+    "expected_boolean": "expected boolean",
+    "expected_cidr": "expected a CIDR network",
+    "expected_collection": "expected a collection: {detail}",
+    "expected_credit_card_number": "expected a credit card number",
+    "expected_data_uri": "expected a data URI",
+    "expected_duration": "expected a duration",
+    "expected_duration_detailed": "expected a duration like H:MM, H:MM:SS, an ISO 8601 duration like PT1H30M, or a number of seconds",
+    "expected_email_address": "expected an email address",
+    "expected_fqdn": "expected a fully-qualified domain name",
+    "expected_hex_color": "expected a hex color like #rrggbb",
+    "expected_hex_string": "expected a hex string",
+    "expected_hexadecimal_integer": "expected a hexadecimal integer",
+    "expected_hostname": "expected a hostname",
+    "expected_iana_time_zone": "expected an IANA time zone",
+    "expected_iban": "expected an IBAN",
+    "expected_ip": "expected an IP address",
+    "expected_ipv4": "expected an IPv4 address",
+    "expected_ipv6": "expected an IPv6 address",
+    "expected_iso_date": "expected an ISO 8601 date",
+    "expected_iso_datetime": "expected an ISO 8601 datetime",
+    "expected_iso_time": "expected an ISO 8601 time",
+    "expected_json_string": "expected a JSON string",
+    "expected_mac_address": "expected a MAC address",
+    "expected_mapping": "expected a mapping",
+    "expected_no_whitespace": "expected no whitespace",
+    "expected_object": "expected a {cls!r}",
+    "expected_percentage": "expected a percentage between 0 and 100",
+    "expected_phone_number": "expected a phone number",
+    "expected_port": "expected a port number between 1 and 65535",
+    "expected_printable_ascii": "expected only printable ASCII characters",
+    "expected_sequence": "expected a {expected}",
+    "expected_sequence_of_items": "expected a sequence of {count} items",
+    "expected_slug": "expected a slug",
+    "expected_string": "expected a string",
+    "expected_timezone_aware_datetime": "expected a timezone-aware datetime",
+    "expected_type": "expected {expected}",
+    "expected_type_or_one_of": "expected {expected} or one of {values}",
+    "expected_ulid": "expected a ULID",
+    "expected_unix_timestamp": "expected a Unix timestamp",
+    "expected_url": "expected a URL",
+    "expected_url_with_fqdn": "expected a URL with a fully-qualified domain name",
+    "expected_utc_offset": "expected a UTC offset like +01:00, Z, or UTC",
+    "expected_uuid": "expected a UUID",
+    "expected_uuid_version": "expected a version {version} UUID",
+    "expected_valid_regex": "expected a valid regular expression",
+    "expected_yaml_string": "expected a YAML string",
+    "inclusive_group": "some but not all values in the same group of inclusion {group!r}",
+    "invalid_credit_card_number": "invalid credit card number",
+    "invalid_data_uri": "invalid data URI",
+    "invalid_iban": "invalid IBAN",
+    "invalid_json": "invalid JSON",
+    "invalid_phone_number": "invalid phone number",
+    "invalid_value": "invalid value",
+    "invalid_value_or_type": "invalid value or type",
+    "invalid_yaml": "invalid YAML",
+    "key_not_allowed": "key not allowed",
+    "length_max": "length of value must be at most {max}",
+    "length_min": "length of value must be at least {min}",
+    "list_lengths_differ": "List lengths differ, value:{value_length} != target:{target_length}",
+    "max_contains": "expected at most {max} matching item(s)",
+    "min_contains": "expected at least {min} matching item(s)",
+    "must_not_match_not_schema": "value must not match the 'not' schema",
+    "no_valid_value": "no valid value found",
+    "not_a_block_device": "Not a block device",
+    "not_a_collection": "value is not a collection",
+    "not_a_directory": "Not a directory",
+    "not_a_fifo": "Not a FIFO",
+    "not_a_file": "Not a file",
+    "not_a_path": "Not a Path",
+    "not_a_sequence_value": "Value {value} is not sequence!",
+    "not_a_socket": "Not a socket",
+    "not_a_symlink": "Not a symlink",
+    "not_a_valid_option": "not a valid option",
+    "not_a_valid_value": "not a valid value",
+    "not_a_valid_value_detail": "not a valid value: {detail}",
+    "path_does_not_exist": "path does not exist",
+    "precision_must_equal": "precision must be equal to {precision}",
+    "range_max": "value must be at most {max}",
+    "range_max_exclusive": "value must be lower than {max}",
+    "range_min": "value must be at least {min}",
+    "range_min_exclusive": "value must be higher than {min}",
+    "recursion_too_deep": "data is nested too deeply for this recursive schema",
+    "required": "required key not provided",
+    "required_any_of": "at least one of {keys} is required",
+    "required_none_or_all_of": "either none or all of {keys} are required",
+    "required_one_of": "exactly one of {keys} is required",
+    "required_when_absent": "{key!r} is required when {triggers} is absent",
+    "required_when_present": "{key!r} is required when {triggers} is present",
+    "required_when_value": "{key!r} is required when {conditions}",
+    "scale_must_equal": "scale must be equal to {scale}",
+    "value_does_not_match_format": "value does not match expected format {format}",
+    "value_has_no_precision": "value has no precision",
+    "value_multiple_of": "value must be a multiple of {factor}",
+    "value_must_be_number_string": "value must be a number enclosed in a string",
+    "value_must_contain": "value must contain {item!r}",
+    "value_must_end_with": "value must end with {suffix!r}",
+    "value_must_start_with": "value must start with {prefix!r}",
+    "value_no_length": "value has no length",
+    "value_not_allowed": "value is not allowed",
+    "value_not_empty": "value must not be empty",
+    "value_not_equal": "value is not equal to {target!r}",
+    "value_not_match": "{value} not match for {lit}",
+    "value_not_one_of": "value must not be one of {values}",
+    "value_not_sorted": "value is not sorted",
+    "value_one_of": "value must be one of {values}",
+    "value_was_not_false": "value was not false",
+    "value_was_not_true": "value was not true",
+    "write_once_already_set": "{field!r} is write-once and already set",
+}
+
+
+def render(key: str, placeholders: dict[str, Any] | None) -> str:
+    """Render the catalog template for ``key`` with the given placeholders."""
+    template = CATALOG[key]
+    if not placeholders:
+        return template
+    return template.format(**placeholders)

--- a/src/probatio/_vol_shim/schema_builder.py
+++ b/src/probatio/_vol_shim/schema_builder.py
@@ -28,8 +28,11 @@ def _compile_scalar(schema: Any) -> Any:
             """Require the data to be an instance of the schema type."""
             if isinstance(data, schema):
                 return data
-            message = f"expected {schema.__name__}"
-            raise _error.TypeInvalid(message, path)
+            raise _error.TypeInvalid(
+                path=path,
+                translation_key="expected_type",
+                placeholders={"expected": schema.__name__},
+            )
 
         return validate_instance
 
@@ -40,8 +43,10 @@ def _compile_scalar(schema: Any) -> Any:
             try:
                 return schema(data)
             except ValueError as exc:
-                message = "not a valid value"
-                raise _error.ValueInvalid(message, path) from exc
+                raise _error.ValueInvalid(
+                    path=path,
+                    translation_key="not_a_valid_value",
+                ) from exc
             except _error.Invalid as exc:
                 exc.prepend(path)
                 raise
@@ -51,8 +56,10 @@ def _compile_scalar(schema: Any) -> Any:
     def validate_value(path: Any, data: Any) -> Any:
         """Require the data to equal the schema value."""
         if data != schema:
-            message = "not a valid value"
-            raise _error.ScalarInvalid(message, path)
+            raise _error.ScalarInvalid(
+                path=path,
+                translation_key="not_a_valid_value",
+            )
         return data
 
     return validate_value

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -788,8 +788,7 @@ class _Not:
         except Invalid:
             return value
 
-        message = "value must not match the 'not' schema"
-        raise Invalid(message)
+        raise Invalid(translation_key="must_not_match_not_schema")
 
 
 def _from_enum(values: Any) -> In:
@@ -1188,8 +1187,7 @@ class _ContainsCount:
         try:
             items = list(value)
         except TypeError as exc:
-            message = "value is not a collection"
-            raise ContainsInvalid(message) from exc
+            raise ContainsInvalid(translation_key="not_a_collection") from exc
 
         count = 0
         for element in items:
@@ -1200,11 +1198,15 @@ class _ContainsCount:
             count += 1
 
         if count < self._min:
-            message = f"expected at least {self._min} matching item(s)"
-            raise ContainsInvalid(message)
+            raise ContainsInvalid(
+                translation_key="min_contains",
+                placeholders={"min": self._min},
+            )
         if self._max is not None and count > self._max:
-            message = f"expected at most {self._max} matching item(s)"
-            raise ContainsInvalid(message)
+            raise ContainsInvalid(
+                translation_key="max_contains",
+                placeholders={"max": self._max},
+            )
 
         return value
 

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -734,9 +734,13 @@ def _fuse_validate_and_construct(
 
     def _constructor_error(exc: ValueError) -> MultipleInvalid:
         """Build the tower-identical error for a constructor ``ValueError``."""
-        detail = str(exc)
-        message = f"not a valid value: {detail}" if detail else "not a valid value"
-        error = ValueInvalid(message)
+        if detail := str(exc):
+            error = ValueInvalid(
+                translation_key="not_a_valid_value_detail",
+                placeholders={"detail": detail},
+            )
+        else:
+            error = ValueInvalid(translation_key="not_a_valid_value")
         error.__cause__ = exc
         return MultipleInvalid([error])
 

--- a/src/probatio/error.py
+++ b/src/probatio/error.py
@@ -8,11 +8,11 @@ Every error carries two layers. The voluptuous-compatible layer is ``path`` (a
 list of segments), ``msg``, ``error_message`` (the bare message, without the
 path), and ``error_type``; downstream code reads these attributes, so they keep
 their voluptuous semantics. The structured layer is additive: a stable
-machine-readable ``code`` (defaulted per error class) and a ``context`` dict,
-both filled in by the built-in validators, plus ``translation_key`` /
-``placeholders`` slots for localization that the built-ins leave empty for a
-caller raising its own error to populate. All four are surfaced together by
-``as_dict()``.
+machine-readable ``code`` (defaulted per error class), a ``context`` dict, and
+``translation_key`` / ``placeholders``, the message's catalog key and the raw
+values it interpolates (see ``probatio._messages``). The built-in validators
+fill all four; a caller raising its own error can too. Everything is surfaced
+together by ``as_dict()``.
 
 ``str(error)`` is for humans and deliberately deviates from voluptuous
 (ADR-015): the path renders as a dotted trail (``at 'hosts[2].name'``) instead
@@ -27,6 +27,8 @@ import re
 from dataclasses import dataclass
 from difflib import get_close_matches
 from typing import Any, cast
+
+from probatio._messages import render
 
 # A single rendered path segment is capped at this length, so an error string
 # cannot be blown up by a huge attacker-controlled mapping key. Far longer than
@@ -143,7 +145,7 @@ class Invalid(Error):
 
     def __init__(
         self,
-        message: str,
+        message: str | None = None,
         path: list[Any] | None = None,
         error_message: str | None = None,
         error_type: str | None = None,
@@ -153,7 +155,24 @@ class Invalid(Error):
         translation_key: str | None = None,
         placeholders: dict[str, Any] | None = None,
     ) -> None:
-        """Create an error for ``message`` at the given ``path``."""
+        """Create an error for ``message`` at the given ``path``.
+
+        With ``message`` omitted and a ``translation_key`` given, the message
+        text is rendered from the English catalog on first read (and cached),
+        so an error that is built and discarded never pays for formatting.
+        An explicit ``message`` always wins; the key still rides along for a
+        consumer rendering its own output.
+
+        The error takes ownership of ``context`` and ``placeholders``: pass a
+        fresh dict, not one you keep mutating. Error construction sits on the
+        engine's reject path, and skipping a defensive copy there is a measured
+        win; every built-in raise site passes a fresh literal.
+        """
+        # A deferred error still carries one args entry (``None``): a raise-and-
+        # discard loop with empty-args exceptions segfaults CPython 3.13 under
+        # CodSpeed's native walltime hooks (reproduced ~50% of runs on the
+        # any-miss benchmark; clean without instrumentation). ``None`` is the
+        # "render me lazily" marker that ``_message_text`` replaces.
         super().__init__(message)
 
         self._path = list(path) if path else []
@@ -162,20 +181,38 @@ class Invalid(Error):
             self._error_type = error_type
         if code is not None:
             self._code = code
-        # ``None`` until read: most errors never have their context/placeholders
-        # looked at (a miss inside a combinator branch is built and discarded), so
-        # the dict copies are deferred to the property getters.
+        # Owned, not copied (see the docstring): the built-in raise sites all
+        # pass fresh dict literals, and the reject path is hot.
         if context:
-            self._context = dict(context)
+            self._context = context
         if translation_key is not None:
             self._translation_key = translation_key
         if placeholders:
-            self._placeholders = dict(placeholders)
+            self._placeholders = placeholders
+
+    def _message_text(self) -> str:
+        """Return the message text, rendering from the catalog on first read.
+
+        An eagerly-messaged error carries its text in ``args``; a deferred one
+        (``args[0] is None``) renders its ``translation_key`` template once and
+        caches the result in ``args``, so later reads (and pickling) see a
+        plain string.
+        """
+        text = self.args[0]
+        if text is not None:
+            return cast("str", text)
+        rendered = (
+            render(self._translation_key, self._placeholders)
+            if self._translation_key is not None
+            else ""
+        )
+        self.args = (rendered,)
+        return rendered
 
     @property
     def msg(self) -> str:
         """The human-readable message."""
-        return cast("str", self.args[0])
+        return self._message_text()
 
     @property
     def path(self) -> list[Any]:
@@ -185,7 +222,9 @@ class Invalid(Error):
     @property
     def error_message(self) -> str:
         """The bare message, without the path appended."""
-        return self._error_message
+        if self._error_message is not None:
+            return self._error_message
+        return self._message_text()
 
     @property
     def error_type(self) -> str | None:
@@ -238,7 +277,7 @@ class Invalid(Error):
 
     def __str__(self) -> str:
         """Render the message with the path to the offending value appended."""
-        output = Exception.__str__(self)
+        output = self._message_text()
 
         if self._path:
             output += f" at '{render_path(self._path)}'"
@@ -278,7 +317,7 @@ class _SuggestionInvalid(Invalid):
 
     def __init__(
         self,
-        message: str,
+        message: str | None = None,
         path: list[Any] | None = None,
         error_message: str | None = None,
         error_type: str | None = None,
@@ -332,10 +371,17 @@ class _SuggestionInvalid(Invalid):
         return self._candidates
 
     def _suffix_text(self) -> str:
-        """Return the ``, did you mean ...?`` fragment for the message, cached."""
+        """Return the ``, did you mean ...?`` fragment for the message, cached.
+
+        The fragment renders from the catalog (``did_you_mean``), so it is
+        addressable by key like the base sentences.
+        """
         if self._suffix_cache is None:
             self._suffix_cache = (
-                f", did you mean {_format_candidates(self.candidates)}?"
+                render(
+                    "did_you_mean",
+                    {"candidates": _format_candidates(self.candidates)},
+                )
                 if self._with_suffix and self.candidates
                 else ""
             )
@@ -344,7 +390,12 @@ class _SuggestionInvalid(Invalid):
     @property
     def error_message(self) -> str:
         """The bare message, with the suggestion suffix when there is one."""
-        return self._error_message + self._suffix_text()
+        base = (
+            self._error_message
+            if self._error_message is not None
+            else self._message_text()
+        )
+        return base + self._suffix_text()
 
     @property
     def msg(self) -> str:

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -158,8 +158,7 @@ class recursion_guard:  # noqa: N801 - a context manager, named like contextlib'
         """Charge one level, raising ``Invalid`` if the budget is exceeded."""
         depth = _SELF_DEPTH.get() + self._cost
         if depth > sys.getrecursionlimit() // _SELF_DEPTH_DIVISOR:
-            message = "data is nested too deeply for this recursive schema"
-            raise Invalid(message)
+            raise Invalid(translation_key="recursion_too_deep")
         self._token = _SELF_DEPTH.set(depth)
 
     def __exit__(self, *exc: object) -> None:
@@ -249,8 +248,11 @@ class _TypeCheck:
     def __call__(self, data: Any) -> Any:
         """Require the value to be an instance of the expected type."""
         if not isinstance(data, self.checked_type):
-            message = f"expected {self._expected}"
-            raise TypeInvalid(message, context={"expected": self._expected})
+            raise TypeInvalid(
+                context={"expected": self._expected},
+                translation_key="expected_type",
+                placeholders={"expected": self._expected},
+            )
         return data
 
 
@@ -306,10 +308,10 @@ class _EnumCheck:
             # ValueError: no member has this value. TypeError: the value is
             # unhashable, so the value-to-member lookup cannot even be tried.
             values = [member.value for member in self._enum]
-            message = f"value must be one of {values}"
             raise EnumInvalid(
-                message,
                 context={"expected": self._expected, "values": values},
+                translation_key="value_one_of",
+                placeholders={"values": values},
             ) from exc
 
 
@@ -1084,11 +1086,12 @@ class Schema:
             except Invalid:
                 raise
             except ValueError as exc:
-                detail = str(exc)
-                message = (
-                    f"not a valid value: {detail}" if detail else "not a valid value"
-                )
-                raise ValueInvalid(message) from exc
+                if detail := str(exc):
+                    raise ValueInvalid(
+                        translation_key="not_a_valid_value_detail",
+                        placeholders={"detail": detail},
+                    ) from exc
+                raise ValueInvalid(translation_key="not_a_valid_value") from exc
 
         return validate
 
@@ -1099,8 +1102,7 @@ class Schema:
         def validate(data: Any) -> Any:
             """Require the value to equal the literal."""
             if data != schema:
-                message = "not a valid value"
-                raise ScalarInvalid(message)
+                raise ScalarInvalid(translation_key="not_a_valid_value")
             return data
 
         return validate

--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -33,9 +33,9 @@ class Coerce[T](_SafeValidator):
         self.type_name: str = getattr(type, "__name__", str(type))
         self.msg = msg
         # Filled on the first failure, not eagerly: building the default message
-        # (and for an enum, its value pool) walks the enum members, a cost a schema
-        # that never fails should not pay at construction either.
-        self._failure_cache: tuple[str, tuple[str, ...]] | None = None
+        # placeholders (and for an enum, its value pool) walks the enum members, a
+        # cost a schema that never fails should not pay at construction either.
+        self._failure_cache: tuple[str, dict[str, str], tuple[str, ...]] | None = None
 
     def __repr__(self) -> str:
         """Render as a constructor call, matching voluptuous."""
@@ -66,29 +66,38 @@ class Coerce[T](_SafeValidator):
                 return typing.cast("T", value)
             # The suggestion match is deferred to the error, so a miss inside a
             # combinator branch that is then discarded never pays for difflib. The
-            # default message and pool depend only on ``self.type``, so they are
-            # built once on the first failure; ``self.msg`` stays raise-time.
+            # translation key, placeholders, and pool depend only on ``self.type``,
+            # so they are built once on the first failure; ``self.msg`` stays
+            # raise-time.
             cached = self._failure_cache
             if cached is None:
-                cached = (self._default_message(), tuple(self._enum_values()))
+                key, placeholders = self._default_message_parts()
+                cached = (key, placeholders, tuple(self._enum_values()))
                 self._failure_cache = cached
             raise CoerceInvalid(
-                self.msg or cached[0],
+                self.msg,
                 suggest_value=value,
-                suggest_pool=cached[1],
+                suggest_pool=cached[2],
                 suffix=self.msg is None,
+                translation_key=cached[0],
+                placeholders=cached[1],
             ) from exc
         else:
             return coerced
 
-    def _default_message(self) -> str:
-        """Build the failure message, listing an enum's values (like voluptuous)."""
-        message = f"expected {self.type_name}"
+    def _default_message_parts(self) -> tuple[str, dict[str, str]]:
+        """Pick the failure key and placeholders, listing an enum's values.
+
+        Matches voluptuous: a plain target reads "expected int", an enum target
+        appends its value pool ("expected Color or one of 'red', 'green'").
+        """
         if isinstance(self.type, type) and issubclass(self.type, enum.Enum):
             values = ", ".join(repr(member.value) for member in self.type)
-            message = f"{message} or one of {values}"
-
-        return message
+            return (
+                "expected_type_or_one_of",
+                {"expected": self.type_name, "values": values},
+            )
+        return "expected_type", {"expected": self.type_name}
 
     def _enum_values(self) -> list[str]:
         """Return the string enum values, the pool a 'did you mean ...?' hint matches.
@@ -102,7 +111,7 @@ class Coerce[T](_SafeValidator):
         return [member.value for member in self.type if isinstance(member.value, str)]
 
 
-@message("expected boolean", cls=BooleanInvalid)
+@message("expected boolean", cls=BooleanInvalid, translation_key="expected_boolean")
 def Boolean(value: typing.Any) -> bool:
     """Read common truthy/falsy strings (and other values) as a boolean.
 
@@ -170,22 +179,28 @@ class Number(_SafeValidator):
             # ArithmeticError covers OverflowError: a 3-element sequence is read by
             # Decimal as a (sign, digits, exponent) spec, and a huge exponent
             # overflows the C long, which must not leak.
-            message = self.msg or "value must be a number enclosed in a string"
-            raise Invalid(message) from exc
+            raise Invalid(
+                self.msg, translation_key="value_must_be_number_string"
+            ) from exc
 
         exponent = number.as_tuple().exponent
         if not isinstance(exponent, int):  # NaN or infinity
-            message = self.msg or "value has no precision"
-            raise Invalid(message)
+            raise Invalid(self.msg, translation_key="value_has_no_precision")
 
         precision = len(number.as_tuple().digits)
         scale = -exponent
         if self.precision is not None and precision != self.precision:
-            message = self.msg or f"precision must be equal to {self.precision}"
-            raise Invalid(message)
+            raise Invalid(
+                self.msg,
+                translation_key="precision_must_equal",
+                placeholders={"precision": self.precision},
+            )
         if self.scale is not None and scale != self.scale:
-            message = self.msg or f"scale must be equal to {self.scale}"
-            raise Invalid(message)
+            raise Invalid(
+                self.msg,
+                translation_key="scale_must_equal",
+                placeholders={"scale": self.scale},
+            )
 
         return number if self.yield_decimal else value
 

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -129,7 +129,7 @@ def _run_any(
     candidates: list[typing.Any],
     value: typing.Any,
     msg: str | None,
-    miss_message: str | None,
+    miss_label: str | None,
 ) -> typing.Any:
     """Return the first candidate that accepts the value, else raise.
 
@@ -152,11 +152,13 @@ def _run_any(
 
     if msg is not None:
         raise AnyInvalid(msg)
-    if miss_message is not None:
-        raise AnyInvalid(miss_message)
+    if miss_label is not None:
+        raise AnyInvalid(
+            translation_key="expected_type",
+            placeholders={"expected": miss_label},
+        )
     if best is None:
-        message = "no valid value found"
-        raise AnyInvalid(message)
+        raise AnyInvalid(translation_key="no_valid_value")
     if isinstance(best, MultipleInvalid):
         raise best
     raise MultipleInvalid([best])
@@ -270,13 +272,13 @@ def _run_typed_any(
     allow_none: bool,
     value: typing.Any,
     msg: str | None,
-    miss_message: str | None,
+    miss_label: str | None,
 ) -> typing.Any:
     """Resolve an all-type (or None) ``Any``/``Union`` without per-branch exceptions.
 
     One ``isinstance``, plus a ``value is None`` check when a ``None`` branch is
     present, accepts on the hot path. On a miss a single ``AnyInvalid`` is raised
-    with the message precomputed at branch-compile time (every branch is a type,
+    with the label precomputed at branch-compile time (every branch is a type,
     so it always labels), without running any branch, so both the match and the
     miss skip the try/except churn.
     """
@@ -284,9 +286,14 @@ def _run_typed_any(
         return value
     if msg is not None:
         raise AnyInvalid(msg)
-    # The typed path always labels (every branch is a type), so the fallback
-    # string is unreachable; it keeps the type checker honest without a cast.
-    raise AnyInvalid(miss_message or "no valid value found")
+    if miss_label is not None:
+        raise AnyInvalid(
+            translation_key="expected_type",
+            placeholders={"expected": miss_label},
+        )
+    # The typed path always labels (every branch is a type), so this fallback
+    # is unreachable; it keeps the type checker honest without a cast.
+    raise AnyInvalid(translation_key="no_valid_value")  # pragma: no cover
 
 
 class Any(_Combinator):
@@ -323,19 +330,17 @@ class Any(_Combinator):
             for validator in self.validators
         ]
         self._types = _type_tuple(self.validators, self._compiled)
+        # Prebuilt so a miss does not re-derive a label that only depends on the
+        # branch labels, which are fixed here; the sentence itself renders lazily
+        # from the "expected_type" catalog template.
         self._expected = _expected_label(self.validators)
-        # Prebuilt so a miss does not re-interpolate a message that only depends
-        # on the branch labels, which are fixed here.
-        self._miss_message = (
-            None if self._expected is None else f"expected {self._expected}"
-        )
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Try each validator, returning the first that accepts the value."""
         # All-type (or None) branches resolve by one isinstance, on match and miss.
         if self._types is not None:
-            return _run_typed_any(*self._types, value, self.msg, self._miss_message)
-        return _run_any(self._compiled, value, self.msg, self._miss_message)
+            return _run_typed_any(*self._types, value, self.msg, self._expected)
+        return _run_any(self._compiled, value, self.msg, self._expected)
 
     def __repr__(self) -> str:
         """Render as ``Any(v, ..., msg=...)``."""
@@ -390,18 +395,15 @@ class Union(_Combinator):
             if self.discriminant is None
             else None
         )
-        self._expected = _expected_label(self.validators)
         # Prebuilt for the same reason as in ``Any._compile_branches``.
-        self._miss_message = (
-            None if self._expected is None else f"expected {self._expected}"
-        )
+        self._expected = _expected_label(self.validators)
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Try the (possibly narrowed) candidates, returning the first match."""
         if self.discriminant is None:
             if self._types is not None:
-                return _run_typed_any(*self._types, value, self.msg, self._miss_message)
-            return _run_any(self._compiled, value, self.msg, self._miss_message)
+                return _run_typed_any(*self._types, value, self.msg, self._expected)
+            return _run_any(self._compiled, value, self.msg, self._expected)
         # A discriminant returns a subset of the raw validators; resolve each to
         # its compiled form, compiling any object it returns that was not among
         # the originals (matching voluptuous, which recompiles the chosen set).

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -69,8 +69,11 @@ class Equal(_SafeValidator):
             unequal = True
 
         if unequal:
-            message = self.msg or f"value is not equal to {self.target!r}"
-            raise Invalid(message)
+            raise Invalid(
+                self.msg,
+                translation_key="value_not_equal",
+                placeholders={"target": self.target},
+            )
         return value
 
 
@@ -93,8 +96,11 @@ class Literal(_SafeValidator):
             unequal = True
 
         if unequal:
-            message = msg or f"{value} not match for {self.lit}"
-            raise LiteralInvalid(message)
+            raise LiteralInvalid(
+                msg,
+                translation_key="value_not_match",
+                placeholders={"value": value, "lit": self.lit},
+            )
         return self.lit
 
     def __str__(self) -> str:
@@ -127,12 +133,14 @@ class Contains(_SafeValidator):
             # may raise anything: an ``ipaddress`` network checks ``other._version``
             # (AttributeError), a hostile object can raise worse. Treat any such
             # failure as "not a collection that contains the item".
-            message = self.msg or "value is not a collection"
-            raise ContainsInvalid(message) from exc
+            raise ContainsInvalid(self.msg, translation_key="not_a_collection") from exc
 
         if not present:
-            message = self.msg or f"value must contain {self.item!r}"
-            raise ContainsInvalid(message)
+            raise ContainsInvalid(
+                self.msg,
+                translation_key="value_must_contain",
+                placeholders={"item": self.item},
+            )
         return value
 
 
@@ -176,23 +184,30 @@ class Range(_SafeValidator):
                 # comparison is False, is rejected rather than slipping through.
                 in_bounds = value >= self.min if self.min_included else value > self.min
                 if not in_bounds:
-                    bound = "at least" if self.min_included else "higher than"
-                    message = self.msg or f"value must be {bound} {self.min}"
-                    raise RangeInvalid(message)
+                    key = "range_min" if self.min_included else "range_min_exclusive"
+                    raise RangeInvalid(
+                        self.msg,
+                        translation_key=key,
+                        placeholders={"min": self.min},
+                    )
 
             if self.max is not None:
                 in_bounds = value <= self.max if self.max_included else value < self.max
                 if not in_bounds:
-                    bound = "at most" if self.max_included else "lower than"
-                    message = self.msg or f"value must be {bound} {self.max}"
-                    raise RangeInvalid(message)
+                    key = "range_max" if self.max_included else "range_max_exclusive"
+                    raise RangeInvalid(
+                        self.msg,
+                        translation_key=key,
+                        placeholders={"max": self.max},
+                    )
         except Invalid:
             # An out-of-bounds RangeInvalid raised just above carries the precise
             # message; let it through rather than redescribing it below.
             raise
         except Exception as exc:
-            message = self.msg or "invalid value or type"
-            raise RangeInvalid(message) from exc
+            raise RangeInvalid(
+                self.msg, translation_key="invalid_value_or_type"
+            ) from exc
 
         return value
 
@@ -223,8 +238,9 @@ class Clamp(_SafeValidator):
             if self.max is not None and value > self.max:
                 return self.max
         except Exception as exc:
-            message = self.msg or "invalid value or type"
-            raise RangeInvalid(message) from exc
+            raise RangeInvalid(
+                self.msg, translation_key="invalid_value_or_type"
+            ) from exc
 
         return value
 
@@ -271,9 +287,11 @@ class MultipleOf(_SafeValidator):
         formatting, not modulo, and a ``bool`` is not a meaningful count, so both
         are rejected rather than mishandled.
         """
-        message = self.msg or f"value must be a multiple of {self.factor}"
+        placeholders = {"factor": self.factor}
         if not isinstance(value, int | float) or isinstance(value, bool):
-            raise MultipleOfInvalid(message)
+            raise MultipleOfInvalid(
+                self.msg, translation_key="value_multiple_of", placeholders=placeholders
+            )
 
         try:
             # ``%`` with a float factor promotes a huge int to float, which can
@@ -281,10 +299,14 @@ class MultipleOf(_SafeValidator):
             # ``__mod__`` that raises. Report either cleanly, not as a leak.
             remainder = value % self.factor
         except Exception as exc:
-            raise MultipleOfInvalid(message) from exc
+            raise MultipleOfInvalid(
+                self.msg, translation_key="value_multiple_of", placeholders=placeholders
+            ) from exc
 
         if remainder != 0:
-            raise MultipleOfInvalid(message)
+            raise MultipleOfInvalid(
+                self.msg, translation_key="value_multiple_of", placeholders=placeholders
+            )
         return value
 
 
@@ -295,7 +317,7 @@ def _percent_value(value: typing.Any, msg: str | None) -> float:
     numeric validators like ``MultipleOf``.
     """
     if isinstance(value, bool):
-        raise RangeInvalid(msg or "expected a percentage between 0 and 100")
+        raise RangeInvalid(msg, translation_key="expected_percentage")
 
     raw = value[:-1] if isinstance(value, str) and value.endswith("%") else value
     try:
@@ -308,10 +330,10 @@ def _percent_value(value: typing.Any, msg: str | None) -> float:
         # error; keep it rather than masking it as a RangeInvalid.
         raise
     except Exception as exc:
-        raise RangeInvalid(msg or "expected a percentage between 0 and 100") from exc
+        raise RangeInvalid(msg, translation_key="expected_percentage") from exc
 
     if not _MIN_PERCENT <= number <= _MAX_PERCENT:
-        raise RangeInvalid(msg or "expected a percentage between 0 and 100")
+        raise RangeInvalid(msg, translation_key="expected_percentage")
     return number
 
 
@@ -397,10 +419,10 @@ class NonEmpty(_SafeValidator):
         try:
             empty = len(value) == 0
         except Exception as exc:
-            raise LengthInvalid(self.msg or "value must not be empty") from exc
+            raise LengthInvalid(self.msg, translation_key="value_not_empty") from exc
 
         if empty:
-            raise LengthInvalid(self.msg or "value must not be empty")
+            raise LengthInvalid(self.msg, translation_key="value_not_empty")
         return value
 
 
@@ -435,15 +457,20 @@ class Length(_SafeValidator):
         try:
             length = len(value)
         except Exception as exc:
-            message = self.msg or "value has no length"
-            raise LengthInvalid(message) from exc
+            raise LengthInvalid(self.msg, translation_key="value_no_length") from exc
 
         if self.min is not None and length < self.min:
-            message = self.msg or f"length of value must be at least {self.min}"
-            raise LengthInvalid(message)
+            raise LengthInvalid(
+                self.msg,
+                translation_key="length_min",
+                placeholders={"min": self.min},
+            )
         if self.max is not None and length > self.max:
-            message = self.msg or f"length of value must be at most {self.max}"
-            raise LengthInvalid(message)
+            raise LengthInvalid(
+                self.msg,
+                translation_key="length_max",
+                placeholders={"max": self.max},
+            )
         return value
 
 
@@ -513,17 +540,15 @@ class In(_SafeValidator):
         try:
             present = candidate in self.container if fast else self._contains(candidate)
         except Exception as exc:
-            message = self.msg or "value is not allowed"
-            raise InInvalid(message) from exc
+            raise InInvalid(self.msg, translation_key="value_not_allowed") from exc
 
         if not present:
             # The suggestion match is deferred to the error, so a miss inside a
             # combinator branch that is then discarded never pays for difflib.
-            message = self.msg or (
-                f"value must be one of {_sorted_for_message(self.container)}"
-            )
             raise InInvalid(
-                message,
+                self.msg,
+                translation_key="value_one_of",
+                placeholders={"values": _sorted_for_message(self.container)},
                 suggest_value=value,
                 suggest_pool=self._string_members(),
                 suffix=self.msg is None,
@@ -548,13 +573,12 @@ class NotIn(_SafeValidator):
         try:
             present = value in self.container
         except Exception as exc:
-            message = self.msg or "value is not allowed"
-            raise NotInInvalid(message) from exc
+            raise NotInInvalid(self.msg, translation_key="value_not_allowed") from exc
 
         if present:
-            message = (
-                self.msg
-                or f"value must not be one of {_sorted_for_message(self.container)}"
+            raise NotInInvalid(
+                self.msg,
+                translation_key="value_not_one_of",
+                placeholders={"values": _sorted_for_message(self.container)},
             )
-            raise NotInInvalid(message)
         return value

--- a/src/probatio/validators/conditional.py
+++ b/src/probatio/validators/conditional.py
@@ -119,11 +119,15 @@ class RequiredWith(_SafeValidator):
             if _fires(flags, self.mode):
                 for key in self.required:
                     if key not in value:
-                        message = self.msg or (
-                            f"{key!r} is required when "
-                            f"{_join(self.triggers, self.mode)} is present"
+                        raise RequiredFieldInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="required_when_present",
+                            placeholders={
+                                "key": key,
+                                "triggers": _join(self.triggers, self.mode),
+                            },
                         )
-                        raise RequiredFieldInvalid(message, path=[key])
         return value
 
 
@@ -156,11 +160,15 @@ class RequiredWithout(_SafeValidator):
             if _fires(flags, self.mode):
                 for key in self.required:
                     if key not in value:
-                        message = self.msg or (
-                            f"{key!r} is required when "
-                            f"{_join(self.triggers, self.mode)} is absent"
+                        raise RequiredFieldInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="required_when_absent",
+                            placeholders={
+                                "key": key,
+                                "triggers": _join(self.triggers, self.mode),
+                            },
                         )
-                        raise RequiredFieldInvalid(message, path=[key])
         return value
 
 
@@ -214,10 +222,15 @@ class RequiredIf(_SafeValidator):
             if _fires(flags, self.mode):
                 for key in self.required:
                     if key not in value:
-                        message = self.msg or (
-                            f"{key!r} is required when {self._describe()}"
+                        raise RequiredFieldInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="required_when_value",
+                            placeholders={
+                                "key": key,
+                                "conditions": self._describe(),
+                            },
                         )
-                        raise RequiredFieldInvalid(message, path=[key])
         return value
 
     def _describe(self) -> str:
@@ -294,8 +307,7 @@ class _KeyGroup(_SafeValidator):
         if isinstance(value, Mapping):
             return value
         if self.require_mapping:
-            message = "expected a mapping"
-            raise DictInvalid(message)
+            raise DictInvalid(translation_key="expected_mapping")
         return None
 
 
@@ -312,8 +324,11 @@ class AtLeastOne(_KeyGroup):
         """Return the mapping, raising if none of the keys are present."""
         mapping = self._mapping(value)
         if mapping is not None and not _present(mapping, self.keys):
-            message = self.msg or f"at least one of {_key_list(self.keys)} is required"
-            raise RequiredFieldInvalid(message)
+            raise RequiredFieldInvalid(
+                self.msg,
+                translation_key="required_any_of",
+                placeholders={"keys": _key_list(self.keys)},
+            )
         return value
 
 
@@ -333,11 +348,17 @@ class AtMostOne(_KeyGroup):
         if mapping is not None:
             present = _present(mapping, self.keys)
             if len(present) > 1:
-                message = (
-                    self.msg or f"at most one of {_key_list(self.keys)} is allowed"
-                )
+                placeholders = {"keys": _key_list(self.keys)}
                 raise MultipleInvalid(
-                    [ExclusiveInvalid(message, path=[key]) for key in present]
+                    [
+                        ExclusiveInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="allowed_at_most_one_of",
+                            placeholders=placeholders,
+                        )
+                        for key in present
+                    ]
                 )
         return value
 
@@ -358,16 +379,23 @@ class ExactlyOne(_KeyGroup):
         if mapping is not None:
             present = _present(mapping, self.keys)
             if not present:
-                message = (
-                    self.msg or f"exactly one of {_key_list(self.keys)} is required"
+                raise RequiredFieldInvalid(
+                    self.msg,
+                    translation_key="required_one_of",
+                    placeholders={"keys": _key_list(self.keys)},
                 )
-                raise RequiredFieldInvalid(message)
             if len(present) > 1:
-                message = (
-                    self.msg or f"exactly one of {_key_list(self.keys)} is allowed"
-                )
+                placeholders = {"keys": _key_list(self.keys)}
                 raise MultipleInvalid(
-                    [ExclusiveInvalid(message, path=[key]) for key in present]
+                    [
+                        ExclusiveInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="allowed_one_of",
+                            placeholders=placeholders,
+                        )
+                        for key in present
+                    ]
                 )
         return value
 
@@ -389,11 +417,16 @@ class AllOrNone(_KeyGroup):
             present = _present(mapping, self.keys)
             if present and len(present) != len(self.keys):
                 missing = [key for key in self.keys if key not in mapping]
-                message = (
-                    self.msg
-                    or f"either none or all of {_key_list(self.keys)} are required"
-                )
+                placeholders = {"keys": _key_list(self.keys)}
                 raise MultipleInvalid(
-                    [InclusiveInvalid(message, path=[key]) for key in missing]
+                    [
+                        InclusiveInvalid(
+                            self.msg,
+                            path=[key],
+                            translation_key="required_none_or_all_of",
+                            placeholders=placeholders,
+                        )
+                        for key in missing
+                    ]
                 )
         return value

--- a/src/probatio/validators/decorators.py
+++ b/src/probatio/validators/decorators.py
@@ -24,6 +24,8 @@ _R = typing.TypeVar("_R")
 def message(
     default: str | None = None,
     cls: type[Invalid] | None = None,
+    *,
+    translation_key: str | None = None,
 ) -> typing.Callable[
     [typing.Callable[_P, _R]],
     typing.Callable[..., typing.Callable[_P, _R]],
@@ -42,11 +44,28 @@ def message(
         Schema(isint())            # raises IntegerInvalid("not an integer")
         Schema(isint("bad value")) # raises IntegerInvalid("bad value")
 
-    Matches voluptuous, so ``Boolean`` and friends are factories here too.
+    Matches voluptuous, so ``Boolean`` and friends are factories here too. The
+    built-in factories also pass ``translation_key``, the catalog key whose
+    template matches ``default``, so their errors render lazily and stay
+    translatable; a per-use message override keeps its own text with the key
+    riding along.
     """
     if cls is not None and not issubclass(cls, Invalid):
         problem = "message can only use subclasses of Invalid as a custom class"
         raise SchemaError(problem)
+
+    # Resolve the fallback once. With a key, the text renders lazily from the
+    # catalog; a keyless ``default`` is eager text (its author gave no key); with
+    # neither, the shared "invalid value" catalog entry is the fallback.
+    if translation_key is not None:
+        fallback = None
+        key: str | None = translation_key
+    elif default is not None:
+        fallback = default
+        key = None
+    else:
+        fallback = None
+        key = "invalid_value"
 
     def decorator(
         func: typing.Callable[_P, _R],
@@ -67,7 +86,7 @@ def message(
                     return func(*args, **kwargs)
                 except ValueError:
                     raise (clsoverride or cls or ValueInvalid)(
-                        msg or default or "invalid value"
+                        msg or fallback, translation_key=key
                     ) from None
 
             # The wrapper forwards ``*args, **kwargs`` to ``func``, so it carries the

--- a/src/probatio/validators/encoding.py
+++ b/src/probatio/validators/encoding.py
@@ -40,12 +40,15 @@ class Base64(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is valid Base64, else raise ValueInvalid."""
         if not isinstance(value, str | bytes):
-            raise ValueInvalid(self.msg or "expected a Base64 string", code="base64")
+            raise ValueInvalid(
+                self.msg, code="base64", translation_key="expected_base64_string"
+            )
         try:
             base64.b64decode(value, validate=True)
         except (binascii.Error, ValueError) as exc:
-            message = self.msg or "expected a Base64 string"
-            raise ValueInvalid(message, code="base64") from exc
+            raise ValueInvalid(
+                self.msg, code="base64", translation_key="expected_base64_string"
+            ) from exc
         return value
 
 
@@ -59,11 +62,15 @@ class Hex(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is valid hex, else raise ValueInvalid."""
         if not isinstance(value, str):
-            raise ValueInvalid(self.msg or "expected a hex string", code="hex")
+            raise ValueInvalid(
+                self.msg, code="hex", translation_key="expected_hex_string"
+            )
         try:
             bytes.fromhex(value)
         except ValueError as exc:
-            raise ValueInvalid(self.msg or "expected a hex string", code="hex") from exc
+            raise ValueInvalid(
+                self.msg, code="hex", translation_key="expected_hex_string"
+            ) from exc
         return value
 
 
@@ -86,7 +93,9 @@ class HexInt(_SafeValidator):
     def _error(self) -> CoerceInvalid:
         """Build the coercion error for a value that is not a hex integer."""
         return CoerceInvalid(
-            self.msg or "expected a hexadecimal integer", code="hex_int"
+            self.msg,
+            code="hex_int",
+            translation_key="expected_hexadecimal_integer",
         )
 
     def __call__(self, value: typing.Any) -> typing.Any:
@@ -121,12 +130,12 @@ class FromJSONString(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the decoded (and validated) value, else raise JsonInvalid."""
         if not isinstance(value, str | bytes | bytearray):
-            raise JsonInvalid(self.msg or "expected a JSON string")
+            raise JsonInvalid(self.msg, translation_key="expected_json_string")
 
         try:
             decoded = json.loads(value)
         except ValueError as exc:
-            raise JsonInvalid(self.msg or "invalid JSON") from exc
+            raise JsonInvalid(self.msg, translation_key="invalid_json") from exc
 
         return self._validate(decoded) if self._validate is not None else decoded
 
@@ -177,14 +186,14 @@ class FromYAMLString(_SafeValidator):
         from probatio.serde import load_yaml  # noqa: PLC0415
 
         if not isinstance(value, str | bytes):
-            raise YamlInvalid(self.msg or "expected a YAML string")
+            raise YamlInvalid(self.msg, translation_key="expected_yaml_string")
 
         try:
             decoded = load_yaml(value)
         except Exception as exc:
             # A YAML backend raises its own parse-error type (YAMLRocks, PyYAML);
             # normalize any of them, plus deep-nesting recursion, to YamlInvalid.
-            raise YamlInvalid(self.msg or "invalid YAML") from exc
+            raise YamlInvalid(self.msg, translation_key="invalid_yaml") from exc
 
         return self._validate(decoded) if self._validate is not None else decoded
 

--- a/src/probatio/validators/formats.py
+++ b/src/probatio/validators/formats.py
@@ -59,7 +59,9 @@ class CreditCard(_SafeValidator):
         """Return the card number (bare digits when normalizing), else raise."""
         if not isinstance(value, str):
             raise ValueInvalid(
-                self.msg or "expected a credit card number", code="credit_card"
+                self.msg,
+                code="credit_card",
+                translation_key="expected_credit_card_number",
             )
 
         digits = value.replace(" ", "").replace("-", "")
@@ -69,7 +71,9 @@ class CreditCard(_SafeValidator):
             or not _luhn_ok(digits)
         ):
             raise ValueInvalid(
-                self.msg or "invalid credit card number", code="credit_card"
+                self.msg,
+                code="credit_card",
+                translation_key="invalid_credit_card_number",
             )
         return digits if self.normalize else value
 
@@ -112,11 +116,11 @@ class IBAN(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the IBAN (compact and upper-cased when normalizing), else raise."""
         if not isinstance(value, str):
-            raise ValueInvalid(self.msg or "expected an IBAN", code="iban")
+            raise ValueInvalid(self.msg, code="iban", translation_key="expected_iban")
 
         compact = value.replace(" ", "").upper()
         if not _valid_iban(compact):
-            raise ValueInvalid(self.msg or "invalid IBAN", code="iban")
+            raise ValueInvalid(self.msg, code="iban", translation_key="invalid_iban")
         return compact if self.normalize else value
 
 
@@ -135,23 +139,29 @@ class DataURI(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is a well-formed data URI, else raise."""
         if not isinstance(value, str):
-            raise ValueInvalid(self.msg or "expected a data URI", code="data_uri")
+            raise ValueInvalid(
+                self.msg, code="data_uri", translation_key="expected_data_uri"
+            )
 
         header, separator, data = value.partition(",")
         if not header.startswith("data:") or not separator:
-            raise ValueInvalid(self.msg or "invalid data URI", code="data_uri")
+            raise ValueInvalid(
+                self.msg, code="data_uri", translation_key="invalid_data_uri"
+            )
 
         params = header[len("data:") :].split(";")
         media_type = params[0]
         if media_type and "/" not in media_type:
-            raise ValueInvalid(self.msg or "invalid data URI", code="data_uri")
+            raise ValueInvalid(
+                self.msg, code="data_uri", translation_key="invalid_data_uri"
+            )
 
         if "base64" in params[1:]:
             try:
                 base64.b64decode(data, validate=True)
             except ValueError as exc:
                 raise ValueInvalid(
-                    self.msg or "invalid data URI", code="data_uri"
+                    self.msg, code="data_uri", translation_key="invalid_data_uri"
                 ) from exc
 
         return value
@@ -176,7 +186,9 @@ class E164(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the E.164 number (compact when normalizing), else raise."""
         if not isinstance(value, str):
-            raise ValueInvalid(self.msg or "expected a phone number", code="e164")
+            raise ValueInvalid(
+                self.msg, code="e164", translation_key="expected_phone_number"
+            )
 
         candidate = value.translate(_E164_SEPARATORS) if self.normalize else value
         digits = candidate[1:]
@@ -186,6 +198,8 @@ class E164(_SafeValidator):
             or digits[0] not in _NONZERO
             or not _DIGITS.issuperset(digits)
         ):
-            raise ValueInvalid(self.msg or "invalid phone number", code="e164")
+            raise ValueInvalid(
+                self.msg, code="e164", translation_key="invalid_phone_number"
+            )
 
         return candidate

--- a/src/probatio/validators/identifiers.py
+++ b/src/probatio/validators/identifiers.py
@@ -46,14 +46,14 @@ class ULID(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is a valid ULID, else raise ValueInvalid."""
         if not isinstance(value, str):
-            raise ValueInvalid(self.msg or "expected a ULID", code="ulid")
+            raise ValueInvalid(self.msg, code="ulid", translation_key="expected_ulid")
 
         # Check the length of the upper-cased form, not the input: ``str.upper`` can
         # change length for some Unicode (``"ß".upper() == "SS"``), so measuring the
         # input would let a 26-code-point string expand past 26 valid characters.
         candidate = value.upper()
         if len(candidate) != _ULID_LENGTH or not _ULID_CHARS.issuperset(candidate):
-            raise ValueInvalid(self.msg or "expected a ULID", code="ulid")
+            raise ValueInvalid(self.msg, code="ulid", translation_key="expected_ulid")
 
         return value
 
@@ -81,11 +81,14 @@ class UUID(_SafeValidator):
                 else uuid_module.UUID(str(value))
             )
         except (ValueError, TypeError) as exc:
-            raise UuidInvalid(self.msg or "expected a UUID") from exc
+            raise UuidInvalid(self.msg, translation_key="expected_uuid") from exc
 
         if self.version is not None and parsed.version != self.version:
-            message = self.msg or f"expected a version {self.version} UUID"
-            raise UuidInvalid(message)
+            raise UuidInvalid(
+                self.msg,
+                translation_key="expected_uuid_version",
+                placeholders={"version": self.version},
+            )
 
         return value
 
@@ -97,7 +100,7 @@ def _clean_mac(value: typing.Any, msg: str | None) -> str:
     a wrong grouping (``aabbc.cddee.ff``) is rejected, not silently stripped.
     """
     if not isinstance(value, str) or _MAC_RE.fullmatch(value) is None:
-        raise MacAddressInvalid(msg or "expected a MAC address")
+        raise MacAddressInvalid(msg, translation_key="expected_mac_address")
 
     return value.replace(":", "").replace("-", "").replace(".", "").lower()
 

--- a/src/probatio/validators/network.py
+++ b/src/probatio/validators/network.py
@@ -69,14 +69,14 @@ class IPv4Address(_SafeValidator):
             # The common case, matched directly: constructing an
             # ``ipaddress.IPv4Address`` costs several times the regex match.
             if _IPV4_PATTERN.fullmatch(value) is None:
-                raise IpInvalid(self.msg or "expected an IPv4 address")
+                raise IpInvalid(self.msg, translation_key="expected_ipv4")
             return value
         # Everything else (int, packed bytes, address objects, str subclasses)
         # keeps the parser's exact acceptance behavior.
         try:
             ipaddress.IPv4Address(_reject_bool(value))
         except _IP_PARSE_ERRORS as exc:
-            raise IpInvalid(self.msg or "expected an IPv4 address") from exc
+            raise IpInvalid(self.msg, translation_key="expected_ipv4") from exc
         return value
 
 
@@ -96,7 +96,7 @@ class IPv6Address(_SafeValidator):
         try:
             ipaddress.IPv6Address(_reject_bool(value))
         except _IP_PARSE_ERRORS as exc:
-            raise IpInvalid(self.msg or "expected an IPv6 address") from exc
+            raise IpInvalid(self.msg, translation_key="expected_ipv6") from exc
         return value
 
 
@@ -116,7 +116,7 @@ class IPAddress(_SafeValidator):
         try:
             ipaddress.ip_address(_reject_bool(value))
         except _IP_PARSE_ERRORS as exc:
-            raise IpInvalid(self.msg or "expected an IP address") from exc
+            raise IpInvalid(self.msg, translation_key="expected_ip") from exc
         return value
 
 
@@ -138,7 +138,7 @@ class IPNetwork(_SafeValidator):
         try:
             ipaddress.ip_network(_reject_bool(value), strict=False)
         except _IP_PARSE_ERRORS as exc:
-            raise IpInvalid(self.msg or "expected a CIDR network") from exc
+            raise IpInvalid(self.msg, translation_key="expected_cidr") from exc
         return value
 
 
@@ -170,11 +170,11 @@ class Hostname(_SafeValidator):
     def __call__(self, value: typing.Any) -> str:
         """Return the value if it is a valid hostname, else raise HostnameInvalid."""
         if not isinstance(value, str):
-            raise HostnameInvalid(self.msg or "expected a hostname")
+            raise HostnameInvalid(self.msg, translation_key="expected_hostname")
 
         host = value.removesuffix(".")
         if not host or len(host) > _MAX_HOSTNAME_LENGTH or not _check_labels(host):
-            raise HostnameInvalid(self.msg or "expected a hostname")
+            raise HostnameInvalid(self.msg, translation_key="expected_hostname")
 
         return value
 
@@ -193,7 +193,7 @@ class Fqdn(_SafeValidator):
     def __call__(self, value: typing.Any) -> str:
         """Return the value if it is a valid FQDN, else raise HostnameInvalid."""
         if not isinstance(value, str):
-            raise HostnameInvalid(self.msg or "expected a fully-qualified domain name")
+            raise HostnameInvalid(self.msg, translation_key="expected_fqdn")
 
         host = value.removesuffix(".")
         if (
@@ -202,7 +202,7 @@ class Fqdn(_SafeValidator):
             or "." not in host
             or not _check_labels(host)
         ):
-            raise HostnameInvalid(self.msg or "expected a fully-qualified domain name")
+            raise HostnameInvalid(self.msg, translation_key="expected_fqdn")
 
         return value
 
@@ -216,24 +216,22 @@ class Port(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> int:
         """Return the port as an int if in range, else raise RangeInvalid."""
-        message = self.msg or "expected a port number between 1 and 65535"
-
         # ``bool`` is an ``int`` subclass, but true and false are not port numbers.
         if isinstance(value, bool):
-            raise RangeInvalid(message)
+            raise RangeInvalid(self.msg, translation_key="expected_port")
 
         # Do not quietly turn 8080.7 into 8080.
         if isinstance(value, float) and not value.is_integer():
-            raise RangeInvalid(message)
+            raise RangeInvalid(self.msg, translation_key="expected_port")
 
         try:
             port = int(value)
         except Exception as exc:
             # ``int(float('inf'))`` raises OverflowError, and a value's ``__int__``
             # or ``__index__`` is user code that may raise anything; reject cleanly.
-            raise RangeInvalid(message) from exc
+            raise RangeInvalid(self.msg, translation_key="expected_port") from exc
 
         if not _MIN_PORT <= port <= _MAX_PORT:
-            raise RangeInvalid(message)
+            raise RangeInvalid(self.msg, translation_key="expected_port")
 
         return port

--- a/src/probatio/validators/predicates.py
+++ b/src/probatio/validators/predicates.py
@@ -49,14 +49,13 @@ class IsTrue(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is truthy, else raise TrueInvalid."""
-        message = self.msg or "value was not true"
         try:
             truthy = bool(value)
         except Exception as exc:
-            raise TrueInvalid(message) from exc
+            raise TrueInvalid(self.msg, translation_key="value_was_not_true") from exc
 
         if not truthy:
-            raise TrueInvalid(message)
+            raise TrueInvalid(self.msg, translation_key="value_was_not_true")
         return value
 
 
@@ -69,14 +68,13 @@ class IsFalse(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if it is falsy, else raise FalseInvalid."""
-        message = self.msg or "value was not false"
         try:
             truthy = bool(value)
         except Exception as exc:
-            raise FalseInvalid(message) from exc
+            raise FalseInvalid(self.msg, translation_key="value_was_not_false") from exc
 
         if truthy:
-            raise FalseInvalid(message)
+            raise FalseInvalid(self.msg, translation_key="value_was_not_false")
         return value
 
 
@@ -87,13 +85,16 @@ class _FilesystemCheck(_SafeValidator):
     messages voluptuous uses: ``default_msg`` for a value that fails the test
     (and which a custom message overrides), and ``empty_msg`` for a falsy or
     un-stringable value (which a custom message does not override, matching
-    voluptuous).
+    voluptuous). ``default_key``/``empty_key`` are the matching translation
+    keys in the message catalog.
     """
 
     test: typing.Callable[[str], bool]
     error: type[Invalid]
     default_msg: str
     empty_msg: str
+    default_key: str
+    empty_key: str
 
     def __init__(self, msg: str | None = None) -> None:
         """Store an optional custom message for the failing-test case."""
@@ -103,7 +104,7 @@ class _FilesystemCheck(_SafeValidator):
         """Return the value if the path test passes, else raise its error."""
         try:
             if not value:
-                raise self.error(self.empty_msg)
+                raise self.error(translation_key=self.empty_key)
             if type(self).test(str(value)):
                 return value
         except Invalid:
@@ -113,10 +114,9 @@ class _FilesystemCheck(_SafeValidator):
         except Exception as exc:
             # ValueError covers a path with an embedded NUL byte (os.stat raises);
             # the value's ``__bool__``/``__str__`` are user code and may raise anything.
-            raise self.error(self.empty_msg) from exc
+            raise self.error(translation_key=self.empty_key) from exc
 
-        message = self.msg or self.default_msg
-        raise self.error(message)
+        raise self.error(self.msg, translation_key=self.default_key)
 
 
 class IsDir(_FilesystemCheck):
@@ -126,6 +126,8 @@ class IsDir(_FilesystemCheck):
     error = DirInvalid
     default_msg = "Not a directory"
     empty_msg = "Not a directory"
+    default_key = "not_a_directory"
+    empty_key = "not_a_directory"
 
 
 class IsFile(_FilesystemCheck):
@@ -135,6 +137,8 @@ class IsFile(_FilesystemCheck):
     error = FileInvalid
     default_msg = "Not a file"
     empty_msg = "Not a file"
+    default_key = "not_a_file"
+    empty_key = "not_a_file"
 
 
 class PathExists(_FilesystemCheck):
@@ -144,6 +148,8 @@ class PathExists(_FilesystemCheck):
     error = PathInvalid
     default_msg = "path does not exist"
     empty_msg = "Not a Path"
+    default_key = "path_does_not_exist"
+    empty_key = "not_a_path"
 
 
 class IsSymlink(_FilesystemCheck):
@@ -153,6 +159,8 @@ class IsSymlink(_FilesystemCheck):
     error = SymlinkInvalid
     default_msg = "Not a symlink"
     empty_msg = "Not a symlink"
+    default_key = "not_a_symlink"
+    empty_key = "not_a_symlink"
 
 
 class IsSocket(_FilesystemCheck):
@@ -162,6 +170,8 @@ class IsSocket(_FilesystemCheck):
     error = SocketInvalid
     default_msg = "Not a socket"
     empty_msg = "Not a socket"
+    default_key = "not_a_socket"
+    empty_key = "not_a_socket"
 
 
 class IsFifo(_FilesystemCheck):
@@ -171,6 +181,8 @@ class IsFifo(_FilesystemCheck):
     error = FifoInvalid
     default_msg = "Not a FIFO"
     empty_msg = "Not a FIFO"
+    default_key = "not_a_fifo"
+    empty_key = "not_a_fifo"
 
 
 class IsBlockDevice(_FilesystemCheck):
@@ -180,3 +192,5 @@ class IsBlockDevice(_FilesystemCheck):
     error = BlockDeviceInvalid
     default_msg = "Not a block device"
     empty_msg = "Not a block device"
+    default_key = "not_a_block_device"
+    empty_key = "not_a_block_device"

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -53,6 +53,9 @@ class _CharacterClass(_SafeValidator):
 
     check: typing.Callable[[str], bool]
     message: str
+    # The catalog key matching ``message``; underscored so it does not shadow the
+    # error's ``translation_key`` property in readers' minds.
+    _translation_key: str
 
     def __init__(self, msg: str | None = None) -> None:
         """Store an optional custom message."""
@@ -62,7 +65,7 @@ class _CharacterClass(_SafeValidator):
         """Return the value if it is a string of the right class, else MatchInvalid."""
         if isinstance(value, str) and type(self).check(value):
             return value
-        raise MatchInvalid(self.msg or self.message)
+        raise MatchInvalid(self.msg, translation_key=self._translation_key)
 
 
 class Alpha(_CharacterClass):
@@ -70,6 +73,7 @@ class Alpha(_CharacterClass):
 
     check = staticmethod(_is_ascii_alpha)
     message = "expected only ASCII letters"
+    _translation_key = "expected_alpha"
 
 
 class Alphanumeric(_CharacterClass):
@@ -77,6 +81,7 @@ class Alphanumeric(_CharacterClass):
 
     check = staticmethod(_is_ascii_alnum)
     message = "expected only ASCII letters and digits"
+    _translation_key = "expected_alphanumeric"
 
 
 class ASCII(_CharacterClass):
@@ -84,6 +89,7 @@ class ASCII(_CharacterClass):
 
     check = staticmethod(str.isascii)
     message = "expected only ASCII characters"
+    _translation_key = "expected_ascii"
 
 
 class PrintableASCII(_CharacterClass):
@@ -91,6 +97,7 @@ class PrintableASCII(_CharacterClass):
 
     check = staticmethod(_is_printable_ascii)
     message = "expected only printable ASCII characters"
+    _translation_key = "expected_printable_ascii"
 
 
 class NoWhitespace(_CharacterClass):
@@ -98,6 +105,7 @@ class NoWhitespace(_CharacterClass):
 
     check = staticmethod(_has_no_whitespace)
     message = "expected no whitespace"
+    _translation_key = "expected_no_whitespace"
 
 
 class StartsWith(_SafeValidator):
@@ -112,7 +120,11 @@ class StartsWith(_SafeValidator):
         """Return the value if it starts with the prefix, else MatchInvalid."""
         if isinstance(value, str) and value.startswith(self.prefix):
             return value
-        raise MatchInvalid(self.msg or f"value must start with {self.prefix!r}")
+        raise MatchInvalid(
+            self.msg,
+            translation_key="value_must_start_with",
+            placeholders={"prefix": self.prefix},
+        )
 
 
 class EndsWith(_SafeValidator):
@@ -127,7 +139,11 @@ class EndsWith(_SafeValidator):
         """Return the value if it ends with the suffix, else MatchInvalid."""
         if isinstance(value, str) and value.endswith(self.suffix):
             return value
-        raise MatchInvalid(self.msg or f"value must end with {self.suffix!r}")
+        raise MatchInvalid(
+            self.msg,
+            translation_key="value_must_end_with",
+            placeholders={"suffix": self.suffix},
+        )
 
 
 class ByteLength(_SafeValidator):
@@ -151,7 +167,7 @@ class ByteLength(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Return the value if its UTF-8 byte length is in bounds, else raise."""
         if not isinstance(value, str):
-            raise LengthInvalid(self.msg or "expected a string")
+            raise LengthInvalid(self.msg, translation_key="expected_string")
 
         # ``surrogatepass`` so a lone surrogate (``'\ud800'``) is measured rather
         # than leaking a UnicodeEncodeError.
@@ -159,7 +175,7 @@ class ByteLength(_SafeValidator):
         if (self.min is not None and size < self.min) or (
             self.max is not None and size > self.max
         ):
-            raise LengthInvalid(self.msg or "byte length out of bounds")
+            raise LengthInvalid(self.msg, translation_key="byte_length_out_of_bounds")
 
         return value
 
@@ -179,7 +195,7 @@ class HexColor(_SafeValidator):
         """Return the value if it is a valid hex color, else raise MatchInvalid."""
         if isinstance(value, str) and _HEX_COLOR.match(value):
             return value
-        raise MatchInvalid(self.msg or "expected a hex color like #rrggbb")
+        raise MatchInvalid(self.msg, translation_key="expected_hex_color")
 
 
 class Match(_SafeValidator):
@@ -199,12 +215,10 @@ class Match(_SafeValidator):
         try:
             matched = self.pattern.match(value)
         except TypeError as exc:
-            message = self.msg or "expected a string"
-            raise MatchInvalid(message) from exc
+            raise MatchInvalid(self.msg, translation_key="expected_string") from exc
 
         if not matched:
-            message = self.msg or "does not match the expected pattern"
-            raise MatchInvalid(message)
+            raise MatchInvalid(self.msg, translation_key="does_not_match_pattern")
 
         return value
 
@@ -306,7 +320,7 @@ def Email(msg: str | None = None) -> typing.Callable[[typing.Any], str]:
     def validate(value: typing.Any) -> str:
         """Validate a basic email address with simple string checks."""
         if not isinstance(value, str) or value.count("@") != 1:
-            raise EmailInvalid(msg or "expected an email address")
+            raise EmailInvalid(msg, translation_key="expected_email_address")
 
         local, _, domain = value.partition("@")
         if (
@@ -314,7 +328,7 @@ def Email(msg: str | None = None) -> typing.Callable[[typing.Any], str]:
             or not _valid_email_local(local)
             or not _valid_email_domain(domain)
         ):
-            raise EmailInvalid(msg or "expected an email address")
+            raise EmailInvalid(msg, translation_key="expected_email_address")
 
         return value
 
@@ -329,15 +343,15 @@ def _validate_url(value: typing.Any, msg: str | None) -> typing.Any:
     # Only a string or bytes can be a URL; anything else makes ``urlparse`` leak
     # an AttributeError (it reaches for ``.decode``), so reject it up front.
     if not isinstance(value, str | bytes):
-        raise UrlInvalid(msg or "expected a URL")
+        raise UrlInvalid(msg, translation_key="expected_url")
 
     try:
         parsed = urlparse(value)
     except (ValueError, TypeError) as exc:
-        raise UrlInvalid(msg or "expected a URL") from exc
+        raise UrlInvalid(msg, translation_key="expected_url") from exc
 
     if not parsed.scheme or not parsed.netloc:
-        raise UrlInvalid(msg or "expected a URL")
+        raise UrlInvalid(msg, translation_key="expected_url")
 
     return value
 
@@ -372,7 +386,7 @@ def FqdnUrl(msg: str | None = None) -> typing.Callable[[typing.Any], str | bytes
         host = urlparse(value).hostname
         dot = b"." if isinstance(value, bytes) else "."
         if host is None or dot not in host:
-            raise UrlInvalid(msg or "expected a URL with a fully-qualified domain name")
+            raise UrlInvalid(msg, translation_key="expected_url_with_fqdn")
 
         return typing.cast("str | bytes", value)
 
@@ -397,8 +411,9 @@ class IsRegex(_SafeValidator):
         try:
             re.compile(value)
         except (re.error, TypeError) as exc:
-            message = self.msg or "expected a valid regular expression"
-            raise MatchInvalid(message) from exc
+            raise MatchInvalid(
+                self.msg, translation_key="expected_valid_regex"
+            ) from exc
         return value
 
 
@@ -425,7 +440,7 @@ class Slug(_SafeValidator):
             or value[-1] in "-_"
             or not _SLUG_CHARS.issuperset(value)
         ):
-            raise SlugInvalid(self.msg or "expected a slug")
+            raise SlugInvalid(self.msg, translation_key="expected_slug")
         return value
 
 
@@ -452,5 +467,4 @@ class Replace(_SafeValidator):
         try:
             return self.pattern.sub(self.substitution, value)
         except TypeError as exc:
-            message = self.msg or "expected a string"
-            raise MatchInvalid(message) from exc
+            raise MatchInvalid(self.msg, translation_key="expected_string") from exc

--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -34,11 +34,13 @@ class Sorted(_SafeValidator):
             in_order = list(value) == sorted(value)
         except Exception as exc:
             raise ValueInvalid(
-                self.msg or "value is not sorted", code="sorted"
+                self.msg, code="sorted", translation_key="value_not_sorted"
             ) from exc
 
         if not in_order:
-            raise ValueInvalid(self.msg or "value is not sorted", code="sorted")
+            raise ValueInvalid(
+                self.msg, code="sorted", translation_key="value_not_sorted"
+            )
 
         return value
 
@@ -63,8 +65,11 @@ class ExactSequence(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Validate each position, rebuilding the sequence of the same type."""
         if not isinstance(value, list | tuple) or len(value) != len(self._schemas):
-            message = self.msg or f"expected a sequence of {len(self._schemas)} items"
-            raise ExactSequenceInvalid(message)
+            raise ExactSequenceInvalid(
+                self.msg,
+                translation_key="expected_sequence_of_items",
+                placeholders={"count": len(self._schemas)},
+            )
 
         result = []
         errors: list[Invalid] = []
@@ -115,15 +120,21 @@ class Unique(_SafeValidator):
             try:
                 value = list(value)
             except Exception as exc:
-                message = self.msg or f"expected a collection: {exc}"
-                raise TypeInvalid(message) from exc
+                raise TypeInvalid(
+                    self.msg,
+                    translation_key="expected_collection",
+                    placeholders={"detail": str(exc)},
+                ) from exc
             length = len(value)
 
         try:
             unique = set(value)
         except Exception as exc:
-            message = self.msg or f"contains unhashable elements: {exc}"
-            raise TypeInvalid(message) from exc
+            raise TypeInvalid(
+                self.msg,
+                translation_key="contains_unhashable_elements",
+                placeholders={"detail": str(exc)},
+            ) from exc
 
         if len(unique) != length:
             seen: set[typing.Any] = set()
@@ -133,8 +144,11 @@ class Unique(_SafeValidator):
                     duplicates.add(item)
                 else:
                     seen.add(item)
-            message = self.msg or f"contains duplicate items: {list(duplicates)}"
-            raise Invalid(message)
+            raise Invalid(
+                self.msg,
+                translation_key="contains_duplicate_items",
+                placeholders={"items": list(duplicates)},
+            )
 
         return value
 
@@ -156,8 +170,11 @@ class Set(_SafeValidator):
         try:
             return set(value)
         except Exception as exc:
-            message = self.msg or f"cannot be converted to a set: {exc}"
-            raise TypeInvalid(message) from exc
+            raise TypeInvalid(
+                self.msg,
+                translation_key="cannot_convert_to_set",
+                placeholders={"detail": str(exc)},
+            ) from exc
 
 
 class Unordered(_SafeValidator):
@@ -187,14 +204,20 @@ class Unordered(_SafeValidator):
     def __call__(self, value: typing.Any) -> typing.Any:
         """Match each item to an unused validator, in any order."""
         if not isinstance(value, list | tuple):
-            message = self.msg or f"Value {value} is not sequence!"
-            raise Invalid(message)
-        if len(value) != len(self._schemas):
-            message = self.msg or (
-                f"List lengths differ, value:{len(value)} "
-                f"!= target:{len(self._schemas)}"
+            raise Invalid(
+                self.msg,
+                translation_key="not_a_sequence_value",
+                placeholders={"value": value},
             )
-            raise Invalid(message)
+        if len(value) != len(self._schemas):
+            raise Invalid(
+                self.msg,
+                translation_key="list_lengths_differ",
+                placeholders={
+                    "value_length": len(value),
+                    "target_length": len(self._schemas),
+                },
+            )
 
         consumed: set[int] = set()
         missing: list[tuple[int, typing.Any]] = []
@@ -204,19 +227,18 @@ class Unordered(_SafeValidator):
 
         if len(missing) == 1:
             position, item = missing[0]
-            message = self.msg or (
-                f"Element #{position} ({item}) is not valid against any validator"
+            raise Invalid(
+                self.msg,
+                translation_key="element_not_valid",
+                placeholders={"position": position, "item": item},
             )
-            raise Invalid(message)
         if missing:
             raise MultipleInvalid(
                 [
                     Invalid(
-                        self.msg
-                        or (
-                            f"Element #{position} ({item}) is not valid "
-                            "against any validator"
-                        ),
+                        self.msg,
+                        translation_key="element_not_valid",
+                        placeholders={"position": position, "item": item},
                     )
                     for position, item in missing
                 ],

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -33,10 +33,6 @@ from probatio.validators._base import _SafeValidator
 # A colon duration has hours:minutes or hours:minutes:seconds.
 _DURATION_PARTS = (2, 3)
 _MAX_CLOCK_FIELD = 59  # the minute and second fields of an H:MM:SS duration
-_DURATION_MSG = (
-    "expected a duration like H:MM, H:MM:SS, an ISO 8601 duration like PT1H30M, "
-    "or a number of seconds"
-)
 
 # An ISO 8601 duration, limited to the fields a ``timedelta`` can represent: weeks
 # and days, then a time part of hours, minutes, and seconds. Each field is optional
@@ -60,17 +56,24 @@ _ISO8601_DURATION = re.compile(
 # A fixed UTC offset: a sign, two-digit hours, optional colon, two-digit minutes.
 # Matched in full, no backtracking, so a crafted string cannot make it hang.
 _UTC_OFFSET = re.compile(r"[+-]\d{2}:?\d{2}")
-_TZ_OFFSET_MSG = "expected a UTC offset like +01:00, Z, or UTC"
 
 # How many epoch sub-units make one second, per accepted ``FromEpoch`` unit.
 _EPOCH_DIVISORS = {"seconds": 1, "milliseconds": 1000}
 
 
-def _format_message(kind: str, fmt: str | None) -> str:
-    """Build the parse-failure message for an ``As*`` validator."""
+def _format_key(
+    iso_key: str,
+    fmt: str | None,
+) -> tuple[str, dict[str, typing.Any] | None]:
+    """Pick the parse-failure translation key for an ``As*`` validator.
+
+    Without a format, the failure is the ISO 8601 sentence for the validator's
+    kind (``iso_key``); with one, it is the shared format-mismatch sentence with
+    the format as a placeholder.
+    """
     if fmt is None:
-        return f"expected an ISO 8601 {kind}"
-    return f"value does not match expected format {fmt}"
+        return iso_key, None
+    return "value_does_not_match_format", {"format": fmt}
 
 
 def _iso_field(raw: str | None) -> float:
@@ -101,8 +104,11 @@ class Datetime(_SafeValidator):
         try:
             datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
         except (TypeError, ValueError) as exc:
-            message = self.msg or f"value does not match expected format {self.format}"
-            raise DatetimeInvalid(message) from exc
+            raise DatetimeInvalid(
+                self.msg,
+                translation_key="value_does_not_match_format",
+                placeholders={"format": self.format},
+            ) from exc
         return value
 
 
@@ -116,8 +122,11 @@ class Date(Datetime):
         try:
             datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
         except (TypeError, ValueError) as exc:
-            message = self.msg or f"value does not match expected format {self.format}"
-            raise DateInvalid(message) from exc
+            raise DateInvalid(
+                self.msg,
+                translation_key="value_does_not_match_format",
+                placeholders={"format": self.format},
+            ) from exc
         return value
 
 
@@ -135,8 +144,11 @@ class Time(Datetime):
         try:
             datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
         except (TypeError, ValueError) as exc:
-            message = self.msg or f"value does not match expected format {self.format}"
-            raise TimeInvalid(message) from exc
+            raise TimeInvalid(
+                self.msg,
+                translation_key="value_does_not_match_format",
+                placeholders={"format": self.format},
+            ) from exc
         return value
 
 
@@ -189,11 +201,18 @@ class AsDatetime(_SafeValidator):
                 else:
                     parsed = datetime.datetime.strptime(value, self.format)  # noqa: DTZ007
             except (TypeError, ValueError) as exc:
-                message = self.msg or _format_message("datetime", self.format)
-                raise DatetimeInvalid(message) from exc
+                key, placeholders = _format_key("expected_iso_datetime", self.format)
+                raise DatetimeInvalid(
+                    self.msg,
+                    translation_key=key,
+                    placeholders=placeholders,
+                ) from exc
 
         if self.require_timezone and parsed.tzinfo is None:
-            raise DatetimeInvalid(self.msg or "expected a timezone-aware datetime")
+            raise DatetimeInvalid(
+                self.msg,
+                translation_key="expected_timezone_aware_datetime",
+            )
 
         return parsed
 
@@ -231,8 +250,12 @@ class AsDate(_SafeValidator):
                 return datetime.date.fromisoformat(value)
             return datetime.datetime.strptime(value, self.format).date()  # noqa: DTZ007
         except (TypeError, ValueError) as exc:
-            message = self.msg or _format_message("date", self.format)
-            raise DateInvalid(message) from exc
+            key, placeholders = _format_key("expected_iso_date", self.format)
+            raise DateInvalid(
+                self.msg,
+                translation_key=key,
+                placeholders=placeholders,
+            ) from exc
 
 
 class AsTime(_SafeValidator):
@@ -265,8 +288,12 @@ class AsTime(_SafeValidator):
                 return datetime.time.fromisoformat(value)
             return datetime.datetime.strptime(value, self.format).time()  # noqa: DTZ007
         except (TypeError, ValueError) as exc:
-            message = self.msg or _format_message("time", self.format)
-            raise TimeInvalid(message) from exc
+            key, placeholders = _format_key("expected_iso_time", self.format)
+            raise TimeInvalid(
+                self.msg,
+                translation_key=key,
+                placeholders=placeholders,
+            ) from exc
 
 
 class AsTimedelta(_SafeValidator):
@@ -293,14 +320,16 @@ class AsTimedelta(_SafeValidator):
 
         if isinstance(value, bool):
             # ``bool`` is an ``int`` subclass, but true and false are not durations.
-            raise DurationInvalid(self.msg or "expected a duration")
+            raise DurationInvalid(self.msg, translation_key="expected_duration")
 
         if isinstance(value, int | float):
             try:
                 return datetime.timedelta(seconds=value)
             except (OverflowError, ValueError) as exc:
                 # A huge value overflows; ``float('nan')`` raises ValueError.
-                raise DurationInvalid(self.msg or "expected a duration") from exc
+                raise DurationInvalid(
+                    self.msg, translation_key="expected_duration"
+                ) from exc
 
         if isinstance(value, str):
             return self._parse_string(value)
@@ -309,9 +338,11 @@ class AsTimedelta(_SafeValidator):
             try:
                 return datetime.timedelta(**value)
             except (TypeError, ValueError, OverflowError) as exc:
-                raise DurationInvalid(self.msg or "expected a duration") from exc
+                raise DurationInvalid(
+                    self.msg, translation_key="expected_duration"
+                ) from exc
 
-        raise DurationInvalid(self.msg or "expected a duration")
+        raise DurationInvalid(self.msg, translation_key="expected_duration")
 
     def _parse_string(self, value: str) -> datetime.timedelta:
         """Parse an ISO 8601, ``H:MM`` / ``H:MM:SS`` colon, or seconds string.
@@ -338,14 +369,18 @@ class AsTimedelta(_SafeValidator):
 
         parts = text.split(":")
         if len(parts) not in _DURATION_PARTS or not all(p.isdigit() for p in parts):
-            raise DurationInvalid(self.msg or _DURATION_MSG)
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            )
         hours, minutes, *rest = (int(part) for part in parts)
         seconds = rest[0] if rest else 0
 
         # In clock-style input, minutes and seconds stay in their usual range.
         # Hours remain unbounded because durations can be longer than a day.
         if minutes > _MAX_CLOCK_FIELD or seconds > _MAX_CLOCK_FIELD:
-            raise DurationInvalid(self.msg or _DURATION_MSG)
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            )
 
         try:
             return sign * datetime.timedelta(
@@ -354,7 +389,9 @@ class AsTimedelta(_SafeValidator):
                 seconds=seconds,
             )
         except OverflowError as exc:
-            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            ) from exc
 
     def _seconds(self, text: str) -> datetime.timedelta:
         """Read a bare number of seconds (``"90"``, ``"90.5"``) as a timedelta."""
@@ -363,7 +400,9 @@ class AsTimedelta(_SafeValidator):
         except (ValueError, OverflowError) as exc:
             # ``float("abc")`` and an empty string raise ValueError; ``"inf"`` or a
             # huge value overflows timedelta; ``"nan"`` raises ValueError there.
-            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            ) from exc
 
     def _parse_iso8601(self, body: str) -> datetime.timedelta:
         """Coerce an ISO 8601 duration body (``"P..."``) to a ``timedelta``.
@@ -374,13 +413,17 @@ class AsTimedelta(_SafeValidator):
         """
         match = _ISO8601_DURATION.fullmatch(body)
         if match is None:
-            raise DurationInvalid(self.msg or _DURATION_MSG)
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            )
 
         fields = match.groupdict()
         has_time = fields["hours"] or fields["minutes"] or fields["seconds"]
         if not any(fields.values()) or ("T" in body and not has_time):
             # ``P`` alone carries nothing; ``P1DT`` has a time separator but no field.
-            raise DurationInvalid(self.msg or _DURATION_MSG)
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            )
 
         try:
             return datetime.timedelta(
@@ -391,7 +434,9 @@ class AsTimedelta(_SafeValidator):
                 seconds=_iso_field(fields["seconds"]),
             )
         except (ValueError, OverflowError) as exc:
-            raise DurationInvalid(self.msg or _DURATION_MSG) from exc
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            ) from exc
 
 
 class Duration(_SafeValidator):
@@ -435,7 +480,9 @@ class TimeZoneInfo(_SafeValidator):
         except (KeyError, ValueError, TypeError, RuntimeError) as exc:
             # ZoneInfoNotFoundError is a KeyError; a bad path is a ValueError; a
             # non-string is a TypeError; a tuple trips the weak-cache RuntimeError.
-            raise TimeZoneInvalid(self.msg or "expected an IANA time zone") from exc
+            raise TimeZoneInvalid(
+                self.msg, translation_key="expected_iana_time_zone"
+            ) from exc
         return value
 
 
@@ -457,7 +504,7 @@ class AsTimezone(_SafeValidator):
         if isinstance(value, datetime.timezone):
             return value
         if not isinstance(value, str):
-            raise TimeZoneInvalid(self.msg or _TZ_OFFSET_MSG)
+            raise TimeZoneInvalid(self.msg, translation_key="expected_utc_offset")
 
         # ``Z`` and ``UTC`` name the zero offset; otherwise the value must be a signed
         # ``HH:MM``/``HHMM`` offset. Parsed by hand, not ``strptime("%z")``, whose
@@ -465,7 +512,7 @@ class AsTimezone(_SafeValidator):
         if value.upper() in ("Z", "UTC"):
             return datetime.UTC
         if not _UTC_OFFSET.fullmatch(value):
-            raise TimeZoneInvalid(self.msg or _TZ_OFFSET_MSG)
+            raise TimeZoneInvalid(self.msg, translation_key="expected_utc_offset")
 
         sign = -1 if value[0] == "-" else 1
         digits = value[1:].replace(":", "")
@@ -477,7 +524,9 @@ class AsTimezone(_SafeValidator):
             return datetime.timezone(offset)
         except ValueError as exc:
             # An offset of 24 hours or more is out of range for ``datetime.timezone``.
-            raise TimeZoneInvalid(self.msg or _TZ_OFFSET_MSG) from exc
+            raise TimeZoneInvalid(
+                self.msg, translation_key="expected_utc_offset"
+            ) from exc
 
 
 class TimeZone(_SafeValidator):
@@ -525,7 +574,7 @@ class FromEpoch(_SafeValidator):
     def __call__(self, value: typing.Any) -> datetime.datetime:
         """Return the timestamp as an aware UTC datetime, else raise EpochInvalid."""
         if isinstance(value, bool) or not isinstance(value, int | float):
-            raise EpochInvalid(self.msg or "expected a Unix timestamp")
+            raise EpochInvalid(self.msg, translation_key="expected_unix_timestamp")
 
         try:
             seconds = value / _EPOCH_DIVISORS[self.unit]
@@ -533,4 +582,6 @@ class FromEpoch(_SafeValidator):
         except (OverflowError, OSError, ValueError) as exc:
             # A huge value overflows (OverflowError/OSError); ``float('nan')`` and
             # ``float('inf')`` raise ValueError/OverflowError out of fromtimestamp.
-            raise EpochInvalid(self.msg or "expected a Unix timestamp") from exc
+            raise EpochInvalid(
+                self.msg, translation_key="expected_unix_timestamp"
+            ) from exc

--- a/src/probatio/validators/transition.py
+++ b/src/probatio/validators/transition.py
@@ -68,8 +68,12 @@ class Immutable(_SafeValidator):
                     and field in value
                     and _changed(previous[field], value[field])
                 ):
-                    message = self.msg or f"{field!r} cannot be changed"
-                    raise ImmutableInvalid(message, path=[field])
+                    raise ImmutableInvalid(
+                        self.msg,
+                        path=[field],
+                        translation_key="cannot_be_changed",
+                        placeholders={"field": field},
+                    )
 
         return value
 
@@ -96,7 +100,11 @@ class WriteOnce(_SafeValidator):
             for field in self.fields:
                 old = previous.get(field)
                 if old is not None and field in value and _changed(old, value[field]):
-                    message = self.msg or f"{field!r} is write-once and already set"
-                    raise ImmutableInvalid(message, path=[field])
+                    raise ImmutableInvalid(
+                        self.msg,
+                        path=[field],
+                        translation_key="write_once_already_set",
+                        placeholders={"field": field},
+                    )
 
         return value

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -1358,6 +1358,29 @@ def test_post_init_valueerror_becomes_value_invalid(extra: int | None) -> None:
     assert schema({"weight": 1.0}).weight == 1.0
 
 
+@dataclass
+class _SilentGuard:
+    """A dataclass whose __post_init__ raises a bare, message-less ValueError."""
+
+    weight: float
+
+    def __post_init__(self) -> None:
+        if self.weight < 0:
+            raise ValueError
+
+
+def test_post_init_bare_valueerror_reports_generic_message() -> None:
+    """A message-less ValueError from __post_init__ reads 'not a valid value'."""
+    schema = DataclassSchema(_SilentGuard)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"weight": -1.0})
+
+    (error,) = caught.value.errors
+    assert error.msg == "not a valid value"
+    assert error.translation_key == "not_a_valid_value"
+
+
 @pytest.mark.parametrize("extra", [None, ALLOW_EXTRA])
 def test_post_init_invalid_is_wrapped_not_normalized(extra: int | None) -> None:
     """An Invalid raised by __post_init__ surfaces as itself, wrapped once."""

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 import probatio
+from probatio import _messages
 from probatio.error import (
     Error,
     Invalid,
@@ -281,3 +282,59 @@ def test_normal_path_segment_is_not_truncated() -> None:
     """An ordinary key renders in full, with no truncation."""
     err = Invalid("bad", path=["port"])
     assert str(err) == "bad at 'port'"
+
+
+def test_deferred_message_renders_from_the_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no message and a translation_key, the text renders from the catalog."""
+    monkeypatch.setitem(_messages.CATALOG, "test_min", "value must be at least {min}")
+    err = Invalid(translation_key="test_min", placeholders={"min": 10}, path=["n"])
+    assert err.msg == "value must be at least 10"
+    assert err.error_message == "value must be at least 10"
+    assert str(err) == "value must be at least 10 at 'n'"
+    assert err.translation_key == "test_min"
+    assert err.placeholders == {"min": 10}
+
+
+def test_deferred_message_is_rendered_once_and_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first read renders and caches; later catalog changes do not show."""
+    monkeypatch.setitem(_messages.CATALOG, "test_key", "first")
+    err = Invalid(translation_key="test_key")
+    assert err.msg == "first"
+    monkeypatch.setitem(_messages.CATALOG, "test_key", "second")
+    assert err.msg == "first"
+    assert err.args == ("first",)
+
+
+def test_deferred_message_without_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template with no placeholders renders as-is."""
+    monkeypatch.setitem(_messages.CATALOG, "test_plain", "value is not allowed")
+    err = Invalid(translation_key="test_plain")
+    assert err.error_message == "value is not allowed"
+
+
+def test_explicit_message_wins_over_the_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A custom message keeps its text; the key still rides along."""
+    monkeypatch.setitem(_messages.CATALOG, "test_min", "value must be at least {min}")
+    err = Invalid(
+        "own words",
+        translation_key="test_min",
+        placeholders={"min": 10},
+    )
+    assert err.msg == "own words"
+    assert err.error_message == "own words"
+    assert err.translation_key == "test_min"
+
+
+def test_invalid_without_message_or_key_is_empty() -> None:
+    """Neither a message nor a key renders as an empty message."""
+    err = Invalid()
+    assert err.msg == ""
+    assert str(err) == ""

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,75 @@
+"""Tests for the English message catalog."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from string import Formatter
+
+import pytest
+
+from probatio import MultipleInvalid, Schema
+from probatio._messages import CATALOG, render
+
+_DOCS_TABLE = (
+    Path(__file__).parent.parent
+    / "docs"
+    / "src"
+    / "content"
+    / "docs"
+    / "reference"
+    / "translation-keys.md"
+)
+
+
+def test_every_template_is_well_formed() -> None:
+    """Every catalog template parses as a str.format template."""
+    formatter = Formatter()
+    for key, template in CATALOG.items():
+        # parse() raises ValueError on a malformed template.
+        assert list(formatter.parse(template)), key
+
+
+def test_keys_are_snake_case() -> None:
+    """Every translation key is a stable snake_case identifier."""
+    for key in CATALOG:
+        assert re.fullmatch(r"[a-z][a-z0-9_]*", key), key
+
+
+def test_render_formats_placeholders() -> None:
+    """render interpolates placeholders into the template."""
+    assert render("length_min", {"min": 10}) == "length of value must be at least 10"
+
+
+def test_render_without_placeholders_returns_the_template() -> None:
+    """render returns the bare template when there is nothing to interpolate."""
+    assert render("required", None) == "required key not provided"
+
+
+def test_docs_reference_mirrors_the_catalog() -> None:
+    """The translation-keys reference page lists exactly the catalog, verbatim.
+
+    The keys are public API; this pins the documentation to the source of
+    truth, so adding, renaming, or rewording a key without updating the docs
+    fails here instead of shipping drift.
+    """
+    documented: dict[str, str] = {}
+    for line in _DOCS_TABLE.read_text().splitlines():
+        match = re.fullmatch(r"\| `([a-z0-9_]+)` \| `(.*)` \|", line)
+        if match:
+            documented[match.group(1)] = match.group(2).replace("\\|", "|")
+
+    assert documented == CATALOG
+
+
+def test_suggestion_suffix_renders_from_the_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The did-you-mean fragment comes from the catalog, so locales can swap it."""
+    monkeypatch.setitem(CATALOG, "did_you_mean", ", bedoelde je {candidates}?")
+    schema = Schema({"name": str})
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"nmae": "x"})
+    error = caught.value.errors[0]
+    assert error.error_message == "not a valid option, bedoelde je 'name'?"
+    assert error.context["candidates"] == ["name"]

--- a/tests/validators/test_decorators.py
+++ b/tests/validators/test_decorators.py
@@ -141,6 +141,21 @@ def test_message_builds_a_validator_with_a_default_message() -> None:
     assert str(caught.value.errors[0]) == "not an integer"
 
 
+def test_message_without_a_default_falls_back_to_invalid_value() -> None:
+    """A message factory with no default reads 'invalid value', from the catalog."""
+
+    @message()
+    def isint(value: object) -> int:
+        return int(value)  # type: ignore[call-overload]
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(isint())("nope")
+
+    error = caught.value.errors[0]
+    assert str(error) == "invalid value"
+    assert error.translation_key == "invalid_value"
+
+
 def test_message_allows_per_use_overrides() -> None:
     """The message and the error class can be overridden when the factory is called."""
 


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None in rendered output: every default English message is byte-identical to before (the untouched existing test suite is the proof). Two behavioral notes that are additive or edge-case only: `Invalid` now accepts being constructed without a message (deferred rendering from the catalog), and `Invalid` takes ownership of the `context` and `placeholders` dicts instead of copying them (documented in the docstring; pass a fresh dict, which every built-in raise site already does).

## Proposed change

Implements ADR-015 phases 1 and 2, the follow-up to #127. Every built-in raise site now carries a stable `translation_key` naming its exact sentence, plus `placeholders`, the raw values that sentence interpolates. `LengthInvalid` carries `translation_key="length_min"`, `placeholders={"min": 10}`, not just the finished string. With that, `as_dict()` is a complete wire format and a consumer (Home Assistant's frontend, a JSON API, a CLI) renders errors in its own words or language without parsing strings.

- The English text lives in one catalog, `probatio._messages` (123 entries, one per distinct sentence; duplicate sentences across validators share a key, so one translation covers both). Messages render lazily on the first read of `msg` / `error_message` / `str(error)`, so an error built and discarded inside a combinator branch never pays for string formatting. A custom `msg=` wins on text, with the key riding along.
- The "did you mean ...?" fragment renders from the catalog too (`did_you_mean`), and the raw close matches stay machine-readable on `context["candidates"]`, so a key-based renderer can compose its own suggestion text. The new guide section "Suggestions compose on top" documents that contract with a worked example.
- The keys are public API: a new reference page lists every key and its English template, pinned to the catalog by a drift-guard test so the docs cannot silently diverge.
- ADR-015 is sharpened to the decision taken here: one catalog, English only. Probatio ships no locale mechanism and no bundled translations; `translation_key` plus `placeholders` is the complete contract a consumer localizes against.

Two implementation notes for reviewers:

- A deferred error still carries one `args` entry (`None`). Raise-and-discard loops with empty-args exceptions segfault CPython 3.13.13 under pytest-codspeed's native walltime hooks (reproduced in roughly half the runs of the any-miss benchmark, clean without instrumentation and clean in plain Python over millions of iterations). The sentinel is load-bearing; the code comment says so.
- Error-path cost, measured interleaved: `config_reject` goes from ~80ns to ~88ns, about 4ns per error, the price of building the placeholders dict at raise time (part of it was clawed back by removing the defensive `context`/`placeholders` copies). `any_miss` is unchanged. CodSpeed will show this; it is the deliberate cost of every error carrying its structured data.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR is related to: #127 and ADR-015

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
