### PR TITLE
Decode date-time, time, and uniqueItems faithfully; cap and fix error messages

### DIFF
--- a/docs/src/content/docs/reference/translation-keys.md
+++ b/docs/src/content/docs/reference/translation-keys.md
@@ -125,6 +125,7 @@ message, with the close matches also available raw on `context["candidates"]`
 | `required_when_present`            | `{key!r} is required when {triggers} is present`                                                    |
 | `required_when_value`              | `{key!r} is required when {conditions}`                                                             |
 | `scale_must_equal`                 | `scale must be equal to {scale}`                                                                    |
+| `too_many_valid`                   | `value matched {passed} alternatives, expected at most {max}`                                       |
 | `value_does_not_match_format`      | `value does not match expected format {format}`                                                     |
 | `value_has_no_precision`           | `value has no precision`                                                                            |
 | `value_multiple_of`                | `value must be a multiple of {factor}`                                                              |

--- a/src/probatio/_messages.py
+++ b/src/probatio/_messages.py
@@ -129,6 +129,7 @@ CATALOG: dict[str, str] = {
     "required_when_present": "{key!r} is required when {triggers} is present",
     "required_when_value": "{key!r} is required when {conditions}",
     "scale_must_equal": "scale must be equal to {scale}",
+    "too_many_valid": "value matched {passed} alternatives, expected at most {max}",
     "value_does_not_match_format": "value does not match expected format {format}",
     "value_has_no_precision": "value has no precision",
     "value_multiple_of": "value must be a multiple of {factor}",
@@ -149,9 +150,27 @@ CATALOG: dict[str, str] = {
 }
 
 
+# How many members of a list placeholder an error message spells out. The
+# structured ``placeholders`` on the error keep the complete list; only the
+# rendered text is capped, so an attacker-sized container (a 100k-entry ``enum``
+# from an untrusted schema, say) cannot turn every miss into megabytes of error
+# text in logs.
+_MAX_LISTED_VALUES = 40
+
+
+def _display(value: Any) -> Any:
+    """Cap a long list placeholder for rendering; short values pass unchanged."""
+    if isinstance(value, list) and len(value) > _MAX_LISTED_VALUES:
+        shown = ", ".join(repr(item) for item in value[:_MAX_LISTED_VALUES])
+        return f"[{shown}, ...] ({len(value) - _MAX_LISTED_VALUES} more not shown)"
+    return value
+
+
 def render(key: str, placeholders: dict[str, Any] | None) -> str:
     """Render the catalog template for ``key`` with the given placeholders."""
     template = CATALOG[key]
     if not placeholders:
         return template
-    return template.format(**placeholders)
+    return template.format(
+        **{name: _display(value) for name, value in placeholders.items()},
+    )

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -14,6 +14,7 @@ validator instead of looping.
 
 from __future__ import annotations
 
+import datetime
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -358,6 +359,11 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     if isinstance(node, Unique):
         return {"uniqueItems": True}
 
+    # The decoder's JSON-value uniqueness check re-emits its keyword, so a
+    # decoded schema round-trips.
+    if isinstance(node, _JsonUnique):
+        return {"uniqueItems": True}
+
     if isinstance(node, Contains):
         return {"contains": _child(node.item)}
 
@@ -519,15 +525,87 @@ def _convert_exact_sequence(node: ExactSequence) -> dict[str, Any]:
     }
 
 
+def _iso_parsable(value: str) -> str:
+    """Normalize an RFC 3339 string for ``fromisoformat``.
+
+    RFC 3339 allows a lowercase ``z`` suffix; ``fromisoformat`` accepts only the
+    uppercase form, so the suffix is normalized before parsing.
+    """
+    return value[:-1] + "Z" if value.endswith("z") else value
+
+
+class _JsonDateTime:
+    """Decode of ``format: date-time``: an RFC 3339 timestamp.
+
+    ``Datetime()`` validates one ``strptime`` format (fractional seconds and a
+    literal ``Z`` both mandatory), which rejects most valid RFC 3339 timestamps:
+    ``2024-01-01T00:00:00Z``, any numeric UTC offset. The decoded validator
+    parses with ``fromisoformat`` instead, which accepts the RFC 3339 forms
+    (``Z`` or an offset, any fraction length, lowercase markers). A timestamp
+    without an offset is accepted too: the spec requires one, but probatio's own
+    temporal validators treat naive timestamps as valid, and rejecting them
+    would surprise more than it protects.
+    """
+
+    __probatio_json_format__ = "date-time"
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return "JsonDateTime()"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if it is an RFC 3339 timestamp, else raise Invalid."""
+        # ``fromisoformat`` also accepts a bare date, which ``date-time``
+        # forbids, so the date/time separator at position 10 is checked first.
+        ok = isinstance(value, str) and len(value) > 10 and value[10] in "Tt"
+        if ok:
+            try:
+                datetime.datetime.fromisoformat(_iso_parsable(value))
+            except ValueError:
+                ok = False
+        if not ok:
+            raise Invalid(translation_key="expected_iso_datetime")
+        return value
+
+
+class _JsonTime:
+    """Decode of ``format: time``: an RFC 3339 time of day.
+
+    ``Time()`` validates ``%H:%M:%S`` only, rejecting fractional seconds and UTC
+    offsets that are valid per the spec. The decoded validator parses with
+    ``fromisoformat`` and requires at least ``HH:MM:SS`` (the spec's
+    partial-time; ``fromisoformat`` alone would accept ``14:30``). As with
+    ``date-time``, the offset stays optional.
+    """
+
+    __probatio_json_format__ = "time"
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return "JsonTime()"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if it is an RFC 3339 time, else raise Invalid."""
+        ok = isinstance(value, str) and len(value) >= 8
+        if ok:
+            try:
+                datetime.time.fromisoformat(_iso_parsable(value))
+            except ValueError:
+                ok = False
+        if not ok:
+            raise Invalid(translation_key="expected_iso_time")
+        return value
+
+
 # JSON Schema "format" values that map to a built probatio string validator.
 # Email/Url are factories (like voluptuous), so they are called once here.
 _FROM_FORMATS: dict[str, Any] = {
     "email": Email(),
     "uri": Url(),
     "url": Url(),
-    "date-time": Datetime(),
+    "date-time": _JsonDateTime(),
     "date": Date(),
-    "time": Time(),
+    "time": _JsonTime(),
     "ipv4": IPv4Address(),
     "ipv6": IPv6Address(),
     "uuid": UUID(),
@@ -797,6 +875,70 @@ class _Not:
         raise Invalid(translation_key="must_not_match_not_schema")
 
 
+def _unique_key(value: Any) -> Any:
+    """Reduce a JSON value to a hashable key with JSON equality semantics.
+
+    Lists and objects (unhashable in Python, but comparable JSON values) are
+    frozen recursively. Booleans are tagged so they stay distinct from ``1``
+    and ``0``; plain numbers keep Python's cross-type equality (``1 == 1.0``),
+    both as JSON equality demands. Anything that is not a JSON value falls
+    through unfrozen; an unhashable one is reported by the caller.
+    """
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, list):
+        return ("list", tuple(_unique_key(item) for item in value))
+    if isinstance(value, dict):
+        return (
+            "dict",
+            frozenset((key, _unique_key(item)) for key, item in value.items()),
+        )
+    return value
+
+
+class _JsonUnique:
+    """Decode of ``uniqueItems``: value-based uniqueness over JSON data.
+
+    ``Unique()`` builds a ``set`` of the items (voluptuous parity), so an array
+    of arrays or objects, all valid and comparable JSON, is rejected as
+    "unhashable" instead of compared. This validator freezes JSON containers
+    into hashable keys first, keeping the check linear. Per the spec the
+    keyword only constrains arrays, so any other value passes vacuously.
+    """
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return "JsonUnique()"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if its items are distinct JSON values, else raise."""
+        if not isinstance(value, list | tuple):
+            return value
+
+        seen: set[Any] = set()
+        duplicates: list[Any] = []
+        for item in value:
+            try:
+                key = _unique_key(item)
+                new = key not in seen
+                if new:
+                    seen.add(key)
+            except TypeError as exc:
+                raise Invalid(
+                    translation_key="contains_unhashable_elements",
+                    placeholders={"detail": str(exc)},
+                ) from exc
+            if not new:
+                duplicates.append(item)
+
+        if duplicates:
+            raise Invalid(
+                translation_key="contains_duplicate_items",
+                placeholders={"items": duplicates},
+            )
+        return value
+
+
 def _from_enum(values: Any) -> In:
     """Build an In from a JSON Schema ``enum``, rejecting a non-array."""
     if not isinstance(values, list):
@@ -1035,7 +1177,7 @@ def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
     # and contains itself, scoped to arrays; adding them standalone here too
     # would double-apply them.
     if node.get("uniqueItems") is True and not has_array:
-        constraints.append(Unique())
+        constraints.append(_JsonUnique())
     if "contains" in node and not has_array:
         constraints.append(_from_contains(node, ctx))
     if _OBJECT_KEYWORDS & node.keys():
@@ -1231,7 +1373,7 @@ def _from_array(node: dict[str, Any], ctx: _Decode) -> Any:
     if bounded:
         constraints.append(Length(min=min_items, max=max_items))
     if has_unique:
-        constraints.append(Unique())
+        constraints.append(_JsonUnique())
     if has_contains:
         constraints.append(_from_contains(node, ctx))
     if constraints:

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -480,6 +480,14 @@ class SomeOf(_Combinator):
 
         message = self.msg or ", ".join(str(error) for error in errors)
         if passed > self.max_valid:
+            # Joining branch errors matches voluptuous, but when every branch
+            # passed there are no errors and the message would be empty ("");
+            # say what actually went wrong: too many alternatives matched.
+            if not message:
+                raise TooManyValid(
+                    translation_key="too_many_valid",
+                    placeholders={"passed": passed, "max": self.max_valid},
+                )
             raise TooManyValid(message)
         raise NotEnoughValid(message)
 

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1025,3 +1025,126 @@ def test_required_property_default_does_not_satisfy_presence() -> None:
     assert schema({"a": 1}) == {"a": 1}
     with pytest.raises(MultipleInvalid):
         schema({})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:00:00+02:00",
+        "2024-01-01T00:00:00.123Z",
+        "2024-01-01t00:00:00z",
+        "2024-01-01T00:00:00",
+    ],
+)
+def test_format_datetime_accepts_rfc3339(value: str) -> None:
+    """format: date-time accepts RFC 3339 forms (Z, offsets, fractions, lowercase)."""
+    schema = from_json_schema({"type": "string", "format": "date-time"})
+    assert schema(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2024-01-01", "not a date", "2024-01-01T99:00:00Z", 20240101],
+)
+def test_format_datetime_rejects_non_timestamps(value: object) -> None:
+    """format: date-time still rejects bare dates, garbage, and non-strings."""
+    schema = from_json_schema({"type": "string", "format": "date-time"})
+    with pytest.raises(MultipleInvalid):
+        schema(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["14:30:00", "14:30:00.5", "14:30:00+02:00", "23:20:50Z"],
+)
+def test_format_time_accepts_rfc3339(value: str) -> None:
+    """format: time accepts fractions and UTC offsets per RFC 3339."""
+    schema = from_json_schema({"type": "string", "format": "time"})
+    assert schema(value) == value
+
+
+@pytest.mark.parametrize("value", ["14:30", "99:00:00", "nope"])
+def test_format_time_rejects_partial_or_garbage(value: str) -> None:
+    """format: time requires at least HH:MM:SS and a parsable time."""
+    schema = from_json_schema({"type": "string", "format": "time"})
+    with pytest.raises(MultipleInvalid):
+        schema(value)
+
+
+def test_format_datetime_and_time_round_trip() -> None:
+    """The RFC 3339 validators re-emit their format keyword."""
+    for document in (
+        {"type": "string", "format": "date-time"},
+        {"type": "string", "format": "time"},
+    ):
+        assert to_json_schema(from_json_schema(document)) == document
+
+
+def test_unique_items_compares_unhashable_elements_by_value() -> None:
+    """uniqueItems accepts distinct arrays/objects and rejects duplicate ones."""
+    schema = from_json_schema({"type": "array", "uniqueItems": True})
+    assert schema([[1], [2]]) == [[1], [2]]
+    assert schema([{"a": 1}, {"a": 2}]) == [{"a": 1}, {"a": 2}]
+    with pytest.raises(MultipleInvalid):
+        schema([[1], [1]])
+    with pytest.raises(MultipleInvalid):
+        schema([{"a": 1}, {"a": 1}])
+
+
+def test_unique_items_follows_json_equality() -> None:
+    """uniqueItems keeps 1 distinct from True but not from 1.0 (JSON equality)."""
+    schema = from_json_schema({"type": "array", "uniqueItems": True})
+    assert schema([1, True]) == [1, True]
+    with pytest.raises(MultipleInvalid):
+        schema([1, 1.0])
+
+
+def test_unique_items_rejects_exotic_unhashables_cleanly() -> None:
+    """A non-JSON unhashable element is a clean Invalid, not a leaked TypeError."""
+    schema = from_json_schema({"type": "array", "uniqueItems": True})
+    with pytest.raises(MultipleInvalid):
+        schema([{1, 2}, {3}])
+
+
+def test_unique_items_round_trips() -> None:
+    """The JSON uniqueness check re-emits uniqueItems."""
+    schema = from_json_schema({"uniqueItems": True})
+    assert to_json_schema(schema) == {"uniqueItems": True}
+
+
+def test_huge_enum_miss_renders_a_capped_message() -> None:
+    """An enum miss lists a bounded sample; the structured placeholders stay whole."""
+    schema = from_json_schema({"enum": list(range(100_000))})
+    with pytest.raises(MultipleInvalid) as caught:
+        schema(-1)
+    error = caught.value.errors[0]
+    assert len(str(caught.value)) < 1_000
+    assert "more not shown" in str(caught.value)
+    assert len(error.placeholders["values"]) == 100_000
+
+
+def test_oneof_too_many_matches_has_a_real_message() -> None:
+    """A value matching several oneOf branches reports that, not an empty string."""
+    schema = from_json_schema({"oneOf": [{"type": "integer"}, {"multipleOf": 2}]})
+    with pytest.raises(MultipleInvalid) as caught:
+        schema(4)
+    assert "matched 2 alternatives, expected at most 1" in str(caught.value)
+
+
+def test_rfc3339_and_unique_validators_repr_readably() -> None:
+    """The internal RFC 3339 and uniqueness validators repr readably."""
+    assert "JsonDateTime()" in repr(
+        from_json_schema({"type": "string", "format": "date-time"}).schema,
+    )
+    assert "JsonTime()" in repr(
+        from_json_schema({"type": "string", "format": "time"}).schema,
+    )
+    assert "JsonUnique()" in repr(from_json_schema({"uniqueItems": True}).schema)
+
+
+def test_unique_items_passes_non_arrays_vacuously() -> None:
+    """Typeless uniqueItems constrains arrays only; other values pass (spec)."""
+    schema = from_json_schema({"uniqueItems": True})
+    assert schema("aa") == "aa"
+    assert schema(5) == 5

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -369,9 +369,11 @@ def test_temporal_custom_format_drops_the_format() -> None:
 
 
 def test_datetime_round_trips_through_the_decoder() -> None:
-    """to_json_schema(Datetime()) decodes back into a Datetime (no asymmetry)."""
-    decoded = from_json_schema(to_json_schema(Schema(Datetime()))).schema
-    assert isinstance(decoded, Datetime)
+    """to_json_schema(Datetime()) decodes into an RFC 3339 validator that re-encodes."""
+    document = to_json_schema(Schema(Datetime()))
+    decoded = from_json_schema(document)
+    assert decoded("2024-01-01T00:00:00Z") == "2024-01-01T00:00:00Z"
+    assert to_json_schema(decoded) == document
 
 
 @pytest.mark.parametrize(
@@ -394,10 +396,10 @@ def test_as_parser_custom_format_drops_the_format() -> None:
     assert to_json_schema(Schema(AsDate(format="%d-%m-%Y"))) == {"type": "string"}
 
 
-def test_as_datetime_round_trips_to_the_string_datetime() -> None:
-    """AsDatetime encodes to date-time, which decodes back to the string Datetime."""
-    decoded = from_json_schema(to_json_schema(Schema(AsDatetime()))).schema
-    assert isinstance(decoded, Datetime)
+def test_as_datetime_round_trips_to_a_string_validator() -> None:
+    """AsDatetime encodes to date-time, which decodes to a string RFC 3339 check."""
+    decoded = from_json_schema(to_json_schema(Schema(AsDatetime())))
+    assert decoded("2024-01-01T00:00:00+02:00") == "2024-01-01T00:00:00+02:00"
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_combinators.py
+++ b/tests/validators/test_combinators.py
@@ -306,3 +306,19 @@ def test_extra_rebind_does_not_mutate_a_shared_combinator() -> None:
     # The same instance, used strictly elsewhere, still rejects the extra key.
     with pytest.raises(Invalid):
         Schema(shared, extra=PREVENT_EXTRA)({"a": 1, "x": 2})
+
+
+def test_some_of_too_many_valid_keeps_branch_errors_in_the_message() -> None:
+    """Too many matches with a failing branch still reports that branch's error."""
+    schema = Schema(SomeOf([int, int, str], min_valid=0, max_valid=1))
+    with pytest.raises(MultipleInvalid) as caught:
+        schema(3)
+    assert "expected str" in str(caught.value)
+
+
+def test_some_of_too_many_valid_without_branch_errors_says_so() -> None:
+    """When every branch matches, the error says too many matched, not ''."""
+    schema = Schema(SomeOf([int, int], min_valid=0, max_valid=1))
+    with pytest.raises(MultipleInvalid) as caught:
+        schema(3)
+    assert "matched 2 alternatives, expected at most 1" in str(caught.value)


### PR DESCRIPTION
## What this changes

Third slice of the JSON Schema review: the decoder's format validators and the error paths around decoded schemas.

- `format: date-time` decoded to `Datetime()` with the hardcoded `%Y-%m-%dT%H:%M:%S.%fZ` format, so it rejected `2024-01-01T00:00:00Z`, every numeric UTC offset, and anything without fractional seconds. Real-world RFC 3339 timestamps failed. It now parses with `fromisoformat`: `Z` or numeric offsets, any fraction length, lowercase `t`/`z` markers, and still rejects bare dates. One documented leniency: the offset stays optional (the spec requires one, but probatio's own temporal validators treat naive timestamps as valid). `format: time` gets the same treatment and requires at least `HH:MM:SS`.
- `uniqueItems` decoded to `Unique()`, which builds a `set`, so an array of arrays or objects (valid, comparable JSON) was rejected as "unhashable" instead of compared. The decoded check now freezes JSON containers into hashable keys: value-based, linear time, JSON equality (`[1, true]` is unique, `[1, 1.0]` is a duplicate), a clean `Invalid` for non-JSON unhashables, and vacuous for non-arrays per the spec.
- A miss against a 100k-entry `enum` produced a 688 kB error message (the whole container in the text), a log-amplification lever on attacker-supplied schemas. Message rendering now caps list placeholders at 40 entries plus a "(N more not shown)" tail. The structured `placeholders` on the error keep the complete list, so the API contract is unchanged; the same miss now renders under 200 characters.
- `oneOf` with a value matching several branches raised `TooManyValid("")`: the message joins the failing branches' errors, and there were none (a quirk shared with voluptuous). That case now reports "value matched 2 alternatives, expected at most 1" through a new `too_many_valid` catalog key. When branch errors exist, the joined message is untouched, so the voluptuous-parity path stays as it was.

The new internal validators re-emit their keyword through `to_json_schema`, so decoded schemas keep round-tripping.

## Tests and docs

Thirteen new behavioral tests pin the RFC 3339 forms (accept and reject), the value-based uniqueness semantics, the capped message (and intact placeholders), and both `TooManyValid` paths. The two tests asserting `format: date-time` decodes to an `isinstance` of `Datetime` are rewritten to the behavioral contract they were actually guarding: the decoded validator accepts RFC 3339 and re-encodes to the same document. The translation-keys reference gains the new catalog row (pinned by the existing docs-sync test).

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
