### PR TITLE
Decode JSON Schema types, enum, and const under the JSON data model

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -326,6 +326,14 @@ def _convert_equality(node: Any) -> dict[str, Any] | None:
     if isinstance(node, Literal):
         return {"const": node.lit}
 
+    # The decoder's JSON-strict enum/const (numbers and booleans kept distinct)
+    # re-emit their keyword, so a decoded schema round-trips.
+    if isinstance(node, _JsonEnum):
+        return {"enum": list(node.values)}
+
+    if isinstance(node, _JsonConst):
+        return {"const": node.value}
+
     return None
 
 
@@ -397,6 +405,11 @@ def _convert_typed(node: Any) -> dict[str, Any] | None:
 
     if isinstance(node, Base64):
         return {"type": "string", "contentEncoding": "base64"}
+
+    # The decoder's JSON-strict numeric types re-emit their keyword, so a
+    # decoded schema round-trips.
+    if isinstance(node, _JsonNumberType):
+        return {"type": "integer" if node.integer else "number"}
 
     return None
 
@@ -613,6 +626,40 @@ _FROM_FORMATS: dict[str, Any] = {
 }
 # JSON Schema scalar types that map to a fixed probatio fragment.
 _SIMPLE_TYPES: dict[str, Any] = {"boolean": bool, "null": None}
+
+
+class _JsonNumberType:
+    """Decode of ``type: integer``/``number`` under the JSON data model.
+
+    Python's ``bool`` subclasses ``int``, so a plain type check accepts ``True``
+    as an integer and rejects ``1.0``, both against the spec: JSON has no
+    boolean-as-number, and Draft 2020-12 defines ``integer`` as any number with
+    a zero fractional part.
+    """
+
+    def __init__(self, *, integer: bool) -> None:
+        """Remember whether the fractional part must be zero (read as ``.integer``)."""
+        self.integer = integer
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return "JsonInteger()" if self.integer else "JsonNumber()"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if it is a JSON number (an integer when required)."""
+        bad = isinstance(value, bool) or not isinstance(value, int | float)
+        if not bad and self.integer and isinstance(value, float):
+            bad = not value.is_integer()
+        if bad:
+            raise Invalid(
+                translation_key="expected_type",
+                placeholders={"expected": "integer" if self.integer else "number"},
+            )
+        return value
+
+
+_JSON_INTEGER = _JsonNumberType(integer=True)
+_JSON_NUMBER = _JsonNumberType(integer=False)
 
 
 class _DeferredRef:
@@ -842,13 +889,101 @@ def _reject_unsupported(node: dict[str, Any]) -> None:
         raise SchemaError(message)
 
 
+def _json_equal(a: Any, b: Any) -> bool:
+    """Equality under JSON's type model: a boolean is never equal to a number.
+
+    Python's ``==`` conflates them (``1 == True``), so a decoded ``enum`` or
+    ``const`` would accept booleans for numbers and the reverse, against the
+    JSON data model. Numbers still compare across int/float (``1 == 1.0``),
+    which matches the spec. Containers compare element-wise so a nested boolean
+    stays distinct too.
+    """
+    if isinstance(a, bool) or isinstance(b, bool):
+        return isinstance(a, bool) and isinstance(b, bool) and a == b
+    # The value side can be a hostile subclass whose __len__, __iter__,
+    # __getitem__, or key equality raises, so the container walks are guarded
+    # just like the plain equality: any failure is a mismatch, never a leak.
+    try:
+        if isinstance(a, list) and isinstance(b, list):
+            return len(a) == len(b) and all(map(_json_equal, a, b))
+        if isinstance(a, dict) and isinstance(b, dict):
+            return a.keys() == b.keys() and all(
+                _json_equal(item, b[key]) for key, item in a.items()
+            )
+        return bool(a == b)
+    except Exception:  # noqa: BLE001 - the value's dunders are user code; never leak
+        return False
+
+
+def _needs_json_equality(value: Any) -> bool:
+    """Whether Python ``==`` could conflate the value with a boolean or number.
+
+    Only booleans and numbers (anywhere in the value) are ambiguous; strings,
+    null, and containers of them compare identically under both models, so those
+    keep the plain validators and their round-trip shape.
+    """
+    if isinstance(value, bool | int | float):
+        return True
+    if isinstance(value, list):
+        return any(_needs_json_equality(item) for item in value)
+    if isinstance(value, dict):
+        return any(_needs_json_equality(item) for item in value.values())
+    return False
+
+
+class _JsonConst:
+    """Decode of ``const`` holding a number or boolean: JSON-strict equality."""
+
+    def __init__(self, value: Any) -> None:
+        """Store the value the input must equal (read as ``.value``)."""
+        self.value = value
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return f"JsonConst({self.value!r})"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if it JSON-equals the const, else raise Invalid."""
+        if not _json_equal(value, self.value):
+            raise Invalid(
+                translation_key="value_not_equal",
+                placeholders={"target": self.value},
+            )
+        return value
+
+
+class _JsonEnum:
+    """Decode of ``enum`` holding numbers or booleans: JSON-strict membership."""
+
+    def __init__(self, values: list[Any]) -> None:
+        """Store the allowed members (read as ``.values``)."""
+        self.values = values
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return f"JsonEnum({self.values!r})"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if a member JSON-equals it, else raise Invalid."""
+        if not any(_json_equal(value, member) for member in self.values):
+            raise Invalid(
+                translation_key="value_one_of",
+                placeholders={"values": self.values},
+            )
+        return value
+
+
 def _from_const(value: Any) -> Any:
     """Build a const equality check.
 
     A scalar is returned as a literal (a ``Schema`` validates a literal by
     equality). A list or dict literal would instead be read as a structural
     sub-schema, so it is wrapped in ``Equal`` to keep const's equality semantics.
+    A value carrying a number or boolean anywhere gets the JSON-strict check,
+    since Python equality would conflate ``1`` with ``True``.
     """
+    if _needs_json_equality(value):
+        return _JsonConst(value)
     if isinstance(value, list | dict):
         return Equal(value)
     return value
@@ -939,11 +1074,18 @@ class _JsonUnique:
         return value
 
 
-def _from_enum(values: Any) -> In:
-    """Build an In from a JSON Schema ``enum``, rejecting a non-array."""
+def _from_enum(values: Any) -> Any:
+    """Build a membership check from a JSON Schema ``enum``, rejecting a non-array.
+
+    An enum carrying a number or boolean anywhere gets the JSON-strict check
+    (``In`` uses Python ``==``, which would conflate ``1`` with ``True``); a
+    purely string/null enum keeps ``In`` and its friendlier miss suggestions.
+    """
     if not isinstance(values, list):
         message = f"JSON Schema 'enum' must be an array, got {type(values).__name__}"
         raise SchemaError(message)
+    if any(_needs_json_equality(value) for value in values):
+        return _JsonEnum(list(values))
     return In(list(values))
 
 
@@ -1058,7 +1200,7 @@ def _from_typed(node: dict[str, Any], ctx: _Decode) -> Any:
         return _from_string(node)
 
     if json_type in ("integer", "number"):
-        base = int if json_type == "integer" else AnyValidator(int, float)
+        base = _JSON_INTEGER if json_type == "integer" else _JSON_NUMBER
         return _from_number(node, base=base)
 
     # A non-empty ``type`` that is none of the seven JSON Schema types is malformed.

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1081,6 +1081,94 @@ def test_format_datetime_and_time_round_trip() -> None:
         assert to_json_schema(from_json_schema(document)) == document
 
 
+def test_integer_follows_the_json_data_model() -> None:
+    """type: integer rejects booleans and accepts a float with a zero fraction."""
+    schema = from_json_schema({"type": "integer"})
+    assert schema(3) == 3
+    assert schema(1.0) == 1.0
+    with pytest.raises(MultipleInvalid):
+        schema(True)
+    with pytest.raises(MultipleInvalid):
+        schema(1.5)
+
+
+def test_number_rejects_booleans() -> None:
+    """type: number rejects booleans; JSON has no boolean-as-number."""
+    schema = from_json_schema({"type": "number"})
+    assert schema(1.5) == 1.5
+    with pytest.raises(MultipleInvalid):
+        schema(True)
+
+
+def test_enum_keeps_booleans_and_numbers_distinct() -> None:
+    """A numeric enum rejects booleans and a boolean enum rejects numbers."""
+    numeric = from_json_schema({"enum": [1, 0]})
+    assert numeric(1) == 1
+    assert numeric(1.0) == 1.0  # numbers compare across int/float per spec
+    with pytest.raises(MultipleInvalid):
+        numeric(True)
+    with pytest.raises(MultipleInvalid):
+        numeric(False)
+
+    boolean = from_json_schema({"enum": [True]})
+    assert boolean(True) is True
+    with pytest.raises(MultipleInvalid):
+        boolean(1)
+
+
+def test_const_keeps_booleans_and_numbers_distinct() -> None:
+    """A numeric const rejects the equal-under-Python boolean, and the reverse."""
+    one = from_json_schema({"const": 1})
+    assert one(1) == 1
+    assert one(1.0) == 1.0
+    with pytest.raises(MultipleInvalid):
+        one(True)
+
+    false = from_json_schema({"const": False})
+    assert false(False) is False
+    with pytest.raises(MultipleInvalid):
+        false(0)
+
+
+def test_const_container_compares_elementwise_under_json_equality() -> None:
+    """A container const keeps nested booleans distinct from nested numbers."""
+    schema = from_json_schema({"const": [1, 2]})
+    assert schema([1, 2]) == [1, 2]
+    assert schema([1.0, 2]) == [1.0, 2]
+    with pytest.raises(MultipleInvalid):
+        schema([True, 2])
+
+    nested = from_json_schema({"const": {"a": 0}})
+    assert nested({"a": 0}) == {"a": 0}
+    with pytest.raises(MultipleInvalid):
+        nested({"a": False})
+
+
+def test_const_rejects_a_value_whose_equality_raises() -> None:
+    """A hostile __eq__ on the value is a mismatch, never a leaked exception."""
+
+    class Hostile:
+        def __eq__(self, other: object) -> bool:
+            raise RuntimeError
+
+        __hash__ = None  # type: ignore[assignment]
+
+    schema = from_json_schema({"const": 1})
+    with pytest.raises(MultipleInvalid):
+        schema(Hostile())
+
+
+def test_json_strict_enum_const_and_integer_round_trip() -> None:
+    """The JSON-strict validators re-emit their keyword through to_json_schema."""
+    for document in (
+        {"enum": [1, 0]},
+        {"const": 1},
+        {"type": "integer"},
+        {"type": "number"},
+    ):
+        assert to_json_schema(from_json_schema(document)) == document
+
+
 def test_unique_items_compares_unhashable_elements_by_value() -> None:
     """uniqueItems accepts distinct arrays/objects and rejects duplicate ones."""
     schema = from_json_schema({"type": "array", "uniqueItems": True})
@@ -1148,3 +1236,31 @@ def test_unique_items_passes_non_arrays_vacuously() -> None:
     schema = from_json_schema({"uniqueItems": True})
     assert schema("aa") == "aa"
     assert schema(5) == 5
+
+
+def test_json_strict_validators_repr_readably() -> None:
+    """The internal JSON-strict validators repr readably for error paths."""
+    assert "JsonEnum(" in repr(from_json_schema({"enum": [1]}).schema)
+    assert "JsonConst(" in repr(from_json_schema({"const": 1}).schema)
+    assert "JsonInteger()" in repr(from_json_schema({"type": "integer"}).schema)
+    assert "JsonNumber()" in repr(from_json_schema({"type": "number"}).schema)
+
+
+def test_const_string_container_stays_an_equal_check() -> None:
+    """A container const without numbers keeps Equal, not a structural subschema."""
+    schema = from_json_schema({"const": ["a", "b"]})
+    assert schema(["a", "b"]) == ["a", "b"]
+    with pytest.raises(MultipleInvalid):
+        schema(["a"])
+
+
+def test_const_rejects_a_hostile_container_value() -> None:
+    """A list subclass whose dunders raise is a mismatch, never a leaked exception."""
+
+    class HostileList(list):
+        def __len__(self) -> int:
+            raise RuntimeError
+
+    schema = from_json_schema({"const": [1, 2]})
+    with pytest.raises(MultipleInvalid):
+        schema(HostileList([1, 2]))


### PR DESCRIPTION
## What this changes

Python's `bool` subclasses `int`, and Python `==` conflates `1` with `True`. Both leaked into the JSON Schema decoder, so a decoded schema disagreed with every spec-compliant validator on booleans and on integral floats. This fixes `from_json_schema` to follow the JSON data model.

- `type: integer` rejected `1.0` and accepted `True`. Both were wrong: Draft 2020-12 defines `integer` as any number with a zero fractional part, and JSON has no boolean-as-number. It now accepts `1.0`, rejects `True` and `1.5`.
- `type: number` accepted `True`. It now rejects booleans.
- `enum` and `const` used Python equality, so `{"enum": [1, 0]}` accepted `True` and `False`, and `{"const": False}` accepted `0`. They now compare under JSON equality: booleans are never equal to numbers, numbers still compare across int/float (`const: 1` matches `1.0`, per spec), and containers compare element-wise so a nested boolean stays distinct too.

A purely string/null `enum` keeps the plain `In` validator and its friendlier "did you mean" miss suggestions; the JSON-strict check only kicks in when a number or boolean is involved. A hostile `__eq__` on the value counts as a mismatch, never a leaked exception, matching how `Equal` treats user code.

The new internal validators re-emit their keyword through `to_json_schema`, so a decoded schema round-trips and the fuzz fixpoint property holds.

## Tests

Nine new behavioral tests pin the type model, the enum/const identity semantics (including nested containers), the hostile `__eq__` path, the round trips, and the reprs.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
