### PR TITLE
Pin hypothesis to the last universal wheel on Python 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,11 @@ test = [
   "tomli-w==1.2.0",
   # Hypothesis drives the property-based and differential fuzz tests (the engine
   # and the codecs are hammered with generated schemas and data). Dev-only.
-  "hypothesis==6.156.1",
+  # From 6.156 hypothesis ships only per-version compiled wheels (no sdist), and
+  # CPython 3.15 has none yet, so the 3.15 beta job pins the last universal
+  # release. Drop the split once hypothesis publishes cp315 wheels.
+  "hypothesis==6.156.1; python_version < '3.15'",
+  "hypothesis==6.155.0; python_version >= '3.15'",
 ]
 typing = ["mypy==2.1.0", "ty==0.0.56"]
 lint = ["ruff==0.15.20", "codespell==2.4.2", "zizmor==1.26.1"]

--- a/uv.lock
+++ b/uv.lock
@@ -322,10 +322,28 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
+version = "6.155.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+]
+dependencies = [
+    { name = "sortedcontainers", marker = "python_full_version >= '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/7d/9569717766867495510712eba388f7ca0633549f9ff4d3c34398b919e5b4/hypothesis-6.155.0.tar.gz", hash = "sha256:cf09ac913b60b49750585a53152704468de666f35c9c29f8e61d82a01f64bbb5", size = 476704, upload-time = "2026-05-28T15:43:24.193Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/f8/31a6a6646c5b76b9746454318989340cea0290ba34e0f3ccd0668ce67868/hypothesis-6.155.0-py3-none-any.whl", hash = "sha256:d6ffa3062afabaf908491be707c60843f6671f7c3e9f2ed249d5827207ebbf33", size = 543120, upload-time = "2026-05-28T15:43:21.855Z" },
+]
+
+[[package]]
+name = "hypothesis"
 version = "6.156.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.15'",
+]
 dependencies = [
-    { name = "sortedcontainers" },
+    { name = "sortedcontainers", marker = "python_full_version < '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/3d/1a0e54652f1b3cad354949ba83f6ab211048ff3a6cfb24edcddc748a8be1/hypothesis-6.156.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0409dea0c0b48705cad8413468282af9c5e7d3a017b6c2b94ef80e7ba4b64862", size = 749005, upload-time = "2026-07-03T14:30:26.045Z" },
@@ -889,7 +907,8 @@ bench-world = [
     { name = "covdefaults" },
     { name = "dacite" },
     { name = "dataclasses-json" },
-    { name = "hypothesis" },
+    { name = "hypothesis", version = "6.155.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
+    { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "marshmallow" },
     { name = "mashumaro" },
     { name = "matplotlib" },
@@ -907,7 +926,8 @@ bench-world = [
 ]
 codspeed = [
     { name = "covdefaults" },
-    { name = "hypothesis" },
+    { name = "hypothesis", version = "6.155.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
+    { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "mashumaro" },
     { name = "orjson" },
     { name = "pytest" },
@@ -924,7 +944,8 @@ codspeed = [
 dev = [
     { name = "codespell" },
     { name = "covdefaults" },
-    { name = "hypothesis" },
+    { name = "hypothesis", version = "6.155.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
+    { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "mashumaro" },
     { name = "mypy" },
     { name = "orjson" },
@@ -949,7 +970,8 @@ lint = [
 ]
 test = [
     { name = "covdefaults" },
-    { name = "hypothesis" },
+    { name = "hypothesis", version = "6.155.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
+    { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "mashumaro" },
     { name = "orjson" },
     { name = "pytest" },
@@ -982,7 +1004,8 @@ bench-world = [
     { name = "covdefaults", specifier = "==2.3.0" },
     { name = "dacite", specifier = "==1.9.2" },
     { name = "dataclasses-json", specifier = "==0.6.7" },
-    { name = "hypothesis", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version < '3.15'", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "marshmallow", specifier = "==3.26.2" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "matplotlib", specifier = "==3.11.0" },
@@ -1000,7 +1023,8 @@ bench-world = [
 ]
 codspeed = [
     { name = "covdefaults", specifier = "==2.3.0" },
-    { name = "hypothesis", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version < '3.15'", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -1017,7 +1041,8 @@ codspeed = [
 dev = [
     { name = "codespell", specifier = "==2.4.2" },
     { name = "covdefaults", specifier = "==2.3.0" },
-    { name = "hypothesis", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version < '3.15'", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "orjson", specifier = "==3.11.9" },
@@ -1042,7 +1067,8 @@ lint = [
 ]
 test = [
     { name = "covdefaults", specifier = "==2.3.0" },
-    { name = "hypothesis", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version < '3.15'", specifier = "==6.156.1" },
+    { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pytest", specifier = "==9.1.1" },


### PR DESCRIPTION
## What this changes

The hypothesis bump to 6.156.1 (#131) broke the Python 3.15 job on main, and every PR inherits it: from 6.156 hypothesis ships only per-version compiled wheels (cp310 to cp314) and no source distribution, so `uv sync --locked` has nothing to install on the CPython 3.15 beta.

This splits the pin with environment markers: 6.156.1 everywhere, and 6.155.0 (the last release with a universal `py3-none-any` wheel) on 3.15 only. The lockfile now resolves both forks. A comment in `pyproject.toml` says when to drop the split: as soon as hypothesis publishes cp315 wheels.

Verified locally: `uv lock` resolves, the regular sync still installs 6.156.1, a `--python 3.15` dry-run sync resolves to 6.155.0, and the hypothesis-driven fuzz tests pass.

For the record: the Docs workflow failure on main is unrelated (a flaky GitHub Pages deployment, "Deployment failed, try again later").
