### PR TITLE
Honor typeless assertions and fail closed on mishandled keywords in from_json_schema

### DIFF
--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -60,20 +60,23 @@ rebuilt({"name": "Ada", "age": 37})  # {'name': 'Ada', 'age': 37}
 :::note
 The mapping is not lossless. `to_json_schema` renders what JSON Schema can
 express and turns anything it does not recognize into an open schema (`{}`).
-`from_json_schema` ignores keywords it does not handle rather than rejecting
-them. Treat a round trip as "the validatable shape survives", not "byte for byte
-identical".
+`from_json_schema` ignores purely descriptive keywords but refuses a restrictive
+keyword it cannot honor (see below). Treat a round trip as "the validatable
+shape survives", not "byte for byte identical".
 :::
 
 ## Supported keywords
 
 `from_json_schema` understands the keywords below. A purely descriptive keyword
-it does not read (`title`, `description`, `examples`) is ignored, so a partial
-schema still yields a usable validator. A _restrictive_ keyword it cannot honor
+it does not read (`title`, `examples`) is ignored, so a partial schema still
+yields a usable validator. A _restrictive_ keyword it cannot honor
 (`if`/`then`/`else`, `propertyNames`, `patternProperties`, `dependentRequired`,
-`dependentSchemas`) is refused with a `SchemaError` rather than silently dropped,
-so an untrusted schema is never quietly widened to accept what its author meant
-to forbid. `to_json_schema` emits the same constructs in the other direction.
+`dependentSchemas`, `dependencies`, `unevaluatedProperties`, `unevaluatedItems`,
+`$dynamicRef`, `$recursiveRef`) is refused with a `SchemaError` rather than
+silently dropped, so an untrusted schema is never quietly widened to accept what
+its author meant to forbid. The object and array keywords apply even on a node
+without a `type` (scoped to instances of their type, as the spec says).
+`to_json_schema` emits the same constructs in the other direction.
 
 | Area    | Keywords                                                                                                                                                                           |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -742,6 +742,12 @@ _UNSUPPORTED_KEYWORDS = frozenset(
         # would widen the schema (accept data the author forbade), so fail closed.
         "unevaluatedProperties",
         "unevaluatedItems",
+        # Dynamic references are restrictive (they point at a constraint), so they
+        # fail closed too. Their anchors are declarations, not constraints: with
+        # every dynamic reference refused, a leftover anchor is inert, so anchors
+        # are not refused.
+        "$dynamicRef",
+        "$recursiveRef",
     },
 )
 
@@ -947,6 +953,46 @@ _NUMERIC_BOUND_KEYS = frozenset(
     {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"},
 )
 
+# Object and array assertion keywords. On a node without a ``type``, these still
+# constrain instances of their type (any other instance passes them vacuously),
+# so a typeless node carrying one must not decode to an accept-anything schema.
+_OBJECT_KEYWORDS = frozenset(
+    {
+        "properties",
+        "required",
+        "additionalProperties",
+        "minProperties",
+        "maxProperties",
+    },
+)
+_ARRAY_KEYWORDS = frozenset({"items", "prefixItems", "minItems", "maxItems"})
+
+
+class _WhenType:
+    """Apply a subschema only to instances of one JSON type.
+
+    JSON Schema object and array keywords constrain only instances of their own
+    type; every other value passes them vacuously. This wrapper carries that
+    conditional applicability for a typeless node, so ``properties`` or ``items``
+    without a ``type`` is honored on matching instances without rejecting the
+    rest.
+    """
+
+    def __init__(self, base: type, subschema: Any) -> None:
+        """Compile the subschema and remember the instance type it applies to."""
+        self._base = base
+        self._schema = Schema(subschema)
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return f"WhenType({self._base.__name__}, {self._schema.schema!r})"
+
+    def __call__(self, value: Any) -> Any:
+        """Validate instances of the type; pass every other value through."""
+        if not isinstance(value, self._base):
+            return value
+        return self._schema(value)
+
 
 def _combine_constraints(node: dict[str, Any], ctx: _Decode) -> Any:
     """Combine a node's standalone constraint keywords into one validator, or None.
@@ -955,7 +1001,9 @@ def _combine_constraints(node: dict[str, Any], ctx: _Decode) -> Any:
     ``minimum``, ``minLength``, ``multipleOf``, ``uniqueItems``, and ``contains``.
     Each becomes its matching validator so the encoder's typeless output (a bare
     ``Range``, ``Length``, ``MultipleOf``, ``Unique``, or ``ContainsCount``) round
-    trips. None means the node carries no recognized constraint.
+    trips. Object and array assertions (``properties``, ``required``, ``items``,
+    and their siblings) also apply without a ``type``, scoped to instances of
+    their type. None means the node carries no recognized constraint.
     """
     constraints = _from_constraints(node, ctx)
     if not constraints:
@@ -970,6 +1018,7 @@ def _combine_constraints(node: dict[str, Any], ctx: _Decode) -> Any:
 def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
     """Collect the standalone constraint validators present on a node."""
     constraints: list[Any] = []
+    has_array = bool(_ARRAY_KEYWORDS & node.keys())
     if _NUMERIC_BOUND_KEYS & node.keys():
         constraints.append(_from_range(node))
     if "multipleOf" in node:
@@ -982,10 +1031,17 @@ def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
         )
     if "pattern" in node:
         constraints.append(Match(_safe_pattern(node["pattern"])))
-    if node.get("uniqueItems") is True:
+    # When array keywords are present, the array facet below reads uniqueItems
+    # and contains itself, scoped to arrays; adding them standalone here too
+    # would double-apply them.
+    if node.get("uniqueItems") is True and not has_array:
         constraints.append(Unique())
-    if "contains" in node:
+    if "contains" in node and not has_array:
         constraints.append(_from_contains(node, ctx))
+    if _OBJECT_KEYWORDS & node.keys():
+        constraints.append(_WhenType(dict, _from_object(node, ctx)))
+    if has_array:
+        constraints.append(_WhenType(list, _from_array(node, ctx)))
 
     return constraints
 
@@ -1020,10 +1076,23 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
         mapping[key] = _from_node(subschema, ctx)
 
     additional = node.get("additionalProperties")
-    if isinstance(additional, dict):
-        mapping[str] = _from_node(additional, ctx)
+    additional_schema = (
+        _from_node(additional, ctx) if isinstance(additional, dict) else None
+    )
 
-    base = _object_base(mapping, additional)
+    # A ``required`` name with no ``properties`` entry is still a presence
+    # constraint; dropping it would widen an untrusted schema. Its value schema
+    # is whatever ``additionalProperties`` says (an undeclared property), or
+    # anything.
+    for name in sorted(required - properties.keys()):
+        mapping[Required(name)] = (
+            additional_schema if additional_schema is not None else object
+        )
+
+    if additional_schema is not None:
+        mapping[str] = additional_schema
+
+    base = _object_base(mapping, additional, declared="properties" in node)
     min_props = _item_count(node, "minProperties")
     max_props = _item_count(node, "maxProperties")
     if min_props is not None or max_props is not None:
@@ -1032,19 +1101,21 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     return base
 
 
-def _object_base(mapping: dict[Any, Any], additional: Any) -> Any:
+def _object_base(mapping: dict[Any, Any], additional: Any, *, declared: bool) -> Any:
     """Pick the base object schema from the property map and additionalProperties.
 
     A declared property set is a closed contract (probatio's deliberate strict
     default). But ``{"type": "object"}`` with no declared properties and no
     explicit ``additionalProperties`` is "any object", not a closed empty one; an
-    explicit ``additionalProperties: false`` keeps an empty object closed.
+    explicit ``additionalProperties: false`` keeps an empty object closed. And a
+    ``required`` list without a ``properties`` set constrains presence only, so
+    undeclared extra keys stay allowed.
     """
     if additional is True:
         return Schema(mapping, extra=ALLOW_EXTRA)
 
-    if not mapping and additional is None:
-        return dict
+    if not declared and additional is None:
+        return Schema(mapping, extra=ALLOW_EXTRA) if mapping else dict
 
     return mapping
 
@@ -1055,10 +1126,16 @@ def _from_key(name: str, subschema: Any, *, required: bool) -> Marker:
     A ``writeOnly`` property is a secret, so the key is wrapped in ``Secret`` (its
     value is redacted from error output), the counterpart of the ``writeOnly`` that
     ``to_json_schema`` emits for a ``Secret`` key.
+
+    JSON Schema ``default`` is an annotation: it never satisfies ``required``. A
+    probatio ``Required`` marker with a default does (it fills the value in), so a
+    required property keeps presence enforcement and drops the default. On an
+    optional property the default only fills the output, leaving the accept set
+    unchanged, so there it is applied.
     """
     marker_cls = Required if required else Optional
     description = subschema.get("description") if isinstance(subschema, dict) else None
-    if isinstance(subschema, dict) and "default" in subschema:
+    if not required and isinstance(subschema, dict) and "default" in subschema:
         marker: Marker = marker_cls(
             name,
             default=subschema["default"],
@@ -1102,18 +1179,18 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     """Render a JSON Schema array as a sequence schema, honoring item-count bounds.
 
     ``prefixItems`` with ``items: false`` (a closed, fixed-length positional array)
-    round-trips an ``ExactSequence``. A bool ``items`` (``false`` forbids extra
-    items, ``true`` allows any) carries no per-item schema, so it is treated as an
-    unconstrained list rather than fed to the node decoder.
+    round-trips an ``ExactSequence``. Without ``prefixItems``, ``items: false``
+    forbids every element (only the empty array validates) and ``items: true``
+    carries no per-item schema, so it reads as an unconstrained list.
     """
     prefix = node.get("prefixItems")
     if prefix is not None:
         return _from_prefix_items(prefix, node, ctx)
 
     items = node.get("items")
-    if isinstance(items, bool):
+    if items is True:
         items = None
-    elif items is not None and not isinstance(items, dict):
+    elif items is not None and items is not False and not isinstance(items, dict):
         # The Draft-4 positional form ``items: [schema, ...]`` is not supported;
         # the supported positional form is ``prefixItems``. Refuse it cleanly
         # rather than leaking a TypeError from the node decoder.
@@ -1129,14 +1206,23 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     has_contains = "contains" in node
     has_unique = node.get("uniqueItems") is True
 
-    if items is None:
+    if items is False:
+        # ``items: false`` with no ``prefixItems``: no element is allowed, so
+        # only the empty array validates (an empty sequence schema is exactly
+        # that).
+        sequence: Any = []
+    elif items is None:
         # No item schema: any list. Length, uniqueItems, and contains still apply,
         # so a constrained array accepts any element ([object]) but must satisfy
         # them.
         if not bounded and not has_contains and not has_unique:
             return list
-        sequence: Any = [object]
-    elif isinstance(items, dict) and "anyOf" in items:
+        sequence = [object]
+    elif items.keys() == {"anyOf"}:
+        # The encoder renders a multi-item sequence schema ([int, str]) as an
+        # ``items`` carrying only an ``anyOf``; decode that shape back to the
+        # branch list. Any sibling keyword beside the ``anyOf`` makes it a
+        # normal node whose facets must all apply, handled below.
         sequence = [_from_node(sub, ctx) for sub in items["anyOf"]]
     else:
         sequence = [_from_node(items, ctx)]
@@ -1355,8 +1441,17 @@ def _resolve_bound(
     inclusive = _numeric(node, inclusive_key)
     raw_exclusive = node.get(exclusive_key)
 
-    # Draft-04: ``exclusiveMinimum: true`` flips ``minimum`` to exclusive.
+    # Draft-04: ``exclusiveMinimum: true`` flips ``minimum`` to exclusive. The
+    # boolean form is only meaningful beside its inclusive partner (Draft 4
+    # requires it); without one there is no bound to flip, so the document is
+    # malformed and silently producing no constraint would widen it.
     if isinstance(raw_exclusive, bool):
+        if inclusive is None:
+            message = (
+                f"JSON Schema boolean {exclusive_key!r} (Draft 4 form) requires "
+                f"{inclusive_key!r} beside it"
+            )
+            raise SchemaError(message)
         return inclusive, not raw_exclusive
 
     exclusive = _numeric(node, exclusive_key)

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -459,9 +459,17 @@ def test_prefix_items_round_trips_an_exact_sequence() -> None:
         schema([1, 2])
 
 
-def test_bool_items_decodes_without_leaking() -> None:
-    """A bool 'items' (false/true) carries no per-item schema and is handled."""
-    assert from_json_schema({"type": "array", "items": False})([1, "x"]) == [1, "x"]
+def test_items_true_is_any_list() -> None:
+    """items: true carries no per-item schema, so any list passes."""
+    assert from_json_schema({"type": "array", "items": True})([1, "x"]) == [1, "x"]
+
+
+def test_items_false_forbids_every_element() -> None:
+    """items: false (without prefixItems) allows only the empty array."""
+    schema = from_json_schema({"type": "array", "items": False})
+    assert schema([]) == []
+    with pytest.raises(MultipleInvalid):
+        schema([1])
 
 
 def test_non_list_prefix_items_is_a_clean_schema_error() -> None:
@@ -766,6 +774,8 @@ def test_not_and_contains_count_repr_readably() -> None:
     assert "Not(" in repr(not_schema.schema)
     count_schema = from_json_schema({"contains": {"const": 5}, "minContains": 2})
     assert "ContainsCount(" in repr(count_schema.schema)
+    typeless_schema = from_json_schema({"required": ["a"]})
+    assert "WhenType(dict" in repr(typeless_schema.schema)
 
 
 @pytest.mark.parametrize(
@@ -903,3 +913,115 @@ def test_object_length_round_trips_as_property_count() -> None:
     assert schema({"a": 1, "b": 2}) == {"a": 1, "b": 2}
     with pytest.raises(Invalid):
         schema({"a": 1})  # below the property count
+
+
+def test_typeless_object_assertions_are_honored() -> None:
+    """properties/required without a type still constrain objects (fail closed)."""
+    schema = from_json_schema(
+        {"properties": {"a": {"type": "integer"}}, "required": ["a"]},
+    )
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(MultipleInvalid):
+        schema({})
+    with pytest.raises(MultipleInvalid):
+        schema({"a": "text"})
+
+
+def test_typeless_object_assertions_pass_other_types() -> None:
+    """Object keywords without a type apply only to objects; other values pass."""
+    schema = from_json_schema({"required": ["a"]})
+    assert schema("not an object") == "not an object"
+    assert schema(42) == 42
+
+
+def test_typeless_array_assertions_are_honored() -> None:
+    """items/minItems without a type still constrain arrays (fail closed)."""
+    schema = from_json_schema({"items": {"type": "integer"}, "minItems": 2})
+    assert schema([1, 2]) == [1, 2]
+    with pytest.raises(MultipleInvalid):
+        schema(["x", "y"])
+    with pytest.raises(MultipleInvalid):
+        schema([1])
+
+
+def test_typeless_array_assertions_pass_other_types() -> None:
+    """Array keywords without a type apply only to arrays; other values pass."""
+    schema = from_json_schema({"minItems": 2})
+    assert schema("ab") == "ab"
+    assert schema({"a": 1}) == {"a": 1}
+
+
+def test_required_without_properties_enforces_presence() -> None:
+    """A required name with no properties entry still requires the key."""
+    schema = from_json_schema({"type": "object", "required": ["a"]})
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(MultipleInvalid):
+        schema({})
+
+
+def test_required_without_properties_keeps_extras_open() -> None:
+    """Bare required declares no property set, so undeclared keys stay allowed."""
+    schema = from_json_schema({"type": "object", "required": ["a"]})
+    assert schema({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+
+def test_required_key_honors_additional_properties_schema() -> None:
+    """An undeclared required key is an additional property, so its schema applies."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "required": ["a"],
+            "additionalProperties": {"type": "integer"},
+        },
+    )
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(MultipleInvalid):
+        schema({"a": "text"})
+
+
+def test_items_anyof_sibling_keywords_apply() -> None:
+    """A keyword beside anyOf inside items is enforced, not silently dropped."""
+    schema = from_json_schema(
+        {
+            "type": "array",
+            "items": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+                "not": {"const": "x"},
+            },
+        },
+    )
+    assert schema(["y", 1]) == ["y", 1]
+    with pytest.raises(MultipleInvalid):
+        schema(["x"])
+
+
+@pytest.mark.parametrize("keyword", ["$dynamicRef", "$recursiveRef"])
+def test_dynamic_references_fail_closed(keyword: str) -> None:
+    """A dynamic reference is a constraint probatio cannot honor, so it is refused."""
+    with pytest.raises(SchemaError, match="not supported"):
+        from_json_schema({keyword: "#meta"})
+
+
+@pytest.mark.parametrize("key", ["exclusiveMinimum", "exclusiveMaximum"])
+@pytest.mark.parametrize("flag", [True, False])
+def test_draft4_boolean_exclusive_without_partner_is_refused(
+    key: str,
+    flag: bool,  # noqa: FBT001
+) -> None:
+    """A Draft-4 boolean exclusive bound without its inclusive partner is malformed."""
+    with pytest.raises(SchemaError, match="Draft 4"):
+        from_json_schema({"type": "integer", key: flag})
+
+
+def test_required_property_default_does_not_satisfy_presence() -> None:
+    """default is an annotation: it never satisfies required (spec semantics)."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "integer", "default": 5}},
+            "required": ["a"],
+        },
+    )
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(MultipleInvalid):
+        schema({})


### PR DESCRIPTION
## What this changes

A review of the JSON Schema decoder found a class of keywords that were silently mishandled: dropped (widening an untrusted schema to accept data its author forbade), or quietly producing no constraint. This fixes all of them in `from_json_schema`.

- Object and array assertions (`properties`, `required`, `items`, `minItems`, `additionalProperties`, and siblings) on a node without a `type` were ignored entirely. They now apply, scoped to instances of their type as the spec says: `{"required": ["a"]}` rejects an object missing `a` and still passes a string vacuously. This closes the biggest fail-open hole in the decoder and matches its own documented fail-closed policy.
- `required` naming a property with no `properties` entry was dropped, even with an explicit `type: object`. It now enforces presence. Since no property set is declared, undeclared extra keys stay allowed, and when `additionalProperties` carries a schema, the required key is validated against it (it is an additional property per spec).
- `items: false` (without `prefixItems`) decoded to an unconstrained list. Per spec it forbids every element, so it now allows only the empty array. The test that pinned the old behavior asserted incorrect semantics and is replaced.
- Sibling keywords beside `anyOf` inside `items` were discarded. The anyOf shortcut (which round-trips the encoder's multi-item output) now only fires when `anyOf` is the sole keyword; anything else decodes as a normal node whose facets all apply.
- `$dynamicRef` and `$recursiveRef` were silently ignored. They are restrictive references, so they now fail closed like the other unsupported keywords. Their anchors remain ignored: with every dynamic reference refused, a leftover anchor is inert.
- A Draft 4 boolean `exclusiveMinimum`/`exclusiveMaximum` without its inclusive partner silently produced no constraint. Draft 4 requires the partner, so the malformed document is now refused.
- A `default` on a required property satisfied `required` (the decoder built a `Required` marker with a default, which fills the value in). JSON Schema `default` is an annotation and never satisfies presence, so a required property now keeps enforcement and drops the default. Optional properties still apply theirs, which only fills output and leaves the accept set unchanged.

## Tests and docs

Thirteen new behavioral tests pin the above. The docs note that claimed `from_json_schema` "ignores keywords it does not handle rather than rejecting them" was wrong (and contradicted the same page a few lines down); it now describes the actual fail-closed behavior, and the refused-keyword list is complete.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
