### PR TITLE
Run a full documentation round: accuracy, the performance story, three new pages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,6 +48,17 @@ Or run the full gate at once:
 uv run --no-sync just check
 ```
 
+## Working on the documentation
+
+The documentation checks itself: every Python block in `docs/` is executed in
+CI and its output comments are compared against what the code really produces.
+If you touch a page with code on it, run the harness before opening a pull
+request:
+
+```shell
+uv run --no-sync just examples
+```
+
 ## Pull request process
 
 1. Search our repository for open or closed [pull requests][prs] that relate

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ that carry a path and suggest the key you meant), and it is held to the bar you
 would want from a library that loads untrusted config. See
 [Why trust it](#why-trust-it).
 
-Probatio is pure Python: no compiler, no build step, no native extension.
+It is also fast for pure Python: roughly two to three times voluptuous's speed
+on a representative config schema, and about seven times once a schema compiles
+itself. The numbers, and how to reproduce them, are in the
+[performance reference][docs-performance].
+
+Probatio is pure Python: no native extension, nothing to build at install time.
 Install it and import it. Requires Python 3.12 or newer.
 
 ## Installation
@@ -69,18 +74,19 @@ schema({"name": "app"})
 # {'name': 'app', 'port': 8080}
 ```
 
-When a value does not match, the error carries a path to the offending value:
+When a value does not match, the error carries a path to the offending value,
+however deep it sits:
 
 ```python
 from probatio import Schema, Invalid
 
-schema = Schema({"port": int})
+schema = Schema({"server": {"port": int}})
 
 try:
-    schema({"port": "nope"})
+    schema({"server": {"port": "nope"}})
 except Invalid as err:
     print(err)
-    # expected int at 'port'
+    # expected int at 'server.port'
 ```
 
 ## Why trust it
@@ -208,6 +214,7 @@ SOFTWARE.
 [issues]: https://github.com/frenck/probatio/issues
 [security]: https://github.com/frenck/probatio/blob/main/.github/SECURITY.md
 [docs-migrating]: https://probatio.frenck.dev/getting-started/migrating-from-voluptuous/
+[docs-performance]: https://probatio.frenck.dev/reference/performance/
 [docs]: https://probatio.frenck.dev
 [frenck]: https://github.com/frenck
 [keepchangelog]: http://keepachangelog.com/en/1.0.0/

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,9 +23,19 @@ docs/
 │       ├── index.mdx             # landing page
 │       ├── getting-started/      # install, quick start, migrating from voluptuous
 │       ├── guides/               # dict schemas, combinators, codecs, …
-│       ├── recipes/              # config files, Home Assistant, cookbook
+│       ├── recipes/              # Home Assistant, config files, APIs, LLM tools, …
 │       ├── reference/            # API reference, errors, typing, performance
 │       └── project/              # architecture, roadmap, security, credits
 ```
 
 The site is served at `https://probatio.frenck.dev` (set in `astro.config.mjs`).
+
+## Verified examples
+
+Every Python block in the pages is executed by `verify_examples.py`, and the
+output comments are checked against what the code really produces. Run it from
+the repository root when you change a page with code on it:
+
+```bash
+uv run --no-sync just examples
+```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -99,6 +99,7 @@ export default defineConfig({
               label: "Dict schemas and markers",
               slug: "guides/dict-schemas-and-markers",
             },
+            { label: "Sequence schemas", slug: "guides/sequence-schemas" },
             { label: "Combinators", slug: "guides/combinators" },
             { label: "Built-in validators", slug: "guides/validators" },
             { label: "Error handling", slug: "guides/error-handling" },
@@ -134,6 +135,8 @@ export default defineConfig({
           items: [
             { label: "Home Assistant", slug: "recipes/home-assistant" },
             { label: "Validating a config file", slug: "recipes/config-file" },
+            { label: "Validating API requests", slug: "recipes/web-api" },
+            { label: "LLM tool calling and MCP", slug: "recipes/llm-tools" },
             { label: "Cookbook", slug: "recipes/cookbook" },
           ],
         },

--- a/docs/src/content/docs/getting-started/compatibility.md
+++ b/docs/src/content/docs/getting-started/compatibility.md
@@ -83,16 +83,18 @@ is a deliberate improvement over a sharp edge:
 - Built-in validators never leak a raw exception on a wrong-typed value:
   `Replace("a", "b")(42)` raises `MatchInvalid` rather than the `TypeError` from
   `re.sub`, and `Number()` on `None`/`dict`/`set`/`bytes`/an empty sequence
-  raises `Invalid`. voluptuous fixes the same edges upstream in [PR #540](https://github.com/alecthomas/voluptuous/pull/540) and #539.
+  raises `Invalid`. voluptuous fixes the same edges upstream in [PR #540](https://github.com/alecthomas/voluptuous/pull/540) and
+  [PR #539](https://github.com/alecthomas/voluptuous/pull/539).
 - `extend` accepts another `Schema`, merging its keys and preserving its
   `required` intent (its `extra` must match the result's). voluptuous 0.16.0
   raises an `AssertionError`; it is added upstream in [PR #538](https://github.com/alecthomas/voluptuous/pull/538).
 - Validating a list reports every failing item, each with its index, where
-  voluptuous 0.16.0 stops at the first failing nested item (open request, issue
-  #171). The diagnostics are more complete; error-iterating code is unaffected.
+  voluptuous 0.16.0 stops at the first failing nested item (open request,
+  [issue #171](https://github.com/alecthomas/voluptuous/issues/171)). The
+  diagnostics are more complete; error-iterating code is unaffected.
 - A set schema (`{Coerce(int)}`) transforms its elements like a list schema does,
-  so a `Coerce` coerces. voluptuous returns the set untransformed (bug, issue
-  #400).
+  so a `Coerce` coerces. voluptuous returns the set untransformed (bug,
+  [issue #400](https://github.com/alecthomas/voluptuous/issues/400)).
 - A failing `Any` with concrete branches lists them ("expected int or str or
   None") as `AnyInvalid`, where voluptuous reports only the first branch or "not
   a valid value" ([issue #412](https://github.com/alecthomas/voluptuous/issues/412)). A validator branch keeps surfacing its own error.
@@ -101,19 +103,25 @@ Where Probatio diverges, it tells you with a normal error, not a crash.
 
 ## How compatibility is checked
 
-Two things keep Probatio honest, and neither is a claim you have to take on
-faith.
+The drop-in claim is tested, not asserted. voluptuous 0.16.0 is pinned as a
+dev-only oracle in Probatio's development dependencies (no code is copied from
+it), and three layers of evidence back the claim:
 
-First, differential tests. Probatio and voluptuous run the same schemas against
-the same inputs, and their results are compared. Voluptuous is the oracle: a
-divergence is treated as a Probatio bug unless it is one of the documented
-deviations above. The comparison is driven by generated schemas and data, so it
-covers more than a hand-written suite would.
-
-Second, a real-world proof. Home Assistant's own `config_validation` test suite
-runs against Probatio through the compatibility shim, and it passes. That suite
-exercises voluptuous hard across a large, real configuration surface, so it is a
-strong signal that the drop-in promise holds in practice.
+- **voluptuous's own test suite runs against Probatio.** Through the shim,
+  upstream `tests.py` at 0.16.0 imports Probatio instead of voluptuous. A clean
+  run is all green: every divergence is one of the documented deviations above,
+  marked as expected with a reason, so any new break shows up loudly. This is
+  voluptuous's own authors' notion of the contract, checked.
+- **Differential tests in Probatio's suite** (`tests/test_conformance.py`,
+  `tests/test_fidelity.py`, `tests/test_v0_16.py`). The same schemas and inputs
+  run through both libraries and the results are compared: the same accepted or
+  normalized value, the same error paths, and the same bare error messages
+  where downstream code string-matches them. A divergence is treated as a
+  Probatio bug unless it is one of the documented deviations above.
+- **Home Assistant's `config_validation` test suite passes** with voluptuous
+  swapped out for Probatio through the shim. That suite exercises voluptuous
+  hard across a large, real configuration surface, so it is a strong signal
+  that the drop-in promise holds in practice.
 
 ## Where to next
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -5,8 +5,9 @@ description: Install Probatio, the Python versions it supports, and the optional
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Probatio is pure Python. There is nothing to compile, no build step, and no
-native extension to match against your platform. Install it and import it.
+Probatio is pure Python, and the core has zero runtime dependencies. There is
+nothing to compile, no build step, and no native extension to match against
+your platform. Install it and import it.
 
 ## Install
 
@@ -84,8 +85,8 @@ poetry add "probatio[yaml,toml]"
 </Tabs>
 
 :::note
-The extras are about speed and YAML writing, not features. A schema validates
-the same way with or without them.
+The extras are about speed and YAML support, not validation features. A schema
+validates the same way with or without them.
 :::
 
 ## Confirm it works

--- a/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
+++ b/docs/src/content/docs/getting-started/migrating-from-voluptuous.md
@@ -56,75 +56,51 @@ behavior and the same signatures (including positional `required`/`extra` on
   the error path, and `humanize_error` / `validate_with_humanized_errors` in
   `probatio.humanize`.
 
-Imports that reach into voluptuous submodules keep working too: `voluptuous`,
-`voluptuous.error`, `voluptuous.validators`, `voluptuous.humanize`,
-`voluptuous.util`, and `voluptuous.schema_builder` all have Probatio equivalents.
+Probatio ships three submodules you can import from directly: `probatio.error`,
+`probatio.validators`, and `probatio.humanize`. Deeper `voluptuous.*` imports,
+including `voluptuous.util` and `voluptuous.schema_builder`, are covered by the
+[compatibility shim](/getting-started/compatibility/#the-compatibility-shim),
+which registers voluptuous-shaped modules under the `voluptuous` name.
+
+## When a dependency imports voluptuous
+
+Your own code migrates with an import swap. A dependency you do not control may
+still `import voluptuous`, and editing your imports does not reach it. For that
+case, call `install_as_voluptuous()` from `probatio.compat` once, early at
+process startup; every later `import voluptuous` then resolves to Probatio,
+including the ones inside your dependencies. The
+[compatibility shim](/getting-started/compatibility/#the-compatibility-shim)
+section has the details and the one sharp edge (it aliases process-wide).
 
 ## Known differences
 
-Probatio targets behavioral compatibility, so the list is short and every entry
-is a deliberate improvement, not a regression:
+Every intentional deviation is a deliberate improvement, not a regression, and
+the [compatibility page](/getting-started/compatibility/#intentional-deviations)
+owns the complete list. The ones that bite in practice:
 
 - **The rendered error string differs (ADR-015).** voluptuous renders
   `expected int for dictionary value @ data['server']['port']`; Probatio renders
-  the same error as `expected int at 'server.port'`. The path is a dotted trail
-  (sequence indices as `[n]`), the error-type clause is not rendered, and a
-  non-mapping is rejected as "expected a mapping" instead of "expected a
-  dictionary". The attributes (`path`, `msg`, `error_message`, `error_type`)
-  keep their voluptuous semantics, so only code that string-matches
-  `str(error)` notices; switch that code to `path` and `error_message`, or to
-  `as_dict()`.
-- **Recursive `Self` schemas fail cleanly.** Cyclic or pathologically deep data
-  raises a normal `Invalid` (caught with the rest of your validation errors)
-  instead of crashing with `RecursionError`, as voluptuous does. The depth limit
-  scales with the interpreter's recursion limit, so legitimately deep data is
-  unaffected.
-- **`from_json_schema` treats its input as untrusted.** A catastrophically
-  backtracking `pattern` or a pathologically deep document is refused with
-  `SchemaError`, rather than hanging or overflowing the stack. This only matters
-  when the schema document itself comes from an untrusted source.
-- **A missing complex required key reports once.** For
-  `Required(Any("a", "b"))` ("at least one of these keys"), voluptuous 0.16.0
-  emits both the "at least one of [...] is required" error and a redundant
-  "required key not provided" for the same key. Probatio reports the single,
-  meaningful error; the first error matches voluptuous.
-- **Any `Mapping` is accepted, not only `dict`.** A `MappingProxyType`, a
-  multidict, or any custom type implementing the `Mapping` protocol validates
-  and returns a plain `dict`, where voluptuous rejects it with "expected a
-  dictionary". A genuine `dict` subclass is preserved as its own class, the same
-  as voluptuous, so a subclass that carries metadata (like Home Assistant's
-  `NodeDictClass`) survives validation. This is a strict superset, so dict code
-  is unaffected.
-- **A callable's `ValueError` message is kept.** When a plain callable validator
-  raises `ValueError("reason")`, the reason is carried into the error ("not a
-  valid value: reason") instead of being dropped. A `ValueError` with no message
-  still reads "not a valid value".
-- **Enum members work as schemas and keys.** An `enum` member (a `StrEnum` or
-  `IntEnum` value) is matched by equality and can be used as a mapping key, with
-  `Required`/`Optional`, or as a value. voluptuous 0.16.0 rejects this with
-  `SchemaError`; it is being added upstream in [PR #537](https://github.com/alecthomas/voluptuous/pull/537).
-- **Built-in validators never leak raw exceptions.** A wrong-typed value raises
-  a clean `Invalid` rather than a bare `TypeError`/`ValueError` from the
-  underlying call: `Replace("a", "b")(42)` raises `MatchInvalid`, and `Number()`
-  on `None`, a `dict`, a `set`, `bytes`, or an empty sequence raises `Invalid`.
-  voluptuous fixes the same edges upstream in [PR #540](https://github.com/alecthomas/voluptuous/pull/540) and [PR #539](https://github.com/alecthomas/voluptuous/pull/539).
-- **`extend` accepts another `Schema`.** `base.extend(other_schema)` merges the
-  extension's keys and preserves its `required` intent across the merge
-  (recursively into nested mappings); its `extra` must match the resulting
-  schema's. voluptuous 0.16.0 raises an `AssertionError`; it is added upstream in
-  [PR #538](https://github.com/alecthomas/voluptuous/pull/538). Pass the extension's `.schema` dict for the old raw-merge behavior.
-- **Every failing list item is reported.** Validating a list collects an error
-  for each failing item, not just the first. voluptuous 0.16.0 stops at the first
-  failing nested item (open request, [issue #171](https://github.com/alecthomas/voluptuous/issues/171)). You get more complete
-  diagnostics; code that iterates `MultipleInvalid.errors` is unaffected.
+  the same error as `expected int at 'server.port'`. The attributes (`path`,
+  `msg`, `error_message`, `error_type`) keep their voluptuous semantics, so only
+  code that string-matches `str(error)` notices; switch that code to `path` and
+  `error_message`, or to `as_dict()`.
+- **Every failing list item is reported**, not just the first, so
+  `MultipleInvalid.errors` can hold more entries than under voluptuous. Code
+  that asserts an exact error count on list input notices; code that iterates
+  the errors is unaffected.
 - **Set schemas transform their elements.** A set schema like `{Coerce(int)}`
-  runs the element schema on each item, so a `Coerce` actually coerces.
-  voluptuous returns the set untransformed (bug, [issue #400](https://github.com/alecthomas/voluptuous/issues/400)).
-- **`Any` names its alternatives.** When every branch is concrete (a type,
-  `None`, or a literal), a failing `Any` reports "expected int or str or None"
-  instead of voluptuous's first-branch-only "expected int" or "not a valid value"
-  ([issue #412](https://github.com/alecthomas/voluptuous/issues/412)). A branch that is an arbitrary validator keeps surfacing its own
-  error. The error class for the combined message is `AnyInvalid`.
+  runs the element schema on each item, so a `Coerce` actually coerces, where
+  voluptuous returns the set untransformed.
 
-If you depend on any of the old behaviors (you almost certainly do not), that is
-the place to know about it.
+Anything else that differs and is not on the
+[deviations list](/getting-started/compatibility/#intentional-deviations) is a
+bug; [open an issue](https://github.com/frenck/probatio/issues).
+
+## Where to next
+
+- [Compatibility](/getting-started/compatibility/): the shim in full, the
+  complete list of intentional deviations, and how the drop-in claim is tested.
+- [Error handling](/guides/error-handling/): paths, multiple errors at once, and
+  human-readable messages.
+- [Dict schemas and markers](/guides/dict-schemas-and-markers/): required and
+  optional keys, defaults, and extra-key policy.

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -8,6 +8,9 @@ types and a few helpers, then call it with a value. A valid value comes back
 (possibly normalized); an invalid one raises an error that points at what went
 wrong.
 
+Probatio not installed yet? Start with
+[installation](/getting-started/installation/).
+
 ## Your first schema
 
 ```python
@@ -46,17 +49,18 @@ string becomes an int and then the int is range-checked.
 ## Handling failures
 
 When validation fails, the schema raises `MultipleInvalid` (a subclass of
-`Invalid`) with a path to the value that did not match:
+`Invalid`) with a path to the value that did not match, rendered as a dotted
+trail into the nested data:
 
 ```python
 from probatio import Schema, Invalid
 
-schema = Schema({"port": int})
+schema = Schema({"server": {"port": int}})
 
 try:
-    schema({"port": "nope"})
+    schema({"server": {"port": "nope"}})
 except Invalid as err:
-    print(err)  # expected int at 'port'
+    print(err)  # expected int at 'server.port'
 ```
 
 Catching `Invalid` catches every validation error, because everything Probatio
@@ -73,4 +77,10 @@ and human-readable messages.
 - [Dict schemas and markers](/guides/dict-schemas-and-markers/): required and
   optional keys, defaults, and extra-key policy.
 - [Validating a config file](/recipes/config-file/): a worked end-to-end example.
+- [Dataclasses](/guides/dataclasses/) and [TypedDict](/guides/typeddict/): skip
+  writing the schema when the type already says it.
+- [JSON Schema](/guides/json-schema/) and [OpenAPI](/guides/openapi/): export
+  what you validate.
+- [Performance](/reference/performance/): fast for pure Python, with an opt-in
+  compiled mode.
 - [API reference](/reference/): the full public surface.

--- a/docs/src/content/docs/guides/combinators.md
+++ b/docs/src/content/docs/guides/combinators.md
@@ -97,6 +97,8 @@ schema({"type": "point", "x": 1, "y": 2})  # {'type': 'point', 'x': 1, 'y': 2}
 
 The win is the error message: with a discriminant, a bad `point` reports the
 problem with its own fields, rather than "matched none of the alternatives."
+Note that the discriminant sees the raw input, and the one above assumes a
+mapping; a production discriminant should also handle a non-mapping value.
 `Switch` is an alias for `Union`.
 
 ## SomeOf: enough of them
@@ -112,8 +114,9 @@ schema = Schema(SomeOf(min_valid=2, validators=[Range(1, 5), int, 3]))
 schema(3)  # 3
 ```
 
-Too few passes raises `NotEnoughValid`; too many raises `TooManyValid`. Like
-`All`, each validator's output feeds the next.
+Too few passes raises [`NotEnoughValid`](/reference/errors/); too many raises
+[`TooManyValid`](/reference/errors/). Like `All`, each validator's output feeds
+the next.
 
 ## Combinators nest
 

--- a/docs/src/content/docs/guides/compiled-schemas.md
+++ b/docs/src/content/docs/guides/compiled-schemas.md
@@ -6,8 +6,11 @@ description: How Probatio compiles a hot schema into a specialized validator, on
 Probatio validates with one interpreted engine. On top of that, it can compile a
 schema into a specialized validator: a flat function generated for that exact
 schema, with the common per-key work unrolled and the common validators inlined.
-It is faster, and it is the same result. Compiling only changes speed, never what a
-schema accepts, rejects, or how it reports an error.
+It is faster, and it is the same result: on a representative config schema,
+compiling takes a validation from roughly 2 µs to under 1 µs, about seven times
+faster than the same schema in voluptuous (see [Numbers](#numbers)). Compiling
+only changes speed, never what a schema accepts, rejects, or how it reports an
+error.
 
 By default this happens on its own. You do not have to do anything to get it, and in
 most cases you should not have to think about it at all. This page explains what it
@@ -19,9 +22,14 @@ off.
 The process starts on the `AUTO` policy. Under `AUTO`, a schema validates
 interpreted and quietly counts how often it is called. Once it has proven hot (it
 has been validated enough times to be worth the cost), it compiles itself and runs
-through the generated validator from then on. A schema you build and call once, or a
-handful of times, never crosses that line, so it stays interpreted and never pays
-for code generation.
+through the generated validator from then on. The line is currently drawn at
+roughly 50 validations, an implementation detail that may move. A schema you build
+and call once, or a handful of times, never crosses it, so it stays interpreted
+and never pays for code generation.
+
+There is no public way to ask whether a schema has compiled; the observable
+effect is throughput, so measure that instead. [Performance](/reference/performance/)
+shows how to benchmark it yourself.
 
 So the practical rule is the same as it has always been: build a schema once, at
 module scope, and reuse it. The hot ones speed themselves up.

--- a/docs/src/content/docs/guides/custom-error-messages.md
+++ b/docs/src/content/docs/guides/custom-error-messages.md
@@ -30,11 +30,13 @@ schema = Schema(
 try:
     schema({})
 except MultipleInvalid as err:
+    # error_message is the bare message, without the path
     print(err.errors[0].error_message)  # a port is required
 
 try:
     schema({"port": 0})
 except MultipleInvalid as err:
+    # printing the error itself appends the path
     print(err.errors[0])  # not a valid port number at 'port'
 ```
 

--- a/docs/src/content/docs/guides/custom-validators.md
+++ b/docs/src/content/docs/guides/custom-validators.md
@@ -32,7 +32,7 @@ To reject a value, raise `Invalid` with a message. The message is what the
 caller sees, and Probatio attaches the path to the offending value for you.
 
 ```python
-from probatio import Schema, Invalid, Required, MultipleInvalid
+from probatio import Schema, Invalid, Required
 
 def even(value):
     if value % 2 != 0:
@@ -71,7 +71,7 @@ is on purpose: a lot of standard-library and third-party functions already raise
 `ValueError` on bad input, so they drop straight in as validators.
 
 ```python
-from probatio import Schema, MultipleInvalid
+from probatio import Schema
 
 def port(value):
     number = int(value)  # raises ValueError on "nope"
@@ -110,6 +110,46 @@ carries the `not a valid value: ` prefix. Raise `Invalid` when you want full
 control of the message the caller reads, with no prefix.
 :::
 
+## Wrapping a predicate with truth
+
+Some checks already exist as predicates: a function that answers `True` or
+`False`, like `os.path.isdir` or `str.isidentifier`. A predicate is not a
+validator, because it returns the answer instead of the value. `truth` (a
+voluptuous carry-over) bridges that: it wraps the predicate into a validator
+that passes the value through unchanged when the predicate is truthy, and
+rejects it when it is falsy.
+
+```python
+from probatio import Schema, truth
+
+@truth
+def positive(value):
+    return value > 0
+
+schema = Schema(positive)
+schema(5)  # 5
+```
+
+A falsy result raises a bare `ValueError` under the hood, so the failure reads
+`not a valid value`, with no reason attached. Wrap the result in
+[`Msg`](#reshaping-the-message-with-msg) when the caller deserves a better
+message.
+
+```python
+from probatio import Schema, MultipleInvalid, truth
+
+@truth
+def positive(value):
+    return value > 0
+
+schema = Schema(positive)
+
+try:
+    schema(-1)
+except MultipleInvalid as err:
+    print(err)  # not a valid value
+```
+
 ## Transforming the value
 
 A validator does not have to return the input untouched. Returning a different
@@ -136,7 +176,7 @@ replaces its failure message. Pass `cls` to also swap the error class, so
 callers can catch your failure by type.
 
 ```python
-from probatio import Schema, Msg, Match, MultipleInvalid
+from probatio import Schema, Msg, Match
 
 schema = Schema(Msg(Match(r"^[a-z]+$"), "lowercase letters only"))
 
@@ -180,7 +220,7 @@ Custom validators are validators, so they nest like any other. Drop them into
 validator feeds the next (see [combinators](/guides/combinators/)).
 
 ```python
-from probatio import Schema, All, Strip, Lower, Invalid, Required, MultipleInvalid
+from probatio import Schema, All, Strip, Lower, Invalid, Required
 
 def not_empty(value):
     if not value:
@@ -240,7 +280,7 @@ A class with a `__call__` method works the same way and is handier when the
 validator carries several settings or wants a readable `repr`:
 
 ```python
-from probatio import Schema, Invalid, MultipleInvalid
+from probatio import Schema, Invalid
 
 class AtLeast:
     def __init__(self, minimum):
@@ -306,7 +346,9 @@ Schema(Slug)("Hello").value  # 'hello'
 This keeps the "how do I validate a raw value of myself" knowledge on the type,
 instead of wrapping every use in a `Coerce`. It is the principled way to make a
 domain type a first-class schema. For a type you do not own, reach for `Coerce` or
-a small validator function instead.
+a small validator function instead. See
+[ADR-007](https://github.com/frenck/probatio/blob/main/adr/007-self-validation-protocol.md)
+for the design.
 
 ## Validating against call-time context
 
@@ -361,17 +403,10 @@ except MultipleInvalid as err:
     print(err)  # expected int at 'width'
 ```
 
-The `raises` context manager is the companion test helper: it asserts a block
-raises a given error (optionally matching the message), which is how the examples
-here check the rejection path.
-
-```python
-from probatio import Schema, MultipleInvalid, raises
-
-schema = Schema(int)
-with raises(MultipleInvalid, "expected int"):
-    schema("nope")
-```
+The companion `raises` context manager asserts that a block raises a given
+error, optionally matching the message. It is a test helper, so it lives with
+the rest of the testing story: see
+[Testing with pytest](/guides/testing-with-pytest/).
 
 ## Where to next
 

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -126,18 +126,24 @@ schema = DataclassSchema(User, {"name": Length(min=2)})
 schema({"name": "ada"})  # User(name='ada')
 ```
 
-The same rule can live on the field itself with `Annotated`. The first argument
-is the type and any callable after it is applied as a validator, in order. The
-type is checked on the result, not the raw input, so the annotation says what the
-field _is_: a coercer runs first and the type confirms what it produced.
-`Annotated[datetime, AsDatetime()]` accepts the string, parses it, and confirms a
-`datetime`, keeping the field honestly typed instead of annotating `str` and hiding
-the real type in the validator. This keeps the constraint next to the field instead
-of in a separate map, and it composes inside containers
-(`list[Annotated[int, Range(min=1)]]` checks every element). Metadata that is not
-callable is left alone, so an `Annotated` value you share with another tool passes
-through untouched. To find the right callable to drop in here, whether it checks
-the value or transforms it, see [Built-ins by role](/reference/builtins-by-role/).
+The same rule can live on the field itself with `Annotated`, keeping the
+constraint next to the field instead of in a separate map. The rules:
+
+- The first argument is the type; every callable after it is applied as a
+  validator, in order.
+- The type is checked on the result, not the raw input, so the annotation says
+  what the field _is_: a coercer runs first and the type confirms what it
+  produced.
+- It composes inside containers: `list[Annotated[int, Range(min=1)]]` checks
+  every element.
+- Metadata that is not callable is left alone, so an `Annotated` value you
+  share with another tool passes through untouched.
+
+That second rule is what keeps a coerced field honestly typed.
+`Annotated[datetime, AsDatetime()]` accepts the string, parses it, and confirms
+a `datetime`, instead of annotating `str` and hiding the real type in the
+validator. To find the right callable to drop in here, whether it checks the
+value or transforms it, see [Built-ins by role](/reference/builtins-by-role/).
 
 ```python
 from dataclasses import dataclass
@@ -156,8 +162,7 @@ schema = DataclassSchema(User)
 schema({"name": "ada", "age": 30})  # User(name='ada', age=30)
 ```
 
-Because the type checks the result, a coercer produces the annotated type while the
-field stays honestly typed:
+Here is that coercer-plus-type pairing in practice:
 
 ```python
 from dataclasses import dataclass
@@ -198,9 +203,29 @@ class Account:
     password: Annotated[str, Key(secret=True), Length(min=8)]  # redacted, length-checked
     user_name: Annotated[str, Key(alias=["user-name", "userName"])] = ""  # accept aliases
     is_admin: Annotated[bool, Key(forbidden=True)] = False  # reject if the caller sends it
+
+
+schema = DataclassSchema(Account)
+schema({"name": "a", "password": "secret123", "user-name": "frenck"})
+# Account(name='a', password='secret123', user_name='frenck', is_admin=False)
 ```
 
-`Key(secret=True)` redacts the field's value in validation errors.
+`Key(secret=True)` redacts the field's value in validation errors. It shows up
+when an error renders the offending value: the message stays useful, the secret
+does not leak.
+
+```python
+from probatio import MultipleInvalid
+from probatio.humanize import humanize_error
+
+data = {"name": "a", "password": "short", "user-name": "frenck"}
+try:
+    schema(data)
+except MultipleInvalid as err:
+    print(humanize_error(data, err))
+# length of value must be at least 8 at 'password'. Got <redacted>
+```
+
 `Key(alias=[...])` accepts the field under alternate input names (a bare string
 works for one), emitting it under the field name; `accept_canonical=False` makes it
 a strict rename. `Key(inclusive="grp")` / `Key(exclusive="grp")` group fields the
@@ -218,12 +243,17 @@ dataclass (whose constructor needs a value for every field) such a field must ha
 a default; without one it raises `SchemaError`. A TypedDict constructs nothing, so
 there they need no default.
 
-One boundary to know: a field the schema keeps out of the input, a `forbidden`
-field, a `remove` field, or an unselected `exclusive` member, takes the dataclass's
-own default exactly as declared, without validation or coercion (an `optional` or
-selected field carries its default through the schema and is coerced). The schema
-validates input, and these values are not input, so write an already-typed default
-for such a field; a wrong-typed one is a type error your type-checker flags. See
+One boundary to know, on which defaults pass through the schema:
+
+- An `optional` field, or a selected `exclusive` member, carries its default
+  through the schema, so it is validated and coerced like input.
+- A field the schema keeps out of the input (a `forbidden` field, a `remove`
+  field, an unselected `exclusive` member) takes the dataclass's own default
+  exactly as declared: no validation, no coercion.
+
+The schema validates input, and that second group's values are not input, so
+write an already-typed default for such a field; a wrong-typed one is a type
+error your type-checker flags. See
 [ADR-013](https://github.com/frenck/probatio/blob/main/adr/013-markers-on-annotated-fields.md)
 for the model.
 
@@ -316,7 +346,8 @@ DataclassSchema(Tree)({"name": "root", "children": [{"name": "leaf"}]})
 Recursion follows the data, with the same depth guard as `Self`: cyclic or
 pathologically deep input raises a clean `Invalid`, never a `RecursionError`. A
 recursive dataclass level does more work than a bare `Self` level, so it bottoms
-out sooner; raise `sys.setrecursionlimit` if you genuinely need to go deeper.
+out sooner; raise the limit with `sys.setrecursionlimit()` if you genuinely need
+to go deeper.
 
 ## Discriminated unions
 
@@ -359,12 +390,6 @@ The tag field must be a single-value `Literal` present on every member, with a
 distinct value per member. Without one (or if a member is not a dataclass), the
 union stays an ordinary "try each" `Any`. An unknown tag value falls back to
 trying every member, so it still fails cleanly rather than silently.
-
-## From a TypedDict
-
-The same engine builds a schema from a `TypedDict`. Because that is a different
-tool with a different result (the validated dict, not a constructed instance), it
-has its own page: [Schemas from TypedDicts](/guides/typeddict/).
 
 ## Speed
 
@@ -431,5 +456,31 @@ trusted dict unchanged.
 ## Limits
 
 A field with `init=False` is left out of the schema, since it is not a constructor
-argument. The value is not coerced between container types: a list stays a list
-even where the annotation says `tuple`.
+argument; it keeps whatever its default or `__post_init__` gives it. An `InitVar`
+goes the other way: it is a constructor argument, so it becomes a schema key,
+validated against its annotation like any field, and it feeds `__post_init__` as
+usual.
+
+```python
+from dataclasses import InitVar, dataclass, field
+
+from probatio import DataclassSchema
+
+
+@dataclass
+class Rect:
+    width: int
+    height: int
+    scale: InitVar[int] = 1
+    area: int = field(init=False, default=0)
+
+    def __post_init__(self, scale: int) -> None:
+        self.area = self.width * self.height * scale
+
+
+DataclassSchema(Rect)({"width": 2, "height": 3, "scale": 10})
+# Rect(width=2, height=3, area=60)
+```
+
+The value is not coerced between container types: a list stays a list even where
+the annotation says `tuple`.

--- a/docs/src/content/docs/guides/dict-schemas-and-markers.md
+++ b/docs/src/content/docs/guides/dict-schemas-and-markers.md
@@ -216,6 +216,10 @@ schema({"alias": "ada"})  # {'name': 'ada'}
 schema({"name": "ada"})   # {} (the canonical name is not an input name here)
 ```
 
+Note what the second call does: the canonical key is still recognized, so it is
+not reported as an unknown key, but its value is dropped from the output. An
+actually unknown key would raise.
+
 An aliased key is optional by default (its `default` applies when absent under
 every name); pass `required=True` to demand one of its names. An alias that names
 another key in the schema, or that two keys share, is rejected at build time, so
@@ -226,13 +230,13 @@ an ambiguous schema fails fast rather than at validation.
 `Secret` marks a key whose value is a credential, so a validation failure under it
 is redacted: the error still reports the path and the reason, but shows
 `<redacted>` instead of the offending value (in `Invalid` rendering and
-`humanize_error`). The value passes through validation unchanged; `Secret` marks
-the key, it does not transform the value.
+`humanize_error`, see [error handling](/guides/error-handling/)). The value
+passes through validation unchanged; `Secret` marks the key, it does not
+transform the value.
 
 ```python
-from probatio import Schema, Required, Secret
+from probatio import Schema, Required, Secret, MultipleInvalid
 from probatio.humanize import humanize_error
-from probatio.error import MultipleInvalid
 
 schema = Schema({Required(Secret("password")): int})
 data = {"password": "hunter2"}
@@ -319,6 +323,9 @@ try:
 except Invalid as err:
     print(err)  # some but not all values in the same group of inclusion 'coords' at '<coords>'
 ```
+
+Since no single key is at fault, a group error reports a synthetic path segment
+named after the group, in angle brackets: `<coords>` here, `<auth>` below.
 
 An exclusive group is optional by default (none of its keys is fine). Two flags
 change what an empty group does. `required=True` makes the group demand exactly

--- a/docs/src/content/docs/guides/error-handling.md
+++ b/docs/src/content/docs/guides/error-handling.md
@@ -24,8 +24,9 @@ except Invalid as err:
     print(err)  # expected int
 ```
 
-A broken schema _definition_ is different: that raises `SchemaError`, because it
-is a programming mistake, not bad input. The two never overlap.
+A broken schema _definition_ raises `SchemaError` instead: you wrote the schema
+wrong, and no input would make it right. The two never overlap: `SchemaError`
+means fix the code, `Invalid` means reject the data.
 
 ## The path to the value
 
@@ -50,9 +51,9 @@ find the exact value that failed.
 
 ## Many errors at once
 
-A schema does not stop at the first problem. It collects every failure into a
-`MultipleInvalid`, which is itself an `Invalid`. Its `errors` list holds the
-individual failures:
+A dict schema does not stop at the first failing key (and a list schema not at
+the first failing element). It collects every failure into a `MultipleInvalid`,
+which is itself an `Invalid`. Its `errors` list holds the individual failures:
 
 ```python
 from probatio import Schema, MultipleInvalid
@@ -89,8 +90,9 @@ except Invalid as err:
 ```
 
 `validate_with_humanized_errors(data, schema)` (also in `probatio.humanize`) does
-both steps: it validates and, on failure, raises `Error` carrying the humanized
-message.
+both steps: it validates and, on failure, raises `Error` (importable from
+`probatio` or `probatio.error`) carrying the humanized message. The
+[errors reference](/reference/errors/) has the class.
 
 ## Catching a specific kind
 

--- a/docs/src/content/docs/guides/field-lists.md
+++ b/docs/src/content/docs/guides/field-lists.md
@@ -22,16 +22,25 @@ A mapping becomes a list of field dicts, one per key, carrying the type, the nam
 and whether it is required:
 
 ```python
-from probatio import Schema, Required, Optional, serialize
+from probatio import Schema, Required, Optional, In, serialize
 
-schema = Schema({Required("name"): str, Optional("port", default=8080): int})
+schema = Schema(
+    {
+        Required("name"): str,
+        Optional("port", default=8080): int,
+        Required("mode"): In(["auto", "manual"]),
+    }
+)
 serialize(schema)
-# [{'type': 'string', 'name': 'name', 'required': True}, {'type': 'integer', 'name': 'port', 'required': False, 'optional': True, 'default': 8080}]
+# [{'type': 'string', 'name': 'name', 'required': True}, {'type': 'integer', 'name': 'port', 'required': False, 'optional': True, 'default': 8080}, {'type': 'select', 'options': [('auto', 'auto'), ('manual', 'manual')], 'name': 'mode', 'required': True}]
 ```
 
 Each field carries what the frontend needs to render it: the `type`, the `name`,
 `required`, an `optional` flag and a `default` when present, and bounds (such as
-`valueMin`/`valueMax` for a `Range`) where the validator implies them.
+`valueMin`/`valueMax` for a `Range`) where the validator implies them. An
+`In(...)` becomes a `select` field with its `options` as (value, label) pairs,
+which is how a config-flow form renders a dropdown; pass `In` a mapping to give
+each value its own label.
 
 ## A custom-serializer hook
 
@@ -45,6 +54,29 @@ from probatio import UNSUPPORTED
 
 UNSUPPORTED  # UNSUPPORTED
 ```
+
+The hook is a plain function taking one schema node. Return a dict to render
+that node yourself; return `UNSUPPORTED` for everything else. Here a `Port`
+renders as a dedicated `port` field type instead of the default bounded
+integer:
+
+```python
+from probatio import Schema, Required, Port, serialize, UNSUPPORTED
+
+
+def render_port(node):
+    if isinstance(node, Port):
+        return {"type": "port"}
+    return UNSUPPORTED
+
+
+schema = Schema({Required("host"): str, Required("port"): Port()})
+serialize(schema, custom_serializer=render_port)
+# [{'type': 'string', 'name': 'host', 'required': True}, {'type': 'port', 'name': 'port', 'required': True}]
+```
+
+The hook overrides the value part only; `serialize` still adds the key facets
+(`name`, `required`, `default`) around whatever the hook returns.
 
 :::tip
 Return `UNSUPPORTED` from your hook for the nodes you do not care about. That

--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -7,6 +7,12 @@ A Probatio schema is Python data. JSON Schema is the lingua franca other tools
 speak. The two codecs translate between them, for the constructs that map
 cleanly. They are exported from the top level, so
 `from probatio import to_json_schema, from_json_schema` is all you need.
+That unlocks the places JSON Schema already lives: editor validation of config
+files, form generation in a frontend, and LLM tool definitions (worked through
+in the [LLM tool recipe](/recipes/llm-tools/)). Decoded input is treated as
+untrusted by default; the
+[guards](#untrusted-input-is-the-default-assumption) are covered at the bottom
+of this page.
 
 The same decoder backs OpenAPI (see [OpenAPI](/guides/openapi/)), and a third
 codec renders the flat shape config frontends consume (see [Field
@@ -78,25 +84,35 @@ to forbid. `to_json_schema` emits the same constructs in the other direction.
 | Values  | `enum`, `const`, `not`, `type` (including a type array like `["string", "null"]`)                                                                                                  |
 | Compose | `anyOf`, `oneOf`, `allOf`, `$ref` (resolved against `$defs`/`definitions`)                                                                                                         |
 
-`ExactSequence` exports as `prefixItems` (with `items: false` and matching
-`minItems`/`maxItems`), `Unique` as `uniqueItems`, `Contains` as `contains`,
-`Equal`/`Literal` as `const`, and `NotIn` as `not` over an `enum`. The called
-factory forms `Email()`/`Url()`/`FqdnUrl()` export their `format` (`email`/`uri`),
-the same as the bare names. `Datetime`/`Date`/`Time` export the
-`date-time`/`date`/`time` formats (a custom `strptime` format has no JSON Schema
-equivalent, so it exports as a plain string). The network and identifier
-validators export their standard `format`: `IPv4Address` to `ipv4`, `IPv6Address`
-to `ipv6`, `UUID` to `uuid`, and `Hostname`/`Fqdn` to `hostname`; `Port` exports a
-bounded integer and `MultipleOf` a `multipleOf`. A `Secret` key exports its
-property with `writeOnly: true`, and `Base64` as `contentEncoding: base64`. These
-decode back into the matching validator (a `writeOnly` property decodes to a
-`Secret` key), so they round-trip, with one known widener.
-JSON Schema has a single `hostname` format, so both `Hostname` and `Fqdn` export
-to it and decode back as `Hostname`, meaning a round-tripped `Fqdn` accepts a
-dotless host the original would reject. Pin it with a `pattern` or an explicit
-check if the distinction matters. `oneOf` decodes with its exact semantics (a
-value must match exactly one branch, so one matching two or more is rejected),
-unlike the looser `anyOf`.
+The named validators map to JSON Schema like this, and decode back into the
+matching validator (a `writeOnly` property decodes to a `Secret` key), so they
+round-trip:
+
+| Probatio construct            | JSON Schema output                                                                                                                |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `ExactSequence`               | `prefixItems` (with `items: false`, matching `minItems`/`maxItems`)                                                               |
+| `Unique`                      | `uniqueItems`                                                                                                                     |
+| `Contains`                    | `contains`                                                                                                                        |
+| `Equal` / `Literal`           | `const`                                                                                                                           |
+| `NotIn`                       | `not` over an `enum`                                                                                                              |
+| `Email` / `Email()`           | `format: email`                                                                                                                   |
+| `Url` / `Url()` / `FqdnUrl()` | `format: uri`                                                                                                                     |
+| `Datetime` / `Date` / `Time`  | `format: date-time` / `date` / `time` (a custom `strptime` format has no JSON Schema equivalent, so it exports as a plain string) |
+| `IPv4Address` / `IPv6Address` | `format: ipv4` / `ipv6`                                                                                                           |
+| `UUID`                        | `format: uuid`                                                                                                                    |
+| `Hostname` / `Fqdn`           | `format: hostname`                                                                                                                |
+| `Port`                        | a bounded integer                                                                                                                 |
+| `MultipleOf`                  | `multipleOf`                                                                                                                      |
+| `Secret` key                  | its property with `writeOnly: true`                                                                                               |
+| `Base64`                      | `contentEncoding: base64`                                                                                                         |
+
+The one known widener: JSON Schema has a single `hostname` format, so both
+`Hostname` and `Fqdn` export to it and decode back as `Hostname`, meaning a
+round-tripped `Fqdn` accepts a dotless host the original would reject. Pin it
+with a `pattern` or an explicit check if the distinction matters.
+
+`oneOf` decodes with its exact semantics (a value must match exactly one branch,
+so one matching two or more is rejected), unlike the looser `anyOf`.
 
 `from_openapi` adds the OpenAPI `nullable` keyword, covered in
 [OpenAPI](/guides/openapi/).

--- a/docs/src/content/docs/guides/loading-and-dumping.md
+++ b/docs/src/content/docs/guides/loading-and-dumping.md
@@ -4,11 +4,12 @@ description: Parse JSON, YAML, and TOML into Python, validate it, and write it b
 ---
 
 Validation works on Python values, but data arrives as text: a JSON request
-body, a YAML config file, a TOML manifest. Probatio reads and writes all three
-through one set of functions. JSON read and write and TOML read work on the
-standard library; YAML (read and write) and TOML write need an optional extra,
-covered under [Backends](#backends) below. Every function here is exported from
-the top level.
+body, a YAML config file, a TOML manifest. This page covers the loaders that
+parse all three into Python, the dumpers that write them back out, and the best
+part, [source locations](#source-locations): load YAML with locations and a
+validation error can point at the exact line and column in the file, like
+`Got 70000 (at 2:9)`. voluptuous has none of this: no loaders, no dumpers, no
+source locations. Every function here is exported from the top level.
 
 ## Loading
 
@@ -51,6 +52,10 @@ schema = Schema({Required("port"): int})
 schema.load_json('{"port": 8080}')  # {'port': 8080}
 ```
 
+The convenience methods take no `options`; when you need to tune the backend
+(see [Backend options](#backend-options)), parse with the module function and
+validate the result yourself.
+
 `load` infers the format from a path extension. Write a file, then read it back
 without naming the format:
 
@@ -62,22 +67,19 @@ Path("config.json").write_text('{"port": 8080}')
 load(Path("config.json"))  # {'port': 8080}
 ```
 
-:::caution[YAML is parsed safely]
+:::caution[Untrusted YAML]
 `load_yaml` never uses an unsafe YAML loader. The input is untrusted by default,
 so it sticks to a safe load that builds plain Python values, not arbitrary
-objects. If you were relying on YAML constructing custom types for you, it will
-not.
-:::
-
-:::caution[Use the fast backend for untrusted YAML]
-A safe load still expands YAML aliases, so a small document full of anchors that
-reference each other (the billion-laughs pattern) can blow up to gigabytes of
-logical nodes. The backend decides whether that is contained. YAMLRocks (the
-`probatio[fast]` backend) counts the expanded nodes and refuses a document that
-blows up, so it is bomb-resistant. The PyYAML fallback is not: it shares the alias
-references, so the document parses cheaply and the cost lands later, when the
-structure is walked during validation. Prefer the fast backend for genuinely
-untrusted YAML, and bound the input size when you are on the PyYAML fallback.
+objects; if you were relying on YAML constructing custom types for you, it will
+not. A safe load still expands YAML aliases, though, so a small document full of
+anchors that reference each other (the billion-laughs pattern) can blow up to
+gigabytes of logical nodes. The backend decides whether that is contained.
+YAMLRocks (the `probatio[fast]` backend) counts the expanded nodes and refuses a
+document that blows up, so it is bomb-resistant. The PyYAML fallback is not: it
+shares the alias references, so the document parses cheaply and the cost lands
+later, when the structure is walked during validation. Prefer the fast backend
+for genuinely untrusted YAML, and bound the input size when you are on the
+PyYAML fallback.
 :::
 
 ## Dumping
@@ -97,18 +99,36 @@ load_json(text)  # {'port': 8080}
 ```
 
 Before handing a value to the backend, the dumpers normalize the few non-native
-types a validated value commonly carries: `Decimal` becomes a float, and `set`,
-`frozenset`, and `tuple` become a list. The temporal types are format-aware. TOML
-has native `datetime`, `date`, and `time`, so those pass through and round-trip as
-the same type; JSON and YAML have no temporal types, so they become ISO 8601
-strings. JSON also has no `nan` or `inf`, so a non-finite float is refused with a
-clear error rather than silently corrupted (the fast backend would turn it into
-`null`, the standard library into an invalid token). YAML and TOML keep non-finite
-floats, since both can represent them. The normalization is one-way: a `set`,
-`frozenset`, or `tuple` dumps as a list and loads back as a list, not as the
-original type. This is a convenience for round-tripping validated data, not a
-general serialization framework. Reach for a `default` hook or a dedicated
-serializer when you need more.
+types a validated value commonly carries:
+
+- `Decimal` becomes a float.
+- `set`, `frozenset`, and `tuple` become a list.
+- The temporal types are format-aware. TOML has native `datetime`, `date`, and
+  `time`, so those pass through and round-trip as the same type; JSON and YAML
+  have no temporal types, so they become ISO 8601 strings.
+- A non-finite float (`nan`, `inf`) is refused for JSON with a clear error
+  rather than silently corrupted (the fast backend would turn it into `null`,
+  the standard library into an invalid token). YAML and TOML keep non-finite
+  floats, since both can represent them.
+- The normalization is one-way: a `set`, `frozenset`, or `tuple` dumps as a
+  list and loads back as a list, not as the original type.
+
+This is a convenience for round-tripping validated data, not a general
+serialization framework. For a type the dumpers do not know, every dumper takes
+a `default` hook: a callable that receives the unhandled value and returns one
+the format can carry (the result is normalized again, so it can itself be a
+container). For more than that, reach for a dedicated serializer.
+
+```python
+from probatio import dump_json, load_json
+
+class Color:
+    def __init__(self, name):
+        self.name = name
+
+text = dump_json({"accent": Color("teal")}, default=lambda color: color.name)
+load_json(text)  # {'accent': 'teal'}
+```
 
 :::note
 The output does not depend on which backend is installed. The JSON text is the
@@ -122,7 +142,9 @@ since that is what you actually care about.
 ## Backends
 
 Probatio uses a fast backend when one is installed and falls back to the standard
-library otherwise. The backends are detected once at import time:
+library otherwise. JSON read and write and TOML read work on the standard library
+alone; YAML (read and write) and TOML write need an optional extra. The backends
+are detected once at import time:
 
 - JSON: [orjson](https://github.com/ijl/orjson) when present, otherwise the
   standard library's `json`.

--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -12,10 +12,11 @@ Schema](/guides/json-schema/) first; this page covers what OpenAPI adds.
 ## Both directions
 
 `to_openapi(schema)` renders a schema as an OpenAPI Schema object.
-`from_openapi(dict)` is the inverse: it builds a `Schema` back. This is handy for
-LLM tool calling and MCP, which describe tool parameters as OpenAPI, so a Probatio
-schema can become a tool signature and a tool's declared parameters can become a
-validator.
+`from_openapi(dict)` is the inverse: it builds a `Schema` back. Use the pair to
+publish request and response schemas in the spec of an OpenAPI-described
+service, straight from the validators you already run, or to build a validator
+from a spec you consume. For LLM tool calling and MCP, which take JSON Schema
+rather than OpenAPI, see the [LLM tool recipe](/recipes/llm-tools/).
 
 ```python
 from probatio import Schema, Required, Optional, to_openapi
@@ -24,6 +25,11 @@ schema = Schema({Required("name"): str, Optional("port", default=8080): int})
 to_openapi(schema)
 # {'type': 'object', 'properties': {'name': {'type': 'string'}, 'port': {'type': 'integer', 'default': 8080}}, 'required': ['name']}
 ```
+
+Note the missing `additionalProperties`: where `to_json_schema` closes an object
+with an explicit `additionalProperties: False`, `to_openapi` matches
+voluptuous-openapi's output and omits the keyword on a closed object, emitting
+`additionalProperties: True` only when the schema allows extra keys.
 
 Going the other way, an OpenAPI Schema object becomes a working validator.
 `nullable` is read back too, so a nullable field accepts both `None` and a real

--- a/docs/src/content/docs/guides/probatio-decorator.md
+++ b/docs/src/content/docs/guides/probatio-decorator.md
@@ -29,12 +29,12 @@ def area(width: int, height: int) -> int:
 area(3, 4)  # 12
 ```
 
-A parameter that fails its type raises before the body runs, naming the parameter:
-
-<!-- verify: raises MultipleInvalid -->
+A parameter that fails its type raises `MultipleInvalid` before the body runs,
+naming the parameter. It is the same exception a `Schema` raises, so one
+`except` covers both.
 
 ```python
-from probatio import probatio
+from probatio import probatio, MultipleInvalid
 
 
 @probatio
@@ -42,11 +42,16 @@ def area(width: int, height: int) -> int:
     return width * height
 
 
-area("wide", 4)  # expected int at 'width'
+try:
+    area("wide", 4)
+except MultipleInvalid as err:
+    print(err)  # expected int at 'width'
 ```
 
 An unannotated parameter is left alone, so `self` and `cls` need no special
-handling and the decorator drops straight onto a method.
+handling and the decorator drops straight onto a method. A default the caller
+omits is also left alone: it is not validated or coerced, the body receives it
+exactly as declared, so write an already-valid default.
 
 ```python
 from typing import Annotated
@@ -112,8 +117,9 @@ distance({"x": 3, "y": 4})  # 7
 ## Extra rules per parameter
 
 The annotation gives you the type check. For anything more (a length, a range, a
-pattern), pass a `{parameter: validator}` map as the first argument. It runs after
-the inferred type, exactly like a dataclass's `additional_constraints`.
+pattern), pass a `{parameter: validator}` map as the first argument. It runs
+after the inferred type. (If you know `DataclassSchema`, this is its
+`additional_constraints` in decorator form.)
 
 ```python
 from probatio import probatio, Length
@@ -129,7 +135,9 @@ greet("ada")  # 'hi ada'
 
 A constraint that names no parameter, or names a `*args`/`**kwargs`, is refused
 when the function is decorated, so a typo fails loudly instead of silently doing
-nothing.
+nothing. The packed parameters themselves are skipped entirely: an annotation on
+`*args` or `**kwargs` names no single value to validate, so it is ignored and
+the values pass through unchecked.
 
 ## Validating the return value
 
@@ -205,6 +213,14 @@ def widen(value: Annotated[int, Coerce(int)]) -> int:
 widen("5")             # 5, validated and coerced
 widen.__wrapped__("5") # '5', straight through, no validation
 ```
+
+That escape hatch frames when not to use the decorator at all. Every decorated
+call pays for validation, so decorate boundaries (a request handler, a service
+entry point, the public surface of a library), not hot inner functions that run
+in tight loops on values already validated one frame up. When a single hot call
+site sits behind an otherwise useful boundary check, `__wrapped__` skips the
+cost for just that site. See [Performance](/reference/performance/) for the
+cost model.
 
 ## Where to next
 

--- a/docs/src/content/docs/guides/recursive-schemas.md
+++ b/docs/src/content/docs/guides/recursive-schemas.md
@@ -53,9 +53,8 @@ comment(data)  # {'text': 'top', 'replies': [{'text': 'first', 'replies': []}, {
 ```
 
 Recursion follows the data. A finite structure validates fine, because each
-level is just another call into the same compiled schema, up to the depth guard
-described below. Real data is nowhere near that limit; if you knowingly need
-deeper, raise `sys.setrecursionlimit`, since the guard scales with it.
+level is just another call into the same schema, up to
+[the depth guard](#the-depth-guard) described below.
 
 ## Self in a combinator
 
@@ -115,8 +114,9 @@ Probatio does not. It counts the `Self` recursion depth and, past a limit,
 raises a clean `Invalid` that you catch alongside every other validation error.
 
 The limit is a fraction of the interpreter's recursion limit, read live. So if
-you genuinely have deep data, raising `sys.setrecursionlimit` scales the guard
-with it; you are not boxed in by a hard-coded number. Keep that within reason,
+you genuinely have deep data, raising the limit with `sys.setrecursionlimit()`
+scales the guard with it; you are not boxed in by a hard-coded number. Keep that
+within reason,
 though: past a point the operating system's own stack, not the recursion limit, is
 the ceiling, so an extreme limit can still overflow.
 
@@ -149,6 +149,10 @@ except MultipleInvalid as err:
 The same guard catches cyclic data, where a structure points back at itself and
 would otherwise recurse forever. Either way you get an `Invalid`, never a
 `RecursionError`, so untrusted input cannot crash validation.
+
+One performance note: the [compiled engine](/guides/compiled-schemas/) skips
+recursive schemas, so a schema using `Self` always validates interpreted. It
+behaves exactly the same; it just does not get the compiled speedup.
 
 ## Where to next
 

--- a/docs/src/content/docs/guides/sequence-schemas.md
+++ b/docs/src/content/docs/guides/sequence-schemas.md
@@ -1,0 +1,215 @@
+---
+title: Sequence schemas
+description: How list, tuple, and set schemas validate elements, and how to pin a sequence's shape and bounds.
+---
+
+A `list`, `tuple`, or `set` schema validates a sequence: the container type must
+match, and every element must match one of the element schemas. This page covers
+that rule and its one classic subtlety, error paths into sequences, fixed-shape
+sequences, and nesting. It builds on
+[the validation model](/guides/validation-model/); the mapping side lives in
+[dict schemas and markers](/guides/dict-schemas-and-markers/).
+
+## Every element, any alternative
+
+The schemas inside the brackets are alternatives, not positions. `Schema([int,
+str])` does not mean "an int, then a str"; it means "a list where every element
+is an int _or_ a str", in any order and any number:
+
+```python
+from probatio import Schema
+
+schema = Schema([int, str])
+
+schema([1, "a", 2])  # [1, 'a', 2]
+schema([])           # []
+```
+
+Each element tries the alternatives in order and the first match wins, like
+`Any`. Because a match can transform, order matters here too: with
+`[Coerce(int), str]` a numeric string becomes an int before `str` gets a look.
+
+```python
+from probatio import Schema, Coerce
+
+Schema([Coerce(int), str])(["5", "a"])  # [5, 'a']
+```
+
+An element that matches no alternative fails, and the message names the
+alternative tried last:
+
+```python
+from probatio import Schema, Invalid
+
+try:
+    Schema([int, str])([1, 2.5])
+except Invalid as err:
+    print(err)  # expected str at '[1]'
+```
+
+Validation returns a new list; the input is not mutated. And the container is
+checked strictly: a tuple, a set, or a string (even though Python treats a
+string as a sequence) is not a list.
+
+```python
+from probatio import Schema, Invalid
+
+try:
+    Schema([str])("abc")
+except Invalid as err:
+    print(err)  # expected a list
+```
+
+## The empty sequence schema
+
+With no alternatives there is nothing an element could match, so `Schema([])`
+accepts only the empty list:
+
+```python
+from probatio import Schema, Invalid
+
+schema = Schema([])
+
+schema([])  # []
+
+try:
+    schema([1])
+except Invalid as err:
+    print(err)  # invalid value at '[0]'
+```
+
+## Tuples and sets
+
+A `tuple` or `set` schema follows the same rule with its own container type: the
+input must be a tuple (or a set), every element must match one of the
+alternatives, and the result is a new container of that type.
+
+```python
+from probatio import Schema
+
+Schema((int,))((1, 2, 3))  # (1, 2, 3)
+Schema({int})({1, 2})      # {1, 2}
+```
+
+The container types do not mix:
+
+```python
+from probatio import Schema, Invalid
+
+try:
+    Schema((int,))([1, 2])
+except Invalid as err:
+    print(err)  # expected a tuple
+```
+
+One caveat for sets: a failing element still gets an index in the error path,
+but a set has no order, so that index reflects iteration order, not a position
+you can count on.
+
+## Error paths into sequences
+
+A failing element is reported by its index. In `error.path` the index is an
+integer, and the dotted rendering shows it as `[n]`:
+
+```python
+from probatio import Schema, Invalid
+
+schema = Schema({"ports": [int]})
+
+try:
+    schema({"ports": [80, "nope"]})
+except Invalid as err:
+    print(err)       # expected int at 'ports[1]'
+    print(err.path)  # ['ports', 1]
+```
+
+Like a dict schema, a list schema does not stop at the first failing element;
+every failure lands in the `MultipleInvalid`:
+
+```python
+from probatio import Schema, MultipleInvalid
+
+try:
+    Schema([int])(["a", "b"])
+except MultipleInvalid as err:
+    for sub in err.errors:
+        print(sub)
+    # expected int at '[0]'
+    # expected int at '[1]'
+```
+
+See [error handling](/guides/error-handling/) for paths and rendering in depth.
+
+## Fixed shape and bounds
+
+When the positions _do_ matter, reach for `ExactSequence`: it validates a
+fixed-length sequence position by position.
+
+```python
+from probatio import Schema, ExactSequence, Invalid
+
+pair = Schema(ExactSequence([str, int]))
+
+pair(["a", 1])  # ['a', 1]
+
+try:
+    pair(["a"])
+except Invalid as err:
+    print(err)  # expected a sequence of 2 items
+```
+
+For bounds rather than positions, compose with `All`: the list schema validates
+the elements, then `Length` (or `NonEmpty`) checks the size of the result.
+
+```python
+from probatio import Schema, All, Length
+
+tags = Schema(All([str], Length(min=1, max=3)))
+
+tags(["a", "b"])  # ['a', 'b']
+```
+
+An empty list then fails the bound, not the element rule:
+
+<!-- verify: raises MultipleInvalid -->
+
+```python
+from probatio import Schema, All, NonEmpty
+
+Schema(All([str], NonEmpty()))([])  # value must not be empty
+```
+
+## Nesting
+
+A sequence schema is a value like any other, so lists nest inside dicts and
+dicts inside lists, and error paths follow the nesting all the way down:
+
+```python
+from probatio import Schema, Required, Invalid
+
+schema = Schema(
+    {
+        Required("servers"): [
+            {Required("host"): str, "ports": [int]},
+        ],
+    }
+)
+
+schema({"servers": [{"host": "a", "ports": [80, 443]}]})
+# {'servers': [{'host': 'a', 'ports': [80, 443]}]}
+
+try:
+    schema({"servers": [{"host": "a", "ports": [80, "x"]}]})
+except Invalid as err:
+    print(err)       # expected int at 'servers[0].ports[1]'
+    print(err.path)  # ['servers', 0, 'ports', 1]
+```
+
+## Where to next
+
+- [The validation model](/guides/validation-model/): the mental model behind
+  every schema shape.
+- [Dict schemas and markers](/guides/dict-schemas-and-markers/): the mapping
+  side, with `Required`, defaults, and the extra-key policy.
+- [Built-in validators](/guides/validators/): `Unique`, `Sorted`, `Unordered`,
+  `EnsureList`, and the rest of the collection toolbox.

--- a/docs/src/content/docs/guides/testing-with-pytest.md
+++ b/docs/src/content/docs/guides/testing-with-pytest.md
@@ -79,12 +79,12 @@ matcher just as well as a fresh one.
 
 ```python
 from pytest_probatio import Exact, Partial
-from probatio import Schema, Email, Range
+from probatio import Schema, All, Email, Range
 
 # The shape of a user, defined once and shared by every test below.
 USER = Schema(
     {
-        "id": Range(min=1),
+        "id": All(int, Range(min=1)),
         "name": str,
         "email": Email(),
     }
@@ -112,15 +112,48 @@ def test_user_detail_may_carry_extra_fields(api):
     assert api.get("/users/1?expand=true").json() == Partial(USER)
 ```
 
-Here `api` is your application's test client, an ordinary pytest fixture you
-provide (a `fixture` that returns the schema works the same way, if you would
-rather inject the schema than import a module-level constant). When a response is
-wrong, the failure names the exact field, even inside the composed list:
+The `id` field is `All(int, Range(min=1))` rather than a bare `Range`: `Range`
+alone accepts any comparable value, like `1.5`, so pin the type first. Here
+`api` is your application's test client, an ordinary pytest fixture you
+provide. The schema can be injected the same way: a fixture that returns `USER`
+works just as well as the module-level constant. When a response is wrong, the
+failure names the exact field, even inside the composed list:
 
 ```text
 data does not match the probatio schema (==):
   users[0].email: expected an email address
 ```
+
+## Asserting a rejection with `raises`
+
+The matchers assert that data _fits_ a schema. To assert that a schema
+_rejects_ something, the core library ships a `raises` context manager, kept
+for drop-in compatibility with voluptuous. It comes from `probatio` itself, not
+from the plugin, so it works with or without pytest:
+
+```python
+from probatio import Schema, MultipleInvalid, raises
+
+schema = Schema({"port": int})
+
+with raises(MultipleInvalid):
+    schema({"port": "nope"})
+```
+
+The optional second argument asserts the exact `str()` of the error, and
+`regex=` matches it with `re.search` instead:
+
+```python
+with raises(MultipleInvalid, "expected int at 'port'"):
+    schema({"port": "nope"})
+
+with raises(MultipleInvalid, regex=r"expected int"):
+    schema({"port": "nope"})
+```
+
+`pytest.raises` works too, of course. Reach for probatio's `raises` when
+porting voluptuous tests that already use it, or when you want the exact-match
+message check without the pytest import.
 
 ## Why a separate package
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -7,6 +7,53 @@ A short list of the things that trip people up, with the symptom first and the
 fix second. Most of them are points where Probatio matches voluptuous exactly,
 so the fix is the same one you would reach for there.
 
+## My test asserting the voluptuous error string broke
+
+The number-one migration symptom. Probatio renders errors with a dotted path
+(`expected int at 'server.port'`) where voluptuous rendered
+`expected int for dictionary value @ data['server']['port']`. That is a
+deliberate deviation, listed on the
+[compatibility matrix](/reference/compatibility-matrix/), not a bug to report.
+
+Do not assert on `str(err)`. Assert on the structured attributes, which match
+voluptuous exactly: `path`, `error_message` (the bare message without the
+path), and the exception class.
+
+```python
+from probatio import Schema, MultipleInvalid
+
+schema = Schema({"server": {"port": int}})
+
+try:
+    schema({"server": {"port": "nope"}})
+except MultipleInvalid as err:
+    print(err)                          # expected int at 'server.port'
+    print(err.errors[0].path)           # ['server', 'port']
+    print(err.errors[0].error_message)  # expected int
+```
+
+## My extra keys were rejected
+
+A key the schema does not name is rejected by default, matching voluptuous.
+The first hour with a real payload usually surfaces this. Allow extras
+schema-wide with `extra=ALLOW_EXTRA`, or per key with the `Extra` catch-all
+(`{Extra: object}`), which the
+[dict schemas guide](/guides/dict-schemas-and-markers/) covers in full.
+
+```python
+from probatio import Schema, Invalid, ALLOW_EXTRA
+
+strict = Schema({"name": str})
+
+try:
+    strict({"name": "app", "debug": True})
+except Invalid as err:
+    print(err)  # not a valid option at 'debug'
+
+relaxed = Schema({"name": str}, extra=ALLOW_EXTRA)
+relaxed({"name": "app", "debug": True})  # {'name': 'app', 'debug': True}
+```
+
 ## I caught `Invalid` but got a `MultipleInvalid`
 
 A `Schema` call always wraps its failures in `MultipleInvalid`, even when there
@@ -123,8 +170,8 @@ schema({"keep": 1, "drop": "x"})  # {'keep': 1}
 A recursive `Self` schema has a depth guard, so cyclic or pathologically deep
 data raises a clean `Invalid` instead of crashing the interpreter with a
 `RecursionError`. The limit scales with the interpreter's recursion limit. Real
-data is nowhere near it; if you knowingly need deeper, raise
-`sys.setrecursionlimit` before validating.
+data is nowhere near it; if you knowingly need deeper, raise the interpreter's
+recursion limit with `sys.setrecursionlimit()` before validating.
 
 ## A difference from voluptuous that is not documented
 

--- a/docs/src/content/docs/guides/typeddict.md
+++ b/docs/src/content/docs/guides/typeddict.md
@@ -62,7 +62,9 @@ schema. Pass `extra=ALLOW_EXTRA` (keyword-only) to keep unknown keys instead.
 A `TypedDict` carries its own notion of which keys are required, and the schema
 honors it. A `total=False` class makes every key optional; `Required` and
 `NotRequired` set it per key. An optional key that is absent is simply left out of
-the result, no default is invented.
+the result, no default is invented. Because requiredness comes from the
+`TypedDict` itself, there is no `required` argument to override it, unlike
+`DataclassSchema`.
 
 ```python
 from typing import TypedDict, NotRequired
@@ -144,6 +146,21 @@ schema = TypedDictSchema(Config, {"host": Length(min=2)})
 schema({"port": 8080, "host": "nas"})  # {'port': 8080, 'host': 'nas'}
 ```
 
+With `Annotated`, the rule lives on the field itself, next to the type:
+
+```python
+from typing import Annotated, TypedDict
+
+from probatio import TypedDictSchema, Range
+
+
+class Net(TypedDict):
+    port: Annotated[int, Range(min=1, max=65535)]
+
+
+TypedDictSchema(Net)({"port": 8080})  # {'port': 8080}
+```
+
 ## The functional form
 
 `create_typeddict_schema(typeddict_type, additional_constraints=None)` builds the
@@ -186,6 +203,30 @@ The one difference is the result: a dataclass schema constructs an instance, a
 TypedDict schema returns the validated dict. Because nothing is constructed, a
 `TypedDict` also accepts `Key(forbidden=True)`/`Key(remove=True)` fields with no
 default (they simply shape the validated dict), where a dataclass would need one.
+
+## Speed
+
+The [compiled engine](/guides/compiled-schemas/) applies here too:
+`TypedDictSchema` takes the same `compile=True` flag and `.compile()` method,
+and under the default policy a hot schema compiles itself. The trusted escape
+hatch also carries over: `TypedDictSchema.construct(data)` skips validation and,
+since nothing is constructed, returns the dict unchanged (see
+[trusted construction](/guides/dataclasses/#trusted-construction-without-validation)).
+
+```python
+from typing import TypedDict
+
+from probatio import TypedDictSchema
+
+
+class Point(TypedDict):
+    x: int
+    y: int
+
+
+POINT = TypedDictSchema(Point).compile()
+POINT({"x": 1, "y": 2})  # {'x': 1, 'y': 2}
+```
 
 ## Limits
 

--- a/docs/src/content/docs/guides/validation-model.md
+++ b/docs/src/content/docs/guides/validation-model.md
@@ -23,14 +23,14 @@ Schema({"a": int})({"a": 1})  # {'a': 1}
 
 Each kind of object means something:
 
-| You write              | It means                                                  |
-| ---------------------- | --------------------------------------------------------- |
-| a type (`int`)         | the value must be an instance of that type                |
-| a literal (`"on"`)     | the value must equal that literal                         |
-| a `dict`               | a mapping, each key and value validated by its own schema |
-| a `list`/`tuple`/`set` | a sequence, each item matching one of the element schemas |
-| a callable             | called with the value; it returns the result or raises    |
-| a nested `Schema`      | validated as its own schema                               |
+| You write              | It means                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| a type (`int`)         | the value must be an instance of that type                                                                    |
+| a literal (`"on"`)     | the value must equal that literal                                                                             |
+| a `dict`               | a mapping, each key and value validated by its own schema                                                     |
+| a `list`/`tuple`/`set` | a sequence, each item matching one of the element schemas (see [sequence schemas](/guides/sequence-schemas/)) |
+| a callable             | called with the value; it returns the result or raises                                                        |
+| a nested `Schema`      | validated as its own schema                                                                                   |
 
 Because a schema is just data, schemas compose: a dict can hold lists of nested
 dicts, and any value position can be a validator like `All` or `Coerce`.
@@ -50,7 +50,9 @@ for record in [{"name": "a"}, {"name": "b"}]:
 ```
 
 Keep schemas at module scope, or build them once in a constructor, rather than
-rebuilding inside a hot loop.
+rebuilding inside a hot loop. The numbers, and the opt-in compiled mode that
+goes further, live in the [performance reference](/reference/performance/) and
+the [compiled schemas guide](/guides/compiled-schemas/).
 
 ## Validation returns a new value
 
@@ -93,11 +95,11 @@ raises `SchemaError`, because that is a programming mistake, not bad input. See
 
 ## Order matters
 
-Within `All`, validators run left to right and each receives the previous
-result, so `All(Coerce(int), Range(min=0))` coerces before it range-checks. The
-reverse order would range-check a string. Marker defaults and group rules also
-have defined timing. Where order is significant, the guides call it out, and it
-matches voluptuous.
+Within `All`, validators form a pipeline: each receives the previous result,
+left to right. `All(Strip, Length(min=1))` trims whitespace before it measures,
+so a string of only spaces fails; swapped, the untrimmed string would slip
+through. Marker defaults and group rules also have defined timing. Where order
+is significant, the guides call it out, and it matches voluptuous.
 
 ## Where to next
 

--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -6,7 +6,7 @@ description: A tour of the validators Probatio ships with, grouped by what they 
 A validator is a callable that takes a value and returns it (possibly
 normalized), or raises `Invalid`. Probatio ships a stack of them so you rarely
 have to write your own. This page walks the toolbox by category, with a short
-runnable example for each.
+runnable example for nearly all of them.
 
 These are the leaf validators. The combinators that compose them (`All`, `Any`,
 `Union`, `SomeOf`) live in the [combinators guide](/guides/combinators/), and the
@@ -219,7 +219,9 @@ want to reject non-strings, put a `str` check ahead of the transform with `All`.
 ## Format and checksum
 
 A handful of validators check a structured format or a checksum, all pure (no
-network, no extra dependency): `CreditCard` (the Luhn check), `IBAN` (the ISO 13616
+network, no extra dependency). Like the network validators below, these are
+Probatio additions with no voluptuous equivalent: `CreditCard` (the Luhn
+check), `IBAN` (the ISO 13616
 mod-97 check), `DataURI` (an RFC 2397 `data:` URI), and `E164` (a phone number in
 international format). By default `CreditCard`, `IBAN`, and `E164` canonicalize the
 input (strip grouping, upper-case the IBAN); pass `normalize=False` to validate and
@@ -260,10 +262,13 @@ mapping) and returns the value unchanged; `AsTimedelta` accepts the same forms a
 returns the parsed `datetime.timedelta`, the same `Datetime`/`AsDatetime` split. An
 ISO 8601 duration is limited to the fields a `timedelta` can represent (weeks, days,
 hours, minutes, seconds); a year or a month is rejected, since neither is a fixed
-length. `TimeZoneInfo` validates an IANA name (object via `Coerce(zoneinfo.ZoneInfo)`,
-whose constructor takes the name), and `TimeZone` validates a fixed UTC offset
-(`+01:00`, `Z`, `UTC`), with `AsTimezone` as the object-returning sibling that parses
-the offset into a `datetime.timezone`.
+length.
+
+For time zones, `TimeZoneInfo` validates an IANA name (for the `ZoneInfo`
+object itself, wrap the type: `Coerce(zoneinfo.ZoneInfo)`; its constructor
+takes the name). `TimeZone` validates a fixed UTC offset (`+01:00`, `Z`,
+`UTC`), with `AsTimezone` as the object-returning sibling that parses the
+offset into a `datetime.timezone`.
 
 ```python
 import zoneinfo
@@ -407,6 +412,16 @@ Schema(Base64())("aGVsbG8=")  # 'aGVsbG8='
 Schema(Hex())("deadbeef")     # 'deadbeef'
 ```
 
+`HexInt` is the parsing sibling of `Hex`: it reads a hexadecimal string (a
+leading `0x` is optional) and returns the `int`.
+
+```python
+from probatio import Schema, HexInt
+
+Schema(HexInt())("ff")    # 255
+Schema(HexInt())("0x1A")  # 26
+```
+
 ## Filesystem
 
 `IsDir`, `IsFile`, and `PathExists` check a path on disk, with `IsSymlink`,
@@ -485,6 +500,10 @@ schema = Schema(
 )
 schema({"start": 1, "end": 2})  # unchanged
 ```
+
+For a plain predicate on a single value, rather than a whole mapping, the
+`truth` decorator (a voluptuous-compat helper) turns it into a validator; the
+[custom validators guide](/guides/custom-validators/) covers it.
 
 `AtLeastOne`, `AtMostOne`, `ExactlyOne`, and `AllOrNone` are the key-group
 presence rules: how many of a set of keys may or must appear. `AtLeastOne("host",

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -62,6 +62,11 @@ change before 1.0 while the project gathers production feedback.
   </Card>
 </CardGrid>
 
+It is also fast for pure Python: roughly two to three times voluptuous's speed
+on a representative config schema, and about seven times once a schema
+[compiles itself](/guides/compiled-schemas/). The numbers, and how to reproduce
+them, are on the [performance page](/reference/performance/).
+
 ## At a glance
 
 Define a schema, then call it with a value to validate it:
@@ -81,18 +86,18 @@ schema({"name": "Frenck", "age": 40})
 ```
 
 When a value does not match, the schema raises `Invalid` (or `MultipleInvalid`)
-with a path to the offending value:
+with a path to the offending value, however deep it sits:
 
 ```python
 from probatio import Schema, Invalid
 
-schema = Schema({"port": int})
+schema = Schema({"server": {"port": int}})
 
 try:
-    schema({"port": "nope"})
+    schema({"server": {"port": "nope"}})
 except Invalid as err:
     print(err)
-    # expected int at 'port'
+    # expected int at 'server.port'
 ```
 
 ## Why trust it

--- a/docs/src/content/docs/project/about.md
+++ b/docs/src/content/docs/project/about.md
@@ -42,9 +42,20 @@ Reaching for validation in Python tends to mean one of a few trades:
   model and a migration, not a drop-in. It has also broken backward compatibility
   and reshaped its API substantially in the past (the v1 to v2 rewrite), which is
   not a foundation this project wants to stand on.
+- **marshmallow** validates and (de)serializes through declarative schema
+  classes with explicit field objects, built around the load and dump cycle. A
+  solid model, but a class you declare, not data you compose.
+- **cerberus** keeps the schema as data, like voluptuous, but as dicts of
+  string rule names rather than live Python objects, so composing and reusing
+  schema pieces means manipulating nested dicts.
+- **jsonschema** validates against the JSON Schema specification. The right
+  tool when the contract is a JSON Schema document, less so as a general
+  Python-side validator.
 
 There simply was not a maintained library that kept voluptuous's
-schema-is-data feel while fixing the edges and keeping pace with Python.
+schema-is-data feel while fixing the edges and keeping pace with Python. The
+[comparison page](/project/comparison/) walks through each of these in more
+depth, including when the other library is the better choice.
 
 ## What Probatio is
 
@@ -60,8 +71,9 @@ On top of the drop-in promise, Probatio fixes the rough edges (clean errors on
 deep or cyclic data, no leaked exceptions from built-ins, a richer error model),
 adds tooling voluptuous never had (JSON Schema, OpenAPI, dataclass and
 field-list codecs), and is pure Python with zero required runtime dependencies.
-It is held to a high bar for code and prose, because it is public and read
-closely.
+It is also fast: on a representative config schema, roughly two to three times
+faster than voluptuous interpreted, and more once a hot schema compiles itself.
+The [performance page](/reference/performance/) has the honest numbers.
 
 The compatibility is measured, not asserted: Home Assistant's own
 `config_validation` test suite runs against Probatio (the full suite passing), and

--- a/docs/src/content/docs/project/architecture.md
+++ b/docs/src/content/docs/project/architecture.md
@@ -9,12 +9,16 @@ big choices, read the architecture decision records in
 [`adr/`](https://github.com/frenck/probatio/tree/main/adr), starting at
 [`adr/README.md`](https://github.com/frenck/probatio/blob/main/adr/README.md).
 
-Probatio is pure Python. No native extension, no build step, no compiler. That
-is a deliberate choice, not a limitation we have not gotten around to yet. The
-target workload (config validation, such as Home Assistant) runs at load time,
-not in a hot inner loop, and the pure-Python engine already beats voluptuous
-there. See [ADR-004](https://github.com/frenck/probatio/blob/main/adr/004-single-validation-engine.md)
-for the measurements and the call to keep a single engine.
+Probatio is pure Python. No native extension, nothing to build at install
+time. That is a deliberate choice, not a limitation I have not gotten around to
+yet. The target workload (config validation, such as Home Assistant) runs at
+load time, not in a hot inner loop, and the interpreted engine already beats
+voluptuous there. On top of that engine sits an optional compiled fast path: a
+hot schema generates specialized Python for itself, purely as an accelerator.
+[ADR-004](https://github.com/frenck/probatio/blob/main/adr/004-single-validation-engine.md)
+and [ADR-011](https://github.com/frenck/probatio/blob/main/adr/011-opt-in-compiled-schema.md)
+together tell that story: one set of validation semantics, with speed layered
+on top of it.
 
 ## The layers
 
@@ -34,18 +38,42 @@ Markers live in `markers.py`. These are dictionary keys that carry intent:
 catch-all. Each compares and hashes by its underlying key, so a marker can stand
 in for the bare key it wraps.
 
+### Errors for humans
+
+On top of the raw errors sits the rendering layer. Every built-in error carries
+a stable `translation_key` and `placeholders`, drawn from the message catalog in
+`_messages.py`, so a consumer can present a failure in its own words or its own
+language instead of parsing a finished string. `humanize.py` renders the
+default human-facing output: dotted paths, "did you mean ...?" suggestions, and
+`Secret` redaction. [ADR-015](https://github.com/frenck/probatio/blob/main/adr/015-structured-errors-and-localization.md)
+covers why the structured data is the API and the English text is just one
+rendering of it.
+
 ### The engine
 
-`_engine.py` is the compiled core. A schema is compiled once into a callable,
-then run per validation. Think of it like `re.compile`: you pay the build cost
-once, then validate many values cheaply.
+`_engine.py` is the interpreted core. A schema is compiled once into a
+callable, then run per validation. Think of it like `re.compile`: you pay the
+build cost once, then validate many values cheaply.
 
 The engine owns the mapping and sequence validators, where the awkward
 voluptuous semantics live: marker precedence, literal keys before type keys,
-the extra-key policy, and the exact error paths. There is one engine and one set
-of mapping semantics. ADR-004 explains why a second implementation (the removed
-codegen path) was not worth the permanent tax of keeping two engines
-behaviorally identical.
+the extra-key policy, and the exact error paths. There is one set of validation
+semantics, and this engine is it.
+[ADR-004](https://github.com/frenck/probatio/blob/main/adr/004-single-validation-engine.md)
+explains why an earlier second engine was removed: two full implementations
+must stay behaviorally identical on every corner case, and that equivalence tax
+rots.
+
+[ADR-011](https://github.com/frenck/probatio/blob/main/adr/011-opt-in-compiled-schema.md)
+revisits that decision with a design that avoids the tax. `_codegen.py`
+generates a flat, success-path-only function for a schema's exact shape, and
+`_compile_policy.py` decides when: under the default `AUTO` policy a schema
+compiles itself only once it has proven hot. The generated code handles only
+the happy path. On any failure (a missing key, a type mismatch, a validator
+raising) it bails to the interpreted engine, which produces every error, path,
+and ordering. So compiling changes speed, never behavior, and the semantics
+still live in one place. The knobs are in the
+[compiled schemas guide](/guides/compiled-schemas/).
 
 One small optimization stays: validators can declare `__probatio_safe__` to
 promise they only raise `Invalid`, and the engine then calls them without the
@@ -62,13 +90,38 @@ and returns the normalized result, or raises.
 This is the compile-once-then-validate model in one object. Build the schema
 when your program starts, call it on every value after that.
 
+### Dataclass and TypedDict schemas
+
+`dataclass_schema.py` builds schemas from type annotations instead of dict
+literals. `create_dataclass_schema` and `create_typeddict_schema` read a class's
+fields, infer `Required` and `Optional` from defaults, and turn each annotation
+(including `Annotated[int, Range(...)]`) into a schema fragment through a shared
+annotation engine. `DataclassSchema` validates a dict and constructs the
+instance in one step.
+[ADR-013](https://github.com/frenck/probatio/blob/main/adr/013-markers-on-annotated-fields.md)
+covers the field-metadata spec that lets an `Annotated` field carry marker
+facets like `Secret` and `Alias`.
+
+### The probatio decorator
+
+`decorator.py` is the same annotation engine pointed at a function signature.
+`@probatio` reads each parameter's annotation, validates the arguments before
+the body runs, and works on coroutine functions too
+([ADR-014](https://github.com/frenck/probatio/blob/main/adr/014-annotation-driven-argument-decorator.md)).
+The older `validate` decorator (schemas named by hand, sync-only) stays for the
+voluptuous drop-in.
+
 ### The validators
 
-`validators/` holds the building blocks you compose schemas from, grouped by
-what they do: combinators (`All`, `Any`, `Union`, `SomeOf`), comparison and
-membership (`Range`, `In`, `Equal`), coercion (`Coerce`, `Boolean`), strings
-(`Email`, `Url`, the case transforms), structural (`Length`, `ExactSequence`,
-`Object`), temporal (`Datetime`, `Date`), predicates, and the `validate`
+`validators/` holds the building blocks you compose schemas from, one module
+per group: combinators (`All`, `Any`, `Union`, `SomeOf`), comparison and
+membership (`Range`, `In`, `Length`, `Equal`), coercion (`Coerce`, `Boolean`),
+conditional presence (`RequiredWith`, `ExactlyOne`), encodings (`Base64`,
+`JSONString`), checksummed formats (`CreditCard`, `IBAN`), identifiers (`UUID`,
+`ULID`, `MacAddress`), network (`IPAddress`, `Hostname`, `Port`), strings
+(`Email`, `Url`, the case transforms), structural (`ExactSequence`, `Unique`,
+`Maybe`), temporal (`Datetime`, `Date`, `Duration`), transitions between an old
+and a new payload (`Immutable`, `WriteOnce`), predicates, and the `validate`
 decorator. They share a small base in `validators/_base.py`.
 
 ### The codecs
@@ -97,8 +150,12 @@ this layer.
 
 `compat/` is the thin top layer that backs the drop-in promise. It exposes the
 voluptuous names and signatures so changing the import from `voluptuous` to
-`probatio` keeps existing schemas working. Behavior, not source, is what is
-matched here. No code was copied ([ADR-001](https://github.com/frenck/probatio/blob/main/adr/001-clean-room-reimplementation-of-voluptuous.md)).
+`probatio` keeps existing schemas working. The plumbing behind it lives in
+`_vol_shim/`: the voluptuous-shaped modules (`error`, `validators`,
+`schema_builder`, `util`) that `compat.install_as_voluptuous` registers under
+the `voluptuous` name, so even a dependency that imports voluptuous internals
+resolves to Probatio. Behavior, not source, is what is matched here. No code
+was copied ([ADR-001](https://github.com/frenck/probatio/blob/main/adr/001-clean-room-reimplementation-of-voluptuous.md)).
 
 ## Where to read next
 

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -18,16 +18,17 @@ better job, and this page says where.
 
 ## The short answer
 
-| Pick this when                                              | Reach for      |
-| ----------------------------------------------------------- | -------------- |
-| You use voluptuous today and want a maintained replacement  | Probatio       |
-| Your data is plain dicts and lists, schema as data          | Probatio       |
-| You want typed model objects with editor and type support   | pydantic       |
-| You want declarative schema classes with load and dump      | marshmallow    |
-| Your contract is a JSON Schema document                     | jsonschema     |
-| You are (de)serializing your own classes                    | attrs / cattrs |
-| You (de)serialize dataclasses fast, in a known format       | mashumaro      |
-| You just need a dict turned into a dataclass, no validation | dacite         |
+| Pick this when                                              | Reach for                     |
+| ----------------------------------------------------------- | ----------------------------- |
+| You use voluptuous today and want a maintained replacement  | Probatio                      |
+| Your data is plain dicts and lists, schema as data          | Probatio                      |
+| You want typed model objects with editor and type support   | pydantic                      |
+| You want declarative schema classes with load and dump      | marshmallow                   |
+| Your schemas are cerberus rule dicts                        | cerberus, or port to Probatio |
+| Your contract is a JSON Schema document                     | jsonschema                    |
+| You are (de)serializing your own classes                    | attrs / cattrs                |
+| You (de)serialize dataclasses fast, in a known format       | mashumaro                     |
+| You just need a dict turned into a dataclass, no validation | dacite                        |
 
 ## voluptuous
 
@@ -66,16 +67,16 @@ better or worse one.
 
 On raw speed the Rust core is genuinely fast, but the advantage is not uniform, and
 it is worth being precise about where it comes from. It is largest on heavy coercion
-and decoding, parsing a stack of ISO datetimes and enums out of JSON, where the
-native code does real work Probatio does in Python (the cross-library benchmark on
+and decoding: parsing a stack of ISO datetimes and enums out of JSON, where the
+native code does real work Probatio does in Python. The cross-library benchmark on
 the [performance page](/reference/performance/) is exactly that kind of workload, and
-pydantic v2 sits near the top of it). It shrinks on a schema dominated by your own
-**custom validators**: a native core cannot run a Python validator natively, it has
-to call it across the Rust boundary (pydantic does so efficiently, but it is still a
-Python call), so the speedup is muted exactly where the work is your code rather than
-the library's. "Faster because Rust" holds in the parsing-heavy regime, not
-everywhere, and Probatio stays pure Python with no native extension to build or
-install.
+pydantic v2 sits near the top of it. The advantage shrinks on a schema dominated by
+your own **custom validators**, because a native core cannot run a Python validator
+natively; it has to call it across the Rust boundary (pydantic does so efficiently,
+but it is still a Python call), so the speedup is muted exactly where the work is
+your code rather than the library's. "Faster because Rust" holds in the
+parsing-heavy regime, not everywhere, and Probatio stays pure Python with no native
+extension to build or install.
 
 :::note
 The two can live side by side. Use pydantic where you want typed models, use
@@ -95,8 +96,25 @@ Probatio is the better fit when the schema is data you build and compose at runt
 rather than a class you declare, when you validate free-form dicts, or when you are
 replacing voluptuous. marshmallow fits when you want explicit schema classes and its
 serialization story. Probatio is also a good deal faster on the cross-library
-[benchmark](/reference/performance/), marshmallow does more per field and is pure
-Python, but speed is not the main axis here; the model is.
+[benchmark](/reference/performance/) (marshmallow does more per field and is pure
+Python), but speed is not the main axis here; the model is.
+
+## cerberus
+
+`cerberus` is the other schema-is-data validator. You describe rules in a dict
+of string rule names (`{"name": {"type": "string", "required": True}}`), hand
+it to a `Validator`, and check the result. The shared instinct with Probatio is
+real: the schema is data, not a class hierarchy.
+
+The difference is what that data is made of. A cerberus schema is a small rule
+language interpreted by the library, so extending it means registering a rule
+or subclassing the validator. A Probatio schema is live Python objects: plain
+types, callables, and validators you compose directly, so a custom rule is just
+a function, and the schema participates in the rest of your code (imports,
+refactoring, composition) like any other Python value. cerberus is maintained
+and still ships releases; if its rule dicts fit how you think, it is a fine
+choice. If you want the schema itself to be Python you compose, Probatio fits
+better.
 
 ## jsonschema
 
@@ -145,9 +163,9 @@ The two are close on the dict-to-dataclass path, which is worth seeing precisely
 because they do different amounts of work. mashumaro deserializes and largely
 trusts the declared types; Probatio's `DataclassSchema` validates every field
 against its type and then constructs. On a small dataclass, mashumaro builds it in
-about 0.5 µs and a compiled Probatio schema in about 0.7 µs, so Probatio is within
-roughly 1.3x while actually validating, and the gap all but closes as the field
-count grows. That is the trade: mashumaro is faster because it trusts the input,
+about 0.5 µs and Probatio in about 0.7 µs compiled (about 1.5 µs interpreted,
+before the schema compiles itself), so compiled Probatio is within roughly 1.3x
+while actually validating, and the gap all but closes as the field count grows. That is the trade: mashumaro is faster because it trusts the input,
 Probatio costs a little more because it does not. If the input is wrong (a string
 where an int belongs), mashumaro may hand you a dataclass whose values do not match
 their annotations, and Probatio rejects it. Numbers, and how to run them yourself,
@@ -172,8 +190,8 @@ the same family as cattrs and mashumaro: dataclass (de)serialization driven by t
 declared types, not schema validation of free-form data.
 
 Reach for them when you own the dataclasses and want them filled from a dict and do
-not need full validation. Probatio's `DataclassSchema` covers the same dict-to-
-dataclass path with a richer type mapping and real validation, or its opt-in
+not need full validation. Probatio's `DataclassSchema` covers the same
+dict-to-dataclass path with a richer type mapping and real validation, or its opt-in
 `construct` for trusted input. Among the pure (de)serializers, mashumaro and cattrs
 are the fast ones; on the cross-library
 [benchmark](/reference/performance/) `dacite` and `dataclasses-json` are a good deal

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -164,7 +164,7 @@ because they do different amounts of work. mashumaro deserializes and largely
 trusts the declared types; Probatio's `DataclassSchema` validates every field
 against its type and then constructs. On a small dataclass, mashumaro builds it in
 about 0.5 µs and Probatio in about 0.7 µs compiled (about 1.5 µs interpreted,
-before the schema compiles itself), so compiled Probatio is within roughly 1.3x
+before the schema compiles itself), so compiled Probatio is within roughly 1.4x
 while actually validating, and the gap all but closes as the field count grows. That is the trade: mashumaro is faster because it trusts the input,
 Probatio costs a little more because it does not. If the input is wrong (a string
 where an int belongs), mashumaro may hand you a dataclass whose values do not match

--- a/docs/src/content/docs/project/credits.md
+++ b/docs/src/content/docs/project/credits.md
@@ -21,6 +21,23 @@ cover the reasoning.
 The [license](/project/license/) page covers the MIT terms and third-party
 notices in full.
 
+## Ideas borrowed with credit
+
+Clean-room does not mean invented in a vacuum. Several ideas in Probatio are
+borrowed from [mashumaro](https://github.com/Fatal1ty/mashumaro), and the debt
+is recorded where each decision was made:
+[ADR-008](https://github.com/frenck/probatio/blob/main/adr/008-type-to-validator-registry.md)
+(the type-to-validator registry),
+[ADR-009](https://github.com/frenck/probatio/blob/main/adr/009-call-time-validation-context.md)
+(the call-time validation context),
+[ADR-012](https://github.com/frenck/probatio/blob/main/adr/012-trusted-construction-without-validation.md)
+(trusted construction without validation), and
+[ADR-013](https://github.com/frenck/probatio/blob/main/adr/013-markers-on-annotated-fields.md)
+(field metadata on `Annotated` types) all cite its prior art.
+[pydantic](https://docs.pydantic.dev) earns the same credit in ADR-013: its
+`Annotated` field spec is the precedent that settled how Probatio's field
+metadata works.
+
 ## Author
 
 Created and written by **Franck Nijhof**, better known as **Frenck**, a

--- a/docs/src/content/docs/project/license.md
+++ b/docs/src/content/docs/project/license.md
@@ -12,7 +12,7 @@ MIT was a deliberate choice: it lets Probatio fit anywhere voluptuous did,
 including Home Assistant, without trading a maintenance win for a license
 headache ([ADR-002](https://github.com/frenck/probatio/blob/main/adr/002-mit-license.md)).
 The clean-room reimplementation ([ADR-001](https://github.com/frenck/probatio/blob/main/adr/001-clean-room-reimplementation-of-voluptuous.md)) is what makes that
-license honest, no voluptuous source is copied, so nothing constrains it.
+license honest: no voluptuous source is copied, so nothing constrains it.
 
 The authoritative copy is [`LICENSE`](https://github.com/frenck/probatio/blob/main/LICENSE)
 in the repository.

--- a/docs/src/content/docs/project/projects.md
+++ b/docs/src/content/docs/project/projects.md
@@ -5,12 +5,13 @@ description: Where Probatio fits, and who is using it.
 
 Probatio is young. This page tracks projects that use it and, just as usefully,
 the ecosystems it is built to serve. If you adopt Probatio, please
-[open a pull request](https://github.com/frenck/probatio) to add yourself here.
+[edit this page on GitHub](https://github.com/frenck/probatio/edit/main/docs/src/content/docs/project/projects.md)
+and open a pull request to add yourself here.
 
 ## Using Probatio
 
 _Be the first._ There are no public adopters yet. If your project validates data
-with Probatio, we would love to list it.
+with Probatio, I would love to list it.
 
 ## Where Probatio fits
 
@@ -23,10 +24,10 @@ for its design.
 
 Home Assistant validates every integration's configuration with voluptuous, on a
 hot path hit by millions of installations at startup and on every reload.
-Probatio tracks that behavior closely (with documented deviations), its
-compatibility is pinned against Home Assistant's own `config_validation` test
-suite (the full suite passing), and it adds
-a cleaner error model with paths, no interpreter-level `RecursionError` on deep
+Probatio tracks that behavior closely, with documented deviations; how that
+compatibility is measured, including against Home Assistant's own test suite, is
+on the [about page](/project/about/). On top of it, Probatio adds a cleaner
+error model with paths, no interpreter-level `RecursionError` on deep
 configuration, and "did you mean ...?" suggestions for misspelled keys. See the
 [Home Assistant recipe](/recipes/home-assistant/).
 

--- a/docs/src/content/docs/project/roadmap.md
+++ b/docs/src/content/docs/project/roadmap.md
@@ -4,6 +4,9 @@ description: Where Probatio stands today, and what stable means before 1.0.
 ---
 
 Probatio is pre-1.0. Honest status: it works, it is tested, and it is young.
+The current release line is 0.5, with v0.5.4 the latest at the time of writing;
+the [release notes on GitHub](https://github.com/frenck/probatio/releases)
+track what each release changed.
 
 ## The goal
 
@@ -37,8 +40,8 @@ internals are not.
 Probatio follows semantic versioning. While it is pre-1.0 (`0.x`), the practical
 reading is: a patch release (`0.x.y`) is for fixes and compatibility
 corrections, a minor release (`0.x`) may add to the public surface or change an
-internal, and any breaking change to the public API is called out in the release
-notes.
+internal, and any breaking change to the public API is called out in the
+[release notes](https://github.com/frenck/probatio/releases).
 
 Because the public API tracks voluptuous, most changes are really compatibility
 fixes: Probatio moving closer to how voluptuous behaves. Those are bug fixes,
@@ -52,5 +55,6 @@ traceable to its reason.
 
 There are no dates here, and no feature list of things that do not yet exist.
 The roadmap is the goal above: faithful compatibility, then iteration from real
-use. When something ships, it ships in the docs and the changelog, not as a
-promise on this page.
+use. When something ships, it ships in the docs and the
+[release notes](https://github.com/frenck/probatio/releases), not as a promise
+on this page.

--- a/docs/src/content/docs/project/security.md
+++ b/docs/src/content/docs/project/security.md
@@ -41,6 +41,13 @@ code, the same as the rest of your program.
 | Stack exhaustion from deep or cyclic data | Crafted data run through a recursive `Self` schema           | A recursion depth guard raises a clean `Invalid` instead of `RecursionError`                    |
 | Arbitrary object construction from YAML   | Tags in an untrusted YAML payload                            | YAML is always parsed with a safe loader; the unsafe loaders are never used                     |
 
+These guards cover the specific shapes in the table, and only those. What they
+do not do is bound the overall size of the input: a validator cannot know how
+much data is too much for your application, so capping the size and shape of
+what you hand to a schema stays the calling application's job. The project's
+[security policy](https://github.com/frenck/probatio/blob/main/.github/SECURITY.md)
+draws the same line in its out-of-scope list.
+
 ## Regex denial of service
 
 Python's `re` engine backtracks, so a pattern like `(a+)+$` runs in exponential
@@ -195,7 +202,12 @@ wrap it in your own carrier after validation.
 
 ## Reporting a vulnerability
 
-Found something that looks like a security issue? Please report it privately
-through the GitHub security advisories on the
-[project repository](https://github.com/frenck/probatio), not as a public issue.
-That gives a fix time to land before the details are out in the open.
+Found something that looks like a security issue? Please
+[report it privately](https://github.com/frenck/probatio/security/advisories/new)
+through GitHub's private vulnerability reporting, not as a public issue. That
+gives a fix time to land before the details are out in the open.
+
+The full policy lives in
+[`SECURITY.md`](https://github.com/frenck/probatio/blob/main/.github/SECURITY.md):
+the disclosure timeline, what to include in a report, and an email fallback if
+you cannot use GitHub's reporting flow.

--- a/docs/src/content/docs/recipes/config-file.md
+++ b/docs/src/content/docs/recipes/config-file.md
@@ -50,7 +50,7 @@ config = {
     "name": "my-app",
     "server": {"host": "localhost", "port": "9000"},
 }
-Path("config.json").write_text(json.dumps(config, indent=2))  # 85
+_ = Path("config.json").write_text(json.dumps(config, indent=2))
 ```
 
 ## Load and validate

--- a/docs/src/content/docs/recipes/cookbook.md
+++ b/docs/src/content/docs/recipes/cookbook.md
@@ -33,6 +33,12 @@ schema({"type": "point", "x": 1, "y": 2})  # {'type': 'point', 'x': 1, 'y': 2}
 schema({"type": "label", "text": "hi"})    # {'type': 'label', 'text': 'hi'}
 ```
 
+The discriminant sees the raw input, before any validation, so a non-dict input
+raises from `value.get` before the union gets to report anything. A production
+discriminant should guard for that; a
+`if not isinstance(value, dict): return []` up front makes the union reject a
+non-dict with its own clean `Invalid` instead.
+
 A point with a non-int coordinate fails against the point branch, not the whole
 union:
 
@@ -54,6 +60,8 @@ schema = Schema(
 
 schema({"type": "point", "x": "nope", "y": 2})
 ```
+
+Deep dive: [Combinators](/guides/combinators/).
 
 ## Coercing config and environment strings
 
@@ -91,6 +99,8 @@ message to customize the error (`Boolean("not a flag")`). The string transforms
 like `Lower` and `Strip` are plain functions instead, so use those bare.
 :::
 
+Deep dive: [Validators](/guides/validators/).
+
 ## Open mapping with typed keys and values
 
 To describe "any string key, integer value", use a type as the dict key. A type
@@ -118,6 +128,8 @@ schema({"name": "app", "debug": True, "retries": 3})
 # {'name': 'app', 'debug': True, 'retries': 3}
 ```
 
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
+
 ## Nested optional sections with defaults
 
 A whole config section can be optional, holding a nested schema with its own
@@ -144,15 +156,13 @@ schema({"logging": {"level": "debug"}})
 # {'logging': {'level': 'debug', 'file': 'app.log'}}
 ```
 
-The outer default (`dict()`, an empty dict) is validated through the nested
-schema like any other value, so it picks up the inner defaults. A missing section
-and an empty-dict section therefore come back the same, fully populated.
-
 :::note
 Use a callable default (`dict`, `list`) rather than a literal `{}` or `[]`. The
 callable runs per validation, so each result gets its own fresh container instead
 of sharing one mutable object across calls.
 :::
+
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
 
 ## Mutually exclusive and co-dependent keys
 
@@ -214,6 +224,8 @@ except Invalid as err:
     # some but not all values in the same group of inclusion 'server' at '<server>'
 ```
 
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
+
 ## At least one of a group of keys
 
 To require that _at least one_ of several keys is present, while still allowing
@@ -247,6 +259,27 @@ except Invalid as err:
     print(err)  # at least one of ['email', 'phone'] is required at '[Any('email', 'phone', msg=None)]'
 ```
 
+That default group label is honest but ugly: the path segment renders the
+`Any(...)` marker's repr, because the group has no natural key name. (The repr
+leak itself is a known library issue, tracked separately.) The production form
+is a custom `msg` on the marker, read back through `error_message`, which
+carries the message without the path:
+
+```python
+from probatio import Schema, Required, Any, Invalid
+
+schema = Schema(
+    {Required(Any("email", "phone"), msg="provide an email or a phone number"): str}
+)
+
+try:
+    schema({})
+except Invalid as err:
+    print(err.errors[0].error_message)  # provide an email or a phone number
+```
+
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
+
 ## Dropping deprecated keys
 
 `Remove` drops matching keys from the output. The value is still validated, so a
@@ -260,6 +293,8 @@ schema = Schema({"name": str, Remove("legacy_mode"): bool})
 
 schema({"name": "app", "legacy_mode": True})  # {'name': 'app'}
 ```
+
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
 
 ## Extending a base schema with a cross-field rule
 
@@ -307,6 +342,8 @@ except Invalid as err:
     print(err)  # min must be below max
 ```
 
+Deep dive: [Combinators](/guides/combinators/).
+
 ## Recursive tree
 
 `Self` references the schema being defined, which is how you validate tree-shaped
@@ -342,6 +379,8 @@ node = Schema(
 
 node({"name": "root", "children": [{"name": 42}]})
 ```
+
+Deep dive: [Recursive schemas](/guides/recursive-schemas/).
 
 ## Friendly error messages
 
@@ -389,3 +428,6 @@ try:
 except Invalid as err:
     print(err)  # use lowercase letters only
 ```
+
+Deep dive: [Error handling](/guides/error-handling/) and
+[Custom error messages](/guides/custom-error-messages/).

--- a/docs/src/content/docs/recipes/home-assistant.md
+++ b/docs/src/content/docs/recipes/home-assistant.md
@@ -9,16 +9,25 @@ consumers there is. Probatio mirrors the voluptuous API, so it can stand in.
 
 ## The simple case: change the import
 
-If your code uses the voluptuous public API, the swap is a one-liner. Change the
-import and keep your schemas exactly as they are.
+Home Assistant code does not import voluptuous names one by one. The idiom is
+`import voluptuous as vol`, with every schema written against the `vol.`
+namespace: `vol.Schema`, `vol.Required`, `vol.Optional`, `vol.All`. That idiom
+makes the migration a one-line diff, with every `vol.` reference untouched:
+
+```diff
+-import voluptuous as vol
++import probatio as vol
+```
+
+The rest of the file does not change. This runs on Probatio as-is:
 
 ```python
-from probatio import Schema, Required, Optional
+import probatio as vol
 
-CONFIG_SCHEMA = Schema(
+CONFIG_SCHEMA = vol.Schema(
     {
-        Required("name"): str,
-        Optional("port", default=8123): int,
+        vol.Required("name"): str,
+        vol.Optional("port", default=8123): int,
     }
 )
 
@@ -60,18 +69,19 @@ registers and when to call it.
 
 This is not a paraphrase of compatibility. Probatio is validated against Home
 Assistant's own `config_validation` test suite, with voluptuous swapped out for
-Probatio through `install_as_voluptuous`. 136 of the 142 tests pass; the 6 that
-fail all assert the exact voluptuous-rendered error string, which Probatio
-deliberately renders differently (a dotted path instead of `@ data[...]`, see
-the [compatibility matrix](/reference/compatibility-matrix/)). The error
-attributes those tests could assert on instead (`path`, `error_message`, the
-error class) all match.
+Probatio through `install_as_voluptuous`. As of July 2026, 136 of the 142 tests
+pass; the harness in `compat/home_assistant/` in the repository is the source
+of truth for the current count. The 6 that fail all assert the exact
+voluptuous-rendered error string, which Probatio deliberately renders
+differently (a dotted path instead of `@ data[...]`, see the
+[compatibility matrix](/reference/compatibility-matrix/)). The error attributes
+those tests could assert on instead (`path`, `error_message`, the error class)
+all match.
 
 Getting there surfaced real compatibility gaps that isolated unit tests had
 missed, like `Remove(key)` keeping a value that fails its schema, and the
-`error_type` tag on a failed mapping value. Those are fixed. The proof harness
-lives in `compat/home_assistant/` in the repository, so you can reproduce it
-against a Home Assistant checkout.
+`error_type` tag on a failed mapping value. Those are fixed. The harness
+reproduces the run against a Home Assistant checkout.
 
 ## Where to next
 

--- a/docs/src/content/docs/recipes/llm-tools.md
+++ b/docs/src/content/docs/recipes/llm-tools.md
@@ -1,0 +1,114 @@
+---
+title: LLM tool calling and MCP
+description: One Probatio schema as both the tool's JSON Schema definition and the validator for the model's arguments.
+---
+
+LLM tool calling runs on JSON Schema: an Anthropic tool declares its parameters
+as an `input_schema`, an MCP tool as an `inputSchema`, both plain JSON Schema
+documents. And the arguments the model sends back are untrusted input that you
+should validate before executing anything. That is one schema doing two jobs,
+and Probatio covers both directions: `to_json_schema` renders the tool
+definition, and calling the schema validates the arguments.
+
+## Define the tool once
+
+```python
+from probatio import Schema, Required, Optional, All, In, Range, to_json_schema
+
+get_weather = Schema(
+    {
+        Required("location", description="City name, like 'Amsterdam'"): str,
+        Optional("unit", default="celsius"): In(["celsius", "fahrenheit"]),
+        Optional("days", default=1): All(int, Range(min=1, max=14)),
+    }
+)
+
+to_json_schema(get_weather)
+# {'type': 'object', 'properties': {'location': {'type': 'string', 'description': "City name, like 'Amsterdam'"}, 'unit': {'enum': ['celsius', 'fahrenheit'], 'default': 'celsius'}, 'days': {'type': 'integer', 'minimum': 1, 'maximum': 14, 'default': 1}}, 'additionalProperties': False, 'required': ['location']}
+```
+
+The `description` on a marker flows into the JSON Schema, and the model reads
+it, so write it for the model. The output also carries
+`additionalProperties: False`, which strict tool use requires.
+
+## Use it as the tool definition
+
+The rendered dict goes straight into an Anthropic `tools` entry as
+`input_schema`:
+
+<!-- verify: skip -->
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+response = client.messages.create(
+    model="claude-opus-4-8",
+    max_tokens=1024,
+    tools=[
+        {
+            "name": "get_weather",
+            "description": "Get the weather forecast for a city.",
+            "input_schema": to_json_schema(get_weather),
+        }
+    ],
+    messages=[{"role": "user", "content": "What is the weather in Amsterdam?"}],
+)
+```
+
+An MCP server is the same move with a different key: the dict becomes the
+tool's `inputSchema` in its tool listing.
+
+## Validate the model's arguments
+
+When the model calls the tool, run its arguments through the same schema
+before executing. Valid arguments come back normalized, with the defaults
+filled in:
+
+```python
+get_weather({"location": "Amsterdam"})
+# {'location': 'Amsterdam', 'unit': 'celsius', 'days': 1}
+```
+
+Bad arguments fail with a path-precise error. Feed that message back to the
+model as the tool result (with `is_error` set) and it will correct itself:
+
+```python
+from probatio import MultipleInvalid
+
+try:
+    get_weather({"location": "Amsterdam", "days": 30})
+except MultipleInvalid as err:
+    print(err)  # value must be at most 14 at 'days'
+```
+
+One schema, both directions: the definition the model sees and the validation
+its output gets cannot drift apart, because they are the same object.
+
+## When the schema comes from elsewhere
+
+Sometimes the JSON Schema is not yours: a tool listed by an MCP server you
+consume, or a tool definition stored as JSON. `from_json_schema` turns it into
+a validator, treating the document as untrusted (a catastrophic `pattern` or a
+pathologically deep document is refused with `SchemaError`):
+
+```python
+from probatio import from_json_schema
+
+document = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}, "limit": {"type": "integer", "minimum": 1}},
+    "required": ["query"],
+}
+validate_args = from_json_schema(document)
+validate_args({"query": "probatio", "limit": 5})  # {'query': 'probatio', 'limit': 5}
+```
+
+## Where to next
+
+- [JSON Schema](/guides/json-schema/): the full keyword mapping, round-trip
+  caveats, and the untrusted-input guards.
+- [Validating API requests](/recipes/web-api/): the same validate-or-reject
+  flow at an HTTP boundary.
+- [Error handling](/guides/error-handling/): shaping the failure you feed back
+  to the model.

--- a/docs/src/content/docs/recipes/web-api.md
+++ b/docs/src/content/docs/recipes/web-api.md
@@ -1,0 +1,138 @@
+---
+title: Validating API requests
+description: Validate a request body with a schema and turn failures into a JSON 400 with per-field errors.
+---
+
+A request body is untrusted input. Validate it at the boundary, and when it
+fails, answer with a 400 that names every offending field, not just the first
+one. Probatio collects all failures in one pass and exposes them as structured
+data, so the error response is a small dict comprehension away. This recipe
+builds that flow with plain Python first, then shows where it plugs into a
+framework.
+
+## The request schema
+
+A realistic signup payload: a username with length bounds, an email, a minimum
+age, an optional newsletter flag with a default, a nested address, and a list
+of tags:
+
+```python
+from probatio import Schema, Required, Optional, All, Length, Range, Email
+
+signup = Schema(
+    {
+        Required("username"): All(str, Length(min=3, max=30)),
+        Required("email"): Email(),
+        Required("age"): All(int, Range(min=13)),
+        Optional("newsletter", default=False): bool,
+        Required("address"): {
+            Required("city"): str,
+            Required("postal_code"): str,
+        },
+        Optional("tags", default=list): [str],
+    }
+)
+```
+
+A valid body comes back normalized, with the defaults filled in:
+
+```python
+body = {
+    "username": "ada",
+    "email": "ada@example.com",
+    "age": 37,
+    "address": {"city": "Delft", "postal_code": "2611"},
+}
+signup(body)
+# {'username': 'ada', 'email': 'ada@example.com', 'age': 37, 'address': {'city': 'Delft', 'postal_code': '2611'}, 'newsletter': False, 'tags': []}
+```
+
+## Validate or 400
+
+An invalid body raises `MultipleInvalid`, whose `errors` list holds one
+`Invalid` per problem. Each carries `path` (the keys to the offending value)
+and `error_message` (the bare message, no path). That is everything a JSON
+error response needs:
+
+```python
+from probatio import MultipleInvalid
+
+
+def error_response(err):
+    """Build the JSON body of a 400 from a MultipleInvalid."""
+    return {
+        "error": "validation_failed",
+        "details": [
+            {"field": ".".join(str(seg) for seg in e.path), "message": e.error_message}
+            for e in err.errors
+        ],
+    }
+
+
+bad = {
+    "username": "ab",
+    "email": "not-an-email",
+    "age": 37,
+    "address": {"city": "Delft"},
+}
+
+try:
+    signup(bad)
+except MultipleInvalid as err:
+    print(error_response(err))
+    # {'error': 'validation_failed', 'details': [{'field': 'username', 'message': 'length of value must be at least 3'}, {'field': 'email', 'message': 'expected an email address'}, {'field': 'address.postal_code', 'message': 'required key not provided'}]}
+```
+
+Three problems, three entries, and the nested one reads as
+`address.postal_code`. The client can highlight each field.
+
+For a machine-readable contract, each error also offers `as_dict()`, the whole
+structured layer in one serializable dict: a stable `code`, the `path` as a
+list, and localization slots:
+
+```python
+try:
+    signup(bad)
+except MultipleInvalid as err:
+    print(err.errors[0].as_dict())
+    # {'code': 'length', 'message': 'length of value must be at least 3', 'path': ['username'], 'secret': False, 'context': {}, 'translation_key': 'length_min', 'placeholders': {'min': 3}}
+```
+
+Prefer `as_dict()` when clients branch on the failure kind or translate
+messages; the hand-built shape above is fine when they only display them.
+
+## Plugging into a framework
+
+The flow is the same everywhere: parse JSON, call the schema, catch
+`MultipleInvalid`, return 400. In Flask:
+
+<!-- verify: skip -->
+
+```python
+from flask import Flask, jsonify, request
+from probatio import MultipleInvalid
+
+app = Flask(__name__)
+
+
+@app.post("/signup")
+def create_signup():
+    try:
+        data = signup(request.get_json())
+    except MultipleInvalid as err:
+        return jsonify(error_response(err)), 400
+    user = create_user(data)  # your application logic, on clean data
+    return jsonify(user), 201
+```
+
+FastAPI users can do the same inside a route taking a `dict` body, or raise
+`HTTPException(status_code=400, detail=error_response(err))`.
+
+## Where to next
+
+- [Error handling](/guides/error-handling/): paths, `MultipleInvalid`, and the
+  structured layer behind `as_dict()`.
+- [JSON Schema](/guides/json-schema/): publish the same schema to clients as
+  JSON Schema with `to_json_schema`.
+- [Dict schemas and markers](/guides/dict-schemas-and-markers/): required and
+  optional keys, defaults, and the extra-key policy.

--- a/docs/src/content/docs/reference/builtins-by-role.md
+++ b/docs/src/content/docs/reference/builtins-by-role.md
@@ -107,53 +107,50 @@ Check a value and return it unchanged.
 
 ### Strings and formats
 
-| Name             | Note                                           |
-| ---------------- | ---------------------------------------------- |
-| `Email`          | An email address.                              |
-| `Url`            | A URL.                                         |
-| `FqdnUrl`        | A URL with a fully qualified domain.           |
-| `Slug`           | A URL slug.                                    |
-| `Alpha`          | Letters only.                                  |
-| `Alphanumeric`   | Letters and digits only.                       |
-| `ASCII`          | ASCII characters only.                         |
-| `PrintableASCII` | Printable ASCII only.                          |
-| `NoWhitespace`   | No whitespace characters.                      |
-| `StartsWith`     | Begins with a prefix.                          |
-| `EndsWith`       | Ends with a suffix.                            |
-| `ByteLength`     | UTF-8 byte length within bounds.               |
-| `HexColor`       | A hex color; compose `Lower`/`Upper` for case. |
-| `Hex`            | Hexadecimal; checks, does not decode.          |
-| `Base64`         | Base64; checks, does not decode.               |
-| `JSONString`     | A JSON string; value via `FromJSONString`.     |
-| `YAMLString`     | A YAML string; value via `FromYAMLString`.     |
-| `ULID`           | A ULID; compose `Upper` for canonical case.    |
-| `CreditCard`     | A card number (Luhn).                          |
-| `IBAN`           | An IBAN (mod-97).                              |
-| `DataURI`        | A `data:` URI.                                 |
-| `E164`           | An E.164 phone number.                         |
-| `Datetime`       | A datetime string; string in, string out.      |
-| `Date`           | A date string; string in, string out.          |
-| `Time`           | A time string; string in, string out.          |
-| `Duration`       | A duration string; object via `AsTimedelta`.   |
-| `TimeZone`       | A UTC offset; object via `AsTimezone`.         |
-| `TimeZoneInfo`   | An IANA name; object via `Coerce(ZoneInfo)`.   |
+| Name             | Note                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `Email`          | An email address.                                                                           |
+| `Url`            | A URL.                                                                                      |
+| `FqdnUrl`        | A URL with a fully qualified domain.                                                        |
+| `Slug`           | A URL slug.                                                                                 |
+| `Alpha`          | Letters only.                                                                               |
+| `Alphanumeric`   | Letters and digits only.                                                                    |
+| `ASCII`          | ASCII characters only.                                                                      |
+| `PrintableASCII` | Printable ASCII only.                                                                       |
+| `NoWhitespace`   | No whitespace characters.                                                                   |
+| `StartsWith`     | Begins with a prefix.                                                                       |
+| `EndsWith`       | Ends with a suffix.                                                                         |
+| `ByteLength`     | UTF-8 byte length within bounds.                                                            |
+| `HexColor`       | A hex color; compose `Lower`/`Upper` for case.                                              |
+| `Hex`            | Hexadecimal; checks, does not decode.                                                       |
+| `Base64`         | Base64; checks, does not decode.                                                            |
+| `JSONString`     | A JSON string; value via `FromJSONString`.                                                  |
+| `YAMLString`     | A YAML string; value via `FromYAMLString`.                                                  |
+| `ULID`           | A ULID; compose `Upper` for canonical case.                                                 |
+| `DataURI`        | A `data:` URI.                                                                              |
+| `Datetime`       | A datetime string; string in, string out.                                                   |
+| `Date`           | A date string; string in, string out.                                                       |
+| `Time`           | A time string; string in, string out.                                                       |
+| `Duration`       | A duration (also a timedelta, a number of seconds, or a mapping); object via `AsTimedelta`. |
+| `TimeZone`       | A UTC offset; object via `AsTimezone`.                                                      |
+| `TimeZoneInfo`   | An IANA name; object via `Coerce(ZoneInfo)`.                                                |
 
 ### Network and identifier
 
 Check the format and return the string unchanged. The parsed object is opt-in
 through `Coerce`, since each of these types constructs from its string.
 
-| Name          | Note                                                     |
-| ------------- | -------------------------------------------------------- |
-| `Hostname`    | A hostname.                                              |
-| `Fqdn`        | A fully qualified domain name.                           |
-| `Port`        | A TCP/UDP port number.                                   |
-| `MacAddress`  | A MAC address; canonical form via `NormalizeMacAddress`. |
-| `UUID`        | A UUID; object via `Coerce(uuid.UUID)`.                  |
-| `IPv4Address` | Object via `Coerce(ipaddress.IPv4Address)`.              |
-| `IPv6Address` | Object via `Coerce(ipaddress.IPv6Address)`.              |
-| `IPAddress`   | Object via `Coerce(ipaddress.ip_address)`.               |
-| `IPNetwork`   | Object via `Coerce(ipaddress.ip_network)`.               |
+| Name          | Note                                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `Hostname`    | A hostname.                                                                                                 |
+| `Fqdn`        | A fully qualified domain name.                                                                              |
+| `Port`        | A TCP/UDP port number; returns an `int`.                                                                    |
+| `MacAddress`  | A MAC address; canonical form via `NormalizeMacAddress`.                                                    |
+| `UUID`        | A UUID; object via `Coerce(uuid.UUID)`.                                                                     |
+| `IPv4Address` | Object via `Coerce(ipaddress.IPv4Address)`.                                                                 |
+| `IPv6Address` | Object via `Coerce(ipaddress.IPv6Address)`.                                                                 |
+| `IPAddress`   | Object via `Coerce(ipaddress.ip_address)`.                                                                  |
+| `IPNetwork`   | Object via `Coerce(lambda v: ipaddress.ip_network(v, strict=False))`; plain `ip_network` rejects host bits. |
 
 ### Filesystem
 
@@ -183,7 +180,7 @@ Run over a whole mapping, usually after a dict schema with `All`.
 | `RequiredWith`    | Required when another key is present.     |
 | `RequiredWithout` | Required when another key is absent.      |
 | `RequiredIf`      | Required when a condition holds.          |
-| `Check`           | An arbitrary predicate over the mapping.  |
+| `Check`           | An arbitrary predicate over the value.    |
 | `AtLeastOne`      | At least one of a set of keys is present. |
 | `AtMostOne`       | At most one of a set of keys is present.  |
 | `ExactlyOne`      | Exactly one of a set of keys is present.  |
@@ -222,13 +219,19 @@ The type changes.
 
 The type stays; the value is cleaned.
 
-| Name                  | Result                           |
-| --------------------- | -------------------------------- |
-| `Lower`               | Lowercase.                       |
-| `Upper`               | Uppercase.                       |
-| `Capitalize`          | Capitalized.                     |
-| `Title`               | Title-cased.                     |
-| `Strip`               | Whitespace trimmed.              |
-| `Replace`             | Regular-expression replace.      |
-| `Clamp`               | A number pinned into a range.    |
-| `NormalizeMacAddress` | A MAC address in canonical form. |
+| Name                  | Result                                         |
+| --------------------- | ---------------------------------------------- |
+| `Lower`               | Lowercase.                                     |
+| `Upper`               | Uppercase.                                     |
+| `Capitalize`          | Capitalized.                                   |
+| `Title`               | Title-cased.                                   |
+| `Strip`               | Whitespace trimmed.                            |
+| `Replace`             | Regular-expression replace.                    |
+| `Clamp`               | A number pinned into a range.                  |
+| `NormalizeMacAddress` | A MAC address in canonical form.               |
+| `CreditCard`          | A card number (Luhn), stripped to bare digits. |
+| `IBAN`                | An IBAN (mod-97), compacted and upper-cased.   |
+| `E164`                | An E.164 phone number, grouping stripped.      |
+
+`CreditCard`, `IBAN`, and `E164` normalize by default; pass `normalize=False`
+to validate and return the value unchanged.

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -5,8 +5,8 @@ description: A name-by-name map of voluptuous's public API and its status in Pro
 
 The drop-in promise is the point of Probatio. This page makes it checkable. Below
 is voluptuous's meaningful public surface, name by name, with its status in
-Probatio and a short note. Presence was confirmed with `hasattr(probatio, name)`
-against voluptuous 0.16.0, not from memory.
+Probatio and a short note. Every name in voluptuous 0.16.0's public surface was
+checked against Probatio with `hasattr(probatio, name)`, not from memory.
 
 The status column uses three values:
 
@@ -91,7 +91,7 @@ voluptuous](/getting-started/migrating-from-voluptuous/) and
 | `Email`         | Supported | Backtracking-safe email format check.                                          |
 | `Url`           | Supported | Backtracking-safe URL format check.                                            |
 | `FqdnUrl`       | Supported | URL with a fully qualified domain.                                             |
-| `Datetime`      | Supported | Validate a datetime string (default ISO 8601).                                 |
+| `Datetime`      | Supported | Validate a datetime string (default `%Y-%m-%dT%H:%M:%S.%fZ`).                  |
 | `Date`          | Supported | Validate a date string (default `%Y-%m-%d`).                                   |
 | `IsDir`         | Supported | An existing directory path.                                                    |
 | `IsFile`        | Supported | An existing file path.                                                         |

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -55,7 +55,7 @@ the legacy output.
 - `as_dict()`: the structured layer rendered as a serializable dict, handy for a
   JSON API.
 
-Reading `.path`, `.code`, and `.as_dict()` off a caught error. Remember the
+Read `.path`, `.code`, and `.as_dict()` off a caught error. Remember the
 schema raises `MultipleInvalid`, so reach into `err.errors[0]`:
 
 ```python
@@ -116,6 +116,8 @@ Each entry shows the class, its meaning, and its `default_code` in parentheses.
 - `LiteralInvalid` (`not_valid`): the value does not match a `Literal`.
 - `CoerceInvalid` (`coerce`): a value could not be coerced to the requested type;
   for an `Enum` with string values, carries `candidates`, the close matches.
+- `EnumInvalid` (`enum`): the value is not a member of the expected enum, nor one
+  of its values (raised by an enum class used as a schema).
 - `AnyInvalid` (`no_match`): the value matched none of the candidates.
 - `AllInvalid` (`all`): the value failed one of a chain of validators.
 - `MatchInvalid` (`match`): the value does not match the expected pattern.
@@ -149,7 +151,9 @@ Each entry shows the class, its meaning, and its `default_code` in parentheses.
 - `DateInvalid` (`date`): the value is not a valid date.
 - `TimeInvalid` (`time`): the value is not a valid time of day.
 - `DurationInvalid` (`duration`): the value is not a valid duration.
-- `TimeZoneInvalid` (`time_zone`): the value is not a valid IANA time zone.
+- `TimeZoneInvalid` (`time_zone`): the value is not a valid time zone: an IANA
+  name (`TimeZoneInfo`) or a UTC offset (`TimeZone`, `AsTimezone`).
+- `EpochInvalid` (`epoch`): the value is not a valid Unix epoch timestamp.
 - `IpInvalid` (`ip`): the value is not a valid IP address or network.
 - `MacAddressInvalid` (`mac_address`): the value is not a valid MAC address.
 - `UuidInvalid` (`uuid`): the value is not a valid UUID.
@@ -158,6 +162,8 @@ Each entry shows the class, its meaning, and its `default_code` in parentheses.
 - `MultipleOfInvalid` (`multiple_of`): the value is not a multiple of the factor.
 - `JsonInvalid` (`json`): the value is not valid JSON.
 - `YamlInvalid` (`yaml`): the value is not valid YAML.
+- `ImmutableInvalid` (`immutable`): a field that may not change (`Immutable` or
+  `WriteOnce`) was changed.
 - `NotEnoughValid` (`not_enough_valid`): too few of a `SomeOf` group's validators
   passed.
 - `TooManyValid` (`too_many_valid`): too many of a `SomeOf` group's validators

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -6,7 +6,8 @@ description: The public surface of Probatio, grouped by what each name does.
 This is the public surface of `probatio`. It mirrors voluptuous, so the names
 and signatures match what you already know. Everything here is importable
 straight from `probatio` (for example `from probatio import Schema, All, Range`),
-except the error-humanizing helpers, which live in `probatio.humanize`.
+except `humanize_error` and `validate_with_humanized_errors`, which live in
+`probatio.humanize`.
 
 ## Schema
 
@@ -73,6 +74,15 @@ The extra-key policy is set with the `extra` argument to `Schema`:
 - `ALLOW_EXTRA`: keep them untouched.
 - `REMOVE_EXTRA`: drop them from the output.
 
+## Constants and sentinels
+
+- `UNDEFINED`: the "no value" sentinel for marker defaults.
+- `Undefined`: the type of `UNDEFINED`, for `isinstance` checks.
+- `default_factory(value)`: normalize a marker default into a zero-argument
+  factory (the voluptuous helper).
+- `Schemable`: the type alias for anything `Schema` accepts, for annotations.
+- `__version__`: the installed Probatio version string.
+
 ## Combinators
 
 - `All(*validators, msg=None, required=False)`: every validator must pass, the output of each feeding the next. Aliased as `And`.
@@ -104,11 +114,10 @@ schema({"type": "a", "v": 1})  # {'type': 'a', 'v': 1}
 
 ## Validators
 
-The leaf validators, grouped by category. Select a category to expand it. Every
-name is importable straight from `probatio`.
+The leaf validators, grouped by category. Every name is importable straight
+from `probatio`.
 
-<details>
-<summary>Type and value</summary>
+### Type and value
 
 - `Coerce(type, msg=None)`: convert with `type(value)`, failing cleanly as
   `CoerceInvalid`.
@@ -126,10 +135,7 @@ mean ...?`) and records them on the error's `candidates`.
 - `Contains(item, msg=None)`: the value (a collection) must contain `item`.
 - `Match(pattern, msg=None)`: the value must match a regular expression.
 
-</details>
-
-<details>
-<summary>Numbers</summary>
+### Numbers
 
 - `Range(min=None, max=None, min_included=True, max_included=True, msg=None)`:
   numeric bounds, inclusive by default.
@@ -147,10 +153,7 @@ mean ...?`) and records them on the error's `candidates`.
 - `Latitude(msg=None)`, `Longitude(msg=None)`: a coordinate in -90 to 90, or -180
   to 180.
 
-</details>
-
-<details>
-<summary>Collections and structure</summary>
+### Collections and structure
 
 - `Length(min=None, max=None, msg=None)`: bound the length of a sized value.
 - `Unique(msg=None)`: require all items to be distinct.
@@ -182,10 +185,7 @@ result = Schema(Object({"x": int, "y": int}))(Point(1, 2))  # validates the attr
 result.x  # 1
 ```
 
-</details>
-
-<details>
-<summary>Strings</summary>
+### Strings
 
 The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
 
@@ -208,13 +208,11 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
 - `HexColor(msg=None)`: validate a hex color string (`#rgb` or `#rrggbb`), returned
   unchanged. Compose with `Lower` (or `Upper`) to fold case: `All(HexColor(), Lower)`.
 
-</details>
+### Date and time
 
-<details>
-<summary>Date and time</summary>
-
-- `Datetime(format=None, msg=None)`: validate a datetime string (default ISO
-  8601).
+- `Datetime(format=None, msg=None)`: validate a datetime string against a
+  `strptime` format, default `%Y-%m-%dT%H:%M:%S.%fZ`, matching voluptuous. Use
+  `AsDatetime` for ISO 8601 parsing.
 - `Date(format=None, msg=None)`: validate a date string (default `%Y-%m-%d`).
 - `Time(format=None, msg=None)`: validate a time-of-day string (default
   `%H:%M:%S`).
@@ -239,10 +237,7 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
 - `FromEpoch(unit="seconds", msg=None)`: parse a Unix timestamp (`int` or `float`,
   `unit="seconds"` or `"milliseconds"`) into a timezone-aware UTC `datetime`.
 
-</details>
-
-<details>
-<summary>Filesystem</summary>
+### Filesystem
 
 - `IsDir(msg=None)`: an existing directory path.
 - `IsFile(msg=None)`: an existing file path.
@@ -252,10 +247,7 @@ The transforms are plain functions; use them bare (`Lower`, not `Lower()`).
 - `IsFifo(msg=None)`: an existing named pipe (FIFO).
 - `IsBlockDevice(msg=None)`: an existing block device.
 
-</details>
-
-<details>
-<summary>Network and identifiers</summary>
+### Network and identifiers
 
 These are Probatio additions (voluptuous has no equivalent). They validate and
 return the value unchanged; wrap with `Coerce(the type)` when you want the parsed
@@ -284,10 +276,7 @@ Python object.
 - `Fqdn(msg=None)`: a fully-qualified domain name (a dotted hostname).
 - `Port(msg=None)`: a port number (1 to 65535), returned as an `int`.
 
-</details>
-
-<details>
-<summary>Encoding</summary>
+### Encoding
 
 - `JSONString(schema=None, msg=None)`: validate a JSON string (optionally the decoded
   value against `schema`), returning the string unchanged.
@@ -314,18 +303,12 @@ Python object.
   dialable. Grouping characters are stripped by default; `normalize=False` rejects
   them and returns the value unchanged.
 
-</details>
-
-<details>
-<summary>Truthiness</summary>
+### Truthiness
 
 - `IsTrue(msg=None)`: the value must be truthy.
 - `IsFalse(msg=None)`: the value must be falsy.
 
-</details>
-
-<details>
-<summary>Cross-field rules</summary>
+### Cross-field rules
 
 Apply these after a dict schema with `All`; they inspect the whole mapping.
 
@@ -351,17 +334,12 @@ Apply these after a dict schema with `All`; they inspect the whole mapping.
 - `WriteOnce(*fields, msg=None)`: allow a field to be set once (from absent or
   `None`), then reject a later change.
 
-</details>
-
-<details>
-<summary>Defaults and messages</summary>
+### Defaults and messages
 
 - `DefaultTo(default, msg=None)`: replace `None` with a default.
 - `SetTo(value)`: ignore the input and always produce a fixed value.
 - `Msg(validator, msg, cls=None)`: wrap a validator and replace its failure
   message.
-
-</details>
 
 ## Decorators and helpers
 
@@ -374,6 +352,19 @@ Apply these after a dict schema with `All`; they inspect the whole mapping.
   `__return__`) against hand-named schemas (the voluptuous drop-in).
 - `raises(exc, msg=None, regex=None)`: context manager asserting a block raises
   `exc`, optionally matching it.
+- `message(default=None, cls=None, *, translation_key=None)`: decorator turning
+  a function that raises `ValueError` into a validator factory (the voluptuous
+  helper). The decorated function becomes a factory: call it to get the
+  validator (`Schema(isint())`, not `Schema(isint)`), optionally passing a
+  per-use message and `Invalid` subclass.
+- `truth(func)`: decorator turning a predicate into a validator (the voluptuous
+  helper). A truthy result returns the value unchanged; a falsy one fails as
+  "not a valid value". Use the decorated function directly: `Schema(isdir)`.
+- `current_context()`: the `context` value of the active
+  `schema(data, context=...)` call, or `None` outside one. Lets a custom
+  validator read call-time state, such as the previous value `Immutable`
+  compares against. See the
+  [custom validators guide](/guides/custom-validators/).
 
 ```python
 from typing import Annotated
@@ -410,6 +401,10 @@ In `probatio.humanize`:
 
 - `humanize_error(data, validation_error, max_sub_error_length=..., *, locator=None)`: render an error against the data as a readable string, naming the offending value. With a `locator` (a callable mapping an error `path` to a `Location`, such as the one from `load_yaml_with_locations`), each line gains its source position.
 - `validate_with_humanized_errors(data, schema, ...)`: validate, raising `Error` with a humanized message on failure.
+
+Importable straight from `probatio` (it lives in `probatio.error`, not
+`probatio.humanize`):
+
 - `Location`: a source position (`line`, `column`, `file`) a locator returns; renders as `file:line:column`.
 
 ## Schema interchange
@@ -439,6 +434,7 @@ guide](/guides/typeddict/)):
 - `is_dataclass(obj)`: the standard-library check, re-exported.
 - `TypedDictSchema(typeddict_type, additional_constraints=None, *, extra=PREVENT_EXTRA)`: a `Schema` that validates a mapping against a `TypedDict` and returns it typed as that `TypedDict` (nothing is constructed).
 - `create_typeddict_schema(typeddict_type, additional_constraints=None, *, extra=PREVENT_EXTRA)`: the functional form, returning the same `Schema`.
+- `Key(secret=False, alias=None, accept_canonical=True, forbidden=False, remove=False, inclusive=None, exclusive=None, required=None, description=None, msg=None)`: configure the marker a builder generates for an `Annotated` field, so a dataclass or `TypedDict` field carries the marker behavior (secret, alias, forbidden, remove, group membership, and the rest) without a hand-written dict schema. See the [dataclasses guide](/guides/dataclasses/).
 
 A field without a default is `Required`, one with a `default`/`default_factory`
 is `Optional`. Annotations map deeply (`list[str]` to `[str]`, `X | None` to
@@ -455,6 +451,16 @@ more than `isinstance`:
 - `unregister_type(cls)`: drop the registration for `cls`, so its fields go back to a strict `isinstance` check. A no-op when `cls` is not registered.
 - `clear_type_registry()`: empty the registry, dropping every registration.
 - `type_registry(registrations)`: a context manager that applies a mapping of `{type: validator}` for the duration of a `with` block, then restores the previous state. Async- and thread-safe, so a library should prefer it over the process-wide `register_type`.
+
+## Compile policy
+
+A hot schema compiles itself into a specialized validator; these names control
+that process-wide (see [Compiled schemas](/guides/compiled-schemas/)):
+
+- `CompilePolicy`: the policy enum: `OFF`, `ON`, and `AUTO` (the default, which
+  compiles a schema once it runs hot).
+- `get_compile_policy()`: return the active policy.
+- `set_compile_policy(policy)`: set the process-wide policy.
 
 ## Loading and dumping
 

--- a/docs/src/content/docs/reference/performance.md
+++ b/docs/src/content/docs/reference/performance.md
@@ -50,11 +50,11 @@ to turn the behavior off for an unusual workload, see
 
 ## How it compares to voluptuous
 
-On the bundled benchmark scenarios, the interpreted engine runs roughly one and a
-half to three and a half times faster than the same schema in voluptuous, and the
-compiled path reaches up to about seven times faster on real config and dataclass
-shapes. The exact ratio moves with the machine, the Python version, and the shape of
-the schema, so treat these as ballparks, not promises.
+On the bundled benchmark scenarios, the interpreted engine runs roughly 2.3 to
+3.4 times faster than the same schema in voluptuous, and the compiled path
+lands between 6.7 and 7.4 times faster on the same scenarios. The exact ratio
+moves with the machine, the Python version, and the shape of the schema, so
+treat these as ballparks, not promises.
 
 | Scenario                         | voluptuous | Probatio | Probatio compiled |
 | -------------------------------- | ---------- | -------- | ----------------- |
@@ -62,9 +62,10 @@ the schema, so treat these as ballparks, not promises.
 | Config (coerce, range, in, list) | 6.0 µs     | 2.2 µs   | 0.9 µs            |
 | Nested mapping                   | 7.0 µs     | 3.0 µs   | 1.0 µs            |
 
-Microseconds per validation, lower is faster, on one machine with Python 3.13.
+Microseconds per validation, lower is faster. Measured July 2026 on one
+machine with Python 3.13.
 
-![Validation throughput vs voluptuous: probatio is 1.7 to 3.4 times faster interpreted, and 4.7 to 7.2 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
+![Validation throughput vs voluptuous: probatio is 2.3 to 3.4 times faster interpreted, and 6.7 to 7.4 times faster compiled, across the benchmark scenarios.](/benchmarks/vs-voluptuous.svg)
 
 :::caution[Read the benchmark honestly]
 `bench/bench.py` is a rough, single-machine comparison. It builds equivalent
@@ -77,6 +78,9 @@ as guarantees.
 The tracked benchmarks are the CodSpeed ones in `bench/test_benchmarks.py`. Those
 run per pull request, so a performance regression shows up in review. They pin each
 case to a known engine (interpreted or compiled) so the two are tracked separately.
+The tracked benchmarks live on
+[CodSpeed](https://codspeed.io/frenck/probatio), so you can look at the history
+yourself.
 
 ## How a dataclass compares to mashumaro
 
@@ -86,7 +90,7 @@ per class. It is not a like-for-like comparison, and that is the point: mashumar
 deserializes and largely trusts the declared types, while Probatio _validates_ every
 field against its type and then constructs. mashumaro does strictly less work, so it
 is faster on already-correct input. The compiled Probatio path lands within roughly
-1.3x of it on a small dataclass while still validating, and the gap all but closes
+1.4x of it on a small dataclass while still validating, and the gap all but closes
 as the field count grows (about 1.1x on a wide one).
 
 | Dataclass        | mashumaro | Probatio | Probatio compiled |
@@ -94,7 +98,7 @@ as the field count grows (about 1.1x on a wide one).
 | Small (4 fields) | 0.5 µs    | 1.5 µs   | 0.7 µs            |
 | Wide (12 fields) | 1.2 µs    | 2.8 µs   | 1.3 µs            |
 
-![Dataclass construction vs mashumaro: compiled probatio is within about 1.3 times of mashumaro on a small dataclass and essentially even on a wide one, while validating every field.](/benchmarks/dataclass-vs-mashumaro.svg)
+![Dataclass construction vs mashumaro: compiled probatio is within about 1.4 times of mashumaro on a small dataclass and essentially even on a wide one, while validating every field.](/benchmarks/dataclass-vs-mashumaro.svg)
 
 The two libraries pair well: validate untrusted input with Probatio, then hand
 trusted dataclasses to mashumaro to serialize. See

--- a/docs/src/content/docs/reference/translation-keys.md
+++ b/docs/src/content/docs/reference/translation-keys.md
@@ -142,3 +142,8 @@ message, with the close matches also available raw on `context["candidates"]`
 | `value_was_not_false`              | `value was not false`                                                                               |
 | `value_was_not_true`               | `value was not true`                                                                                |
 | `write_once_already_set`           | `{field!r} is write-once and already set`                                                           |
+
+Three keys are JSON Schema-only: `max_contains`, `min_contains`, and
+`must_not_match_not_schema`. They fire only from schemas built by
+`from_json_schema` (see the [JSON Schema guide](/guides/json-schema/)); no
+hand-written validator emits them.

--- a/packages/pytest-probatio/README.md
+++ b/packages/pytest-probatio/README.md
@@ -33,3 +33,7 @@ pip install pytest-probatio
 
 This package lives in the probatio monorepo but ships separately, so the core
 `probatio` library stays dependency-free.
+
+The full guide, including schema reuse across tests and the `raises` helper,
+lives at
+[probatio.frenck.dev](https://probatio.frenck.dev/guides/testing-with-pytest/).


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None.

## Proposed change

A full review-and-fix round over the documentation, the README, and the contributor docs, done page by page with every claim checked against the code.

Accuracy: the architecture page described the pre-ADR-011 engine (codegen removed) and contradicted the compiled schemas guide; it now describes the shipped design. The migration guide claimed `probatio.util` and `probatio.schema_builder` exist (they are shim-only), the OpenAPI guide claimed MCP speaks OpenAPI (it speaks JSON Schema), the reference gave `Datetime` an ISO 8601 default it does not have, documented `Location` under an import path that fails, and missed several exported names (`message`, `truth`, `Key`, the compile-policy trio, `current_context`, three error subclasses). The performance page's prose, table, and alt texts disagreed with each other; they now share one dataset with provenance and a CodSpeed link.

Pitch: the beyond-voluptuous story (speed, dataclasses, TypedDicts, codecs) only existed on the landing page. It is now threaded through quick start, about, the validation model, the README, and the Home Assistant recipe, which now shows the actual `import probatio as vol` one-liner. Quick start and the README demonstrate the dotted error path with a nested schema instead of describing it.

New content: a sequence schemas guide (the missing chapter next to dict schemas), a web API request validation recipe, and an LLM tool calling and MCP recipe. The comparison page gained a cerberus section.

Structure: the deviations list now has one owner (compatibility page), `raises` is documented in the pytest guide, the reference index uses real headings so validators appear in the table of contents, every cookbook section links its deep guide, and CONTRIBUTING documents the docs example harness.

Every code block on every touched page is executed and output-checked by `verify_examples.py` (255 blocks, all green).

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR is related to: the error rendering work in #127, #128, and #129, whose reworded messages these docs are verified against.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
