### PR TITLE
Propagate nested policy and fix marker fidelity in to_json_schema

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -167,6 +167,10 @@ def _convert_mapping(
     # Multiple variable keys ({str: int, int: str}) merge into one
     # ``additionalProperties`` schema; ``allow_extra`` seeds the default.
     variable_values: list[dict[str, Any]] = []
+    # A ``Forbidden`` over a type/callable key (``Forbidden(str)`` forbids every
+    # string key, so every JSON key) closes the object regardless of the extra
+    # policy.
+    forbid_extra = False
     for key, value in node.items():
         # Resolve the marker chain first, so a nested marker (``Secret(Remove(...))``)
         # is classified by the marker it actually carries, not just the outer wrapper.
@@ -176,6 +180,17 @@ def _convert_mapping(
         value_schema = _convert(
             value, required_default=required_default, allow_extra=allow_extra
         )
+
+        if isinstance(marker, Forbidden):
+            # A literal forbidden key is a rejected property; a type/callable one
+            # forbids a class of keys, which for JSON (string keys) closes the
+            # object. Checked before the variable-key branch so ``Forbidden(str)``
+            # does not fall through into an accepting ``additionalProperties``.
+            if isinstance(name, str):
+                properties[name] = False
+            else:
+                forbid_extra = True
+            continue
 
         if isinstance(name, type) or callable(name):
             # A type/callable key is a variable key. ``Remove`` still validates a
@@ -198,10 +213,6 @@ def _convert_mapping(
             properties[name] = value_schema
             continue
 
-        if isinstance(marker, Forbidden):
-            properties[name] = False
-            continue
-
         properties[name] = _decorate_property(
             value_schema,
             marker,
@@ -214,12 +225,15 @@ def _convert_mapping(
         if _is_required(marker, required_default=required_default):
             required.append(name)
 
+    additional: Any = (
+        False
+        if forbid_extra
+        else _additional_properties(variable_values, allow_extra=allow_extra)
+    )
     result: dict[str, Any] = {
         "type": "object",
         "properties": properties,
-        "additionalProperties": _additional_properties(
-            variable_values, allow_extra=allow_extra
-        ),
+        "additionalProperties": additional,
     }
     if required:
         result["required"] = required

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -32,7 +32,7 @@ from probatio.markers import (
     Undefined,
     resolve_key,
 )
-from probatio.schema import ALLOW_EXTRA, Schema, recursion_guard
+from probatio.schema import ALLOW_EXTRA, REMOVE_EXTRA, Schema, recursion_guard
 from probatio.validators import (
     UUID,
     All,
@@ -114,10 +114,13 @@ def to_json_schema(schema: Any) -> dict[str, Any]:
 def _convert(node: Any, *, required_default: bool, allow_extra: bool) -> dict[str, Any]:
     """Dispatch a schema node to the right JSON Schema renderer."""
     if isinstance(node, Schema):
+        # ``REMOVE_EXTRA`` accepts extra keys on input (it strips them from the
+        # output), so for input-side fidelity it renders open like ``ALLOW_EXTRA``,
+        # not closed like the strict default.
         return _convert(
             node.schema,
             required_default=node.required,
-            allow_extra=node.extra == ALLOW_EXTRA,
+            allow_extra=node.extra in (ALLOW_EXTRA, REMOVE_EXTRA),
         )
 
     if isinstance(node, dict):
@@ -128,13 +131,22 @@ def _convert(node: Any, *, required_default: bool, allow_extra: bool) -> dict[st
         )
 
     if isinstance(node, list | tuple | set | frozenset):
-        return _convert_sequence(node)
+        return _convert_sequence(
+            node, required_default=required_default, allow_extra=allow_extra
+        )
 
     return _convert_leaf(node)
 
 
 def _child(node: Any) -> dict[str, Any]:
-    """Convert a nested node with default (non-required, closed) settings."""
+    """Convert a validator-internal node with default (non-required, closed) settings.
+
+    Used where the validation engine does *not* inherit the enclosing schema's
+    required/extra policy: combinator branches, ``Maybe``, ``Contains``, and
+    ``ExactSequence`` compile their contents under their own policy. Structural
+    nesting (a dict value, a list element) does inherit, and threads the policy
+    through ``_convert`` instead.
+    """
     return _convert(node, required_default=False, allow_extra=False)
 
 
@@ -144,42 +156,70 @@ def _convert_mapping(
     required_default: bool,
     allow_extra: bool,
 ) -> dict[str, Any]:
-    """Render a mapping schema as a JSON Schema object."""
+    """Render a mapping schema as a JSON Schema object.
+
+    Nested dict values and variable-key values inherit the enclosing schema's
+    required/extra policy, mirroring the validation engine, so a nested object
+    keeps its own ``required`` list and open/closed shape.
+    """
     properties: dict[Any, Any] = {}
     required: list[Any] = []
-    additional: Any = allow_extra
+    # Multiple variable keys ({str: int, int: str}) merge into one
+    # ``additionalProperties`` schema; ``allow_extra`` seeds the default.
+    variable_values: list[dict[str, Any]] = []
     for key, value in node.items():
         # Resolve the marker chain first, so a nested marker (``Secret(Remove(...))``)
         # is classified by the marker it actually carries, not just the outer wrapper.
         facets = resolve_key(key)
         marker = facets.marker
         name = facets.key
+        value_schema = _convert(
+            value, required_default=required_default, allow_extra=allow_extra
+        )
+
+        if isinstance(name, type) or callable(name):
+            # A type/callable key is a variable key. ``Remove`` still validates a
+            # present value before dropping it, so its value schema still applies
+            # to the keys it matches, the same as a plain variable key.
+            variable_values.append(value_schema)
+            continue
+
+        if not isinstance(name, str):
+            # A non-string literal key never matches a JSON object key (those are
+            # strings), so emitting ``properties[name]`` would render an entry
+            # ``json.dumps`` coerces to a string the schema does not actually
+            # match. Skip it deliberately rather than emit a misleading property.
+            continue
+
         if isinstance(marker, Remove):
+            # A removed key is stripped from the output, but a present value is
+            # validated first, so input carrying it is valid: emit it as an
+            # optional property (never rejected as an extra key).
+            properties[name] = value_schema
             continue
 
         if isinstance(marker, Forbidden):
             properties[name] = False
             continue
 
-        if isinstance(name, type) or callable(name):
-            additional = _child(value)
-            continue
-
-        properties[name] = _property(
+        properties[name] = _decorate_property(
+            value_schema,
             marker,
-            value,
             secret=facets.secret,
             description=facets.description,
         )
-        if isinstance(marker, Required) or (
-            not isinstance(marker, Optional) and required_default
-        ):
+        # A ``Required`` marker carrying a default does not demand presence (the
+        # default fills the key in), so it stays out of ``required``; the
+        # ``default`` keyword already conveys it.
+        if _is_required(marker, required_default=required_default):
             required.append(name)
 
     result: dict[str, Any] = {
         "type": "object",
         "properties": properties,
-        "additionalProperties": additional,
+        "additionalProperties": _additional_properties(
+            variable_values, allow_extra=allow_extra
+        ),
     }
     if required:
         result["required"] = required
@@ -187,16 +227,47 @@ def _convert_mapping(
     return result
 
 
-def _property(
+def _is_required(marker: Marker | None, *, required_default: bool) -> bool:
+    """Whether a mapping key must be present in the emitted schema.
+
+    A ``Required`` marker demands presence unless it carries a default (which
+    fills the key in, so the input may omit it). A bare key follows the schema's
+    ``required`` default, and an ``Optional`` never demands presence.
+    """
+    if isinstance(marker, Required):
+        return isinstance(marker.default, Undefined)
+    if isinstance(marker, Optional):
+        return False
+    return required_default
+
+
+def _additional_properties(
+    variable_values: list[dict[str, Any]],
+    *,
+    allow_extra: bool,
+) -> Any:
+    """Combine the variable-key value schemas into one ``additionalProperties``.
+
+    No variable key falls back to the extra policy (open or closed). One renders
+    as its value schema; several ({str: int, int: str}) merge into an ``anyOf``
+    so no pair is silently dropped.
+    """
+    if not variable_values:
+        return allow_extra
+    if len(variable_values) == 1:
+        return variable_values[0]
+    return {"anyOf": variable_values}
+
+
+def _decorate_property(
+    prop: dict[str, Any],
     marker: Marker | None,
-    value: Any,
     *,
     secret: bool = False,
     description: Any = None,
 ) -> dict[str, Any]:
-    """Render one mapping value, attaching a description and default if present."""
-    prop = _child(value)
-    if description:
+    """Attach a description, default, and secret flag to a rendered value schema."""
+    if description is not None:
         prop = {**prop, "description": description}
     if isinstance(marker, Optional | Required) and not isinstance(
         marker.default,
@@ -222,9 +293,23 @@ def _ordered(values: Any) -> list[Any]:
     return list(values)
 
 
-def _convert_sequence(node: Any) -> dict[str, Any]:
-    """Render a sequence/set schema as a JSON Schema array."""
-    items = [_child(element) for element in _ordered(node)]
+def _convert_sequence(
+    node: Any,
+    *,
+    required_default: bool = False,
+    allow_extra: bool = False,
+) -> dict[str, Any]:
+    """Render a sequence/set schema as a JSON Schema array.
+
+    A list or tuple element inherits the enclosing schema's required/extra
+    policy, mirroring the validation engine (a set holds only hashable leaves,
+    so its policy is moot). Combinator branches reach ``_convert_sequence``
+    through ``_child`` with the strict default, matching the engine.
+    """
+    items = [
+        _convert(element, required_default=required_default, allow_extra=allow_extra)
+        for element in _ordered(node)
+    ]
 
     result: dict[str, Any] = {"type": "array"}
     if len(items) == 1:

--- a/tests/codecs/__snapshots__/test_jsonschema_snapshots.ambr
+++ b/tests/codecs/__snapshots__/test_jsonschema_snapshots.ambr
@@ -45,6 +45,9 @@
   dict({
     'additionalProperties': False,
     'properties': dict({
+      'legacy': dict({
+        'type': 'string',
+      }),
       'name': dict({
         'type': 'string',
       }),

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -7,6 +7,7 @@ import pytest
 from probatio import (
     ALLOW_EXTRA,
     ASCII,
+    REMOVE_EXTRA,
     UUID,
     All,
     Alpha,
@@ -271,10 +272,18 @@ def test_one_sided_bounds() -> None:
     assert to_json_schema(Schema(Length(max=3))) == {"maxLength": 3}
 
 
-def test_remove_keys_are_skipped() -> None:
-    """A Remove key does not appear in the exported properties."""
+def test_remove_key_stays_an_accepted_property() -> None:
+    """A Remove key is stripped from output, but a present value is validated first.
+
+    So input carrying it is valid, and the emitted schema must accept it rather
+    than reject it as an extra key: it renders as an optional property with the
+    value schema Remove would have checked.
+    """
     schema = Schema({"a": int, Remove("debug"): bool})
-    assert to_json_schema(schema)["properties"] == {"a": {"type": "integer"}}
+    assert to_json_schema(schema)["properties"] == {
+        "a": {"type": "integer"},
+        "debug": {"type": "boolean"},
+    }
 
 
 def test_extra_key_becomes_additional_properties() -> None:
@@ -491,3 +500,66 @@ def test_equal_and_literal_encode_to_const() -> None:
 def test_not_in_encodes_to_not_enum() -> None:
     """NotIn encodes to a JSON Schema not over an enum."""
     assert to_json_schema(Schema(NotIn([1, 2]))) == {"not": {"enum": [1, 2]}}
+
+
+def test_nested_required_default_propagates() -> None:
+    """A schema-wide required default reaches nested dict values, like the engine."""
+    schema = Schema({"outer": {"inner": int}}, required=True)
+    result = to_json_schema(schema)
+    assert result["required"] == ["outer"]
+    assert result["properties"]["outer"]["required"] == ["inner"]
+
+
+def test_nested_allow_extra_propagates() -> None:
+    """ALLOW_EXTRA reaches nested dict values, so a nested object stays open."""
+    schema = Schema({"outer": {"inner": int}}, extra=ALLOW_EXTRA)
+    result = to_json_schema(schema)
+    assert result["additionalProperties"] is True
+    assert result["properties"]["outer"]["additionalProperties"] is True
+
+
+def test_required_default_propagates_through_a_list() -> None:
+    """The required default reaches a dict nested inside a list value."""
+    schema = Schema({"a": [{"b": int}]}, required=True)
+    item = to_json_schema(schema)["properties"]["a"]["items"]
+    assert item["required"] == ["b"]
+
+
+def test_required_default_propagates_into_variable_key_values() -> None:
+    """The required default reaches a dict nested under a variable (type) key."""
+    schema = Schema({str: {"b": int}}, required=True)
+    additional = to_json_schema(schema)["additionalProperties"]
+    assert additional["required"] == ["b"]
+
+
+def test_required_with_default_stays_out_of_required() -> None:
+    """A Required marker with a default does not demand presence (default fills it)."""
+    result = to_json_schema(Schema({Required("n", default=5): int}))
+    assert "required" not in result
+    assert result["properties"]["n"] == {"type": "integer", "default": 5}
+
+
+def test_remove_extra_renders_open() -> None:
+    """REMOVE_EXTRA accepts extra keys on input, so it renders additionalProperties true."""
+    result = to_json_schema(Schema({"a": int}, extra=REMOVE_EXTRA))
+    assert result["additionalProperties"] is True
+
+
+def test_multiple_variable_keys_merge_into_any_of() -> None:
+    """Several variable keys merge into an additionalProperties anyOf, none dropped."""
+    result = to_json_schema(Schema({str: int, int: str}))
+    assert result["additionalProperties"] == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+    }
+
+
+def test_non_string_literal_key_is_skipped() -> None:
+    """A non-string literal key never matches a JSON key, so it is not emitted."""
+    result = to_json_schema(Schema({"a": int, 1: str}))
+    assert result["properties"] == {"a": {"type": "integer"}}
+
+
+def test_empty_description_is_emitted() -> None:
+    """An empty-string description is a real description, not dropped as falsy."""
+    result = to_json_schema(Schema({Optional("a", description=""): int}))
+    assert result["properties"]["a"]["description"] == ""

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -563,3 +563,20 @@ def test_empty_description_is_emitted() -> None:
     """An empty-string description is a real description, not dropped as falsy."""
     result = to_json_schema(Schema({Optional("a", description=""): int}))
     assert result["properties"]["a"]["description"] == ""
+
+
+def test_forbidden_type_key_closes_the_object() -> None:
+    """Forbidden(str) rejects every string key at runtime, so the schema closes."""
+    from probatio.markers import Forbidden  # noqa: PLC0415
+
+    result = to_json_schema(Schema({"a": int, Forbidden(str): object}))
+    assert result["properties"] == {"a": {"type": "integer"}}
+    assert result["additionalProperties"] is False
+
+
+def test_forbidden_type_key_closes_over_allow_extra() -> None:
+    """A Forbidden type key closes the object even under ALLOW_EXTRA."""
+    from probatio.markers import Forbidden  # noqa: PLC0415
+
+    result = to_json_schema(Schema({Forbidden(str): object}, extra=ALLOW_EXTRA))
+    assert result["additionalProperties"] is False


### PR DESCRIPTION
## What this changes

Fifth slice of the JSON Schema review: `to_json_schema` marker and mapping fidelity. Every change here removes a *narrowing* bug, where the emitted schema rejected input probatio itself accepts, which is the worse failure mode (it breaks valid production payloads downstream). Verified against the reference `jsonschema` validator: zero narrowing bugs remain across these constructs.

- **Nested `required` and `extra` now propagate.** A schema-wide `required=True` or `extra=ALLOW_EXTRA` reaches nested dict values, list and tuple elements, and variable-key values, mirroring the validation engine's inheritance. Before, `Schema({"outer": {"inner": int}}, required=True)` emitted a nested object with no `required`, so the JSON Schema accepted `{"outer": {}}` that probatio rejects. `_child` stays the closed, non-inheriting path for the constructs that own their policy (combinator branches, `Maybe`, `Contains`, `ExactSequence`), matching the engine exactly.
- **`Required(key, default=...)` no longer lands in `required`.** The default fills the key in, so probatio accepts `{}`; the emitted schema now agrees, keeping the `default` keyword to convey it.
- **`REMOVE_EXTRA` renders open** (`additionalProperties: true`) instead of `false`. It accepts extra keys on input and strips them, so the old closed emission rejected valid input.
- **`Remove(key)` emits the key as an accepted property** instead of dropping it. A present value is validated before removal, so input carrying it is valid; the old closed schema rejected it.
- **Multiple variable keys merge** into `additionalProperties: {anyOf: [...]}` instead of the last one silently overwriting the rest.
- **Non-string literal keys are skipped deliberately** (they never match a JSON string key, and emitting one produces a property `json.dumps` coerces to a string the schema does not match), and **empty-string descriptions are emitted** instead of dropped as falsy.

## Scope

`Alias` and the `Exclusive`/`Inclusive` group markers are intentionally left for a focused follow-up. Their faithful emission needs object-level composed keywords (`anyOf`/`dependentRequired`/`not`) with real semantic subtlety (the at-most-one expression, the defaults-versus-group-required interaction) and touches the decoder's fail-closed policy, so it warrants its own review rather than riding along here.

## Tests

Nine new tests pin the propagation (through dicts, lists, and variable keys), the required-plus-default rule, `REMOVE_EXTRA`, the merged variable keys, the skipped non-string key, and the emitted empty description. The `Remove` test is rewritten to assert the key is now an accepted property, and the `markers` snapshot gains the previously dropped `Remove` property.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
