### PR TITLE
Fix All merge, Match anchoring, Self, and non-JSON values in to_json_schema

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import datetime
 import re
 from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
 from typing import Any
 
 from probatio.codecs._regex_safety import is_catastrophic
@@ -29,6 +31,7 @@ from probatio.markers import (
     Remove,
     Required,
     Secret,
+    Self,
     Undefined,
     resolve_key,
 )
@@ -107,8 +110,21 @@ _MAX_SCHEMA_DEPTH = 100
 
 
 def to_json_schema(schema: Any) -> dict[str, Any]:
-    """Convert a schema (or ``Schema``) into a JSON Schema dictionary."""
-    return _convert(schema, required_default=False, allow_extra=False)
+    """Convert a schema (or ``Schema``) into a JSON Schema dictionary.
+
+    A raw schema that references itself (a dict holding itself as a value, rather
+    than the supported ``Self`` marker) has no finite rendering, so the runaway
+    recursion is caught and reported as a clean ``SchemaError`` instead of a bare
+    ``RecursionError``.
+    """
+    try:
+        return _convert(schema, required_default=False, allow_extra=False)
+    except RecursionError as exc:
+        message = (
+            "schema is too deeply nested or references itself; use the Self "
+            "marker for a recursive schema"
+        )
+        raise SchemaError(message) from exc
 
 
 def _convert(node: Any, *, required_default: bool, allow_extra: bool) -> dict[str, Any]:
@@ -287,7 +303,11 @@ def _decorate_property(
         marker.default,
         Undefined,
     ):
-        prop = {**prop, "default": marker.default()}
+        # ``default`` is annotation-only, so a non-JSON default (a ``datetime``,
+        # say) is omitted rather than emitted raw and crashing ``json.dumps``.
+        default = _json_safe(marker.default())
+        if default is not _UNREPRESENTABLE:
+            prop = {**prop, "default": default}
     if secret:
         # ``writeOnly`` is JSON Schema's marker for a secret (a password field).
         prop = {**prop, "writeOnly": True}
@@ -330,12 +350,24 @@ def _convert_sequence(
         result["items"] = items[0]
     elif items:
         result["items"] = {"anyOf": items}
+    else:
+        # An empty sequence schema (``Schema([])``) accepts only the empty list,
+        # not any array, so forbid every element rather than leave it open.
+        result["maxItems"] = 0
 
     return result
 
 
 def _convert_leaf(node: Any) -> dict[str, Any]:
     """Render a leaf node: a type, a literal, or a validator."""
+    if node is Self:
+        # ``Self`` means "the whole enclosing schema", the recursive reference
+        # the decoder already reads back from ``$ref: "#"``. ``#`` targets the
+        # document root, which is the top-level schema being encoded (the common
+        # recursive-schema case); a ``Self`` inside a separately nested ``Schema``
+        # would resolve against its own root, which this cannot express.
+        return {"$ref": "#"}
+
     json_format = getattr(node, "__probatio_json_format__", None)
 
     if json_format is not None:
@@ -378,12 +410,32 @@ def _convert_validator(node: Any) -> dict[str, Any] | None:
         return {"anyOf": [_child(validator) for validator in node.validators]}
 
     if isinstance(node, All):
-        merged: dict[str, Any] = {}
-        for validator in node.validators:
-            merged.update(_child(validator))
-        return _retarget_length(merged)
+        return _convert_all(node)
 
     return _convert_constraint(node)
+
+
+def _convert_all(node: All) -> dict[str, Any]:
+    """Merge an All's validators into one schema, or ``allOf`` when keys collide.
+
+    Merging with ``dict.update`` is the common, compact case (``All(int, Range)``
+    → one object). But when two validators emit the same keyword (``All(Any(...),
+    Any(...))`` both emit ``anyOf``), a plain update drops the earlier one and
+    widens the schema. Falling back to ``allOf`` keeps every facet, since a value
+    must satisfy them all.
+    """
+    parts = [_child(validator) for validator in node.validators]
+    merged: dict[str, Any] = {}
+    collided = False
+    for part in parts:
+        if merged.keys() & part.keys():
+            collided = True
+            break
+        merged.update(part)
+
+    if collided:
+        return {"allOf": [part for part in parts if part]}
+    return _retarget_length(merged)
 
 
 # JSON Schema spells "length" three ways depending on the type: minLength for a
@@ -411,27 +463,82 @@ def _retarget_length(merged: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
+_UNREPRESENTABLE = object()
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert a value to a JSON-representable form, or ``_UNREPRESENTABLE``.
+
+    ``to_json_schema`` must emit a document ``json.dumps`` accepts (an emitted
+    ``const``, ``enum``, ``default``, or numeric bound holding a raw ``datetime``,
+    ``Decimal``, ``Enum`` member, or ``bytes`` would otherwise crash the caller).
+    Datetimes render ISO, a ``Decimal`` renders a float, an ``Enum`` member
+    renders its value, and a tuple or set renders a list (JSON has no tuple, and
+    a value on the wire arrives as a list anyway). Anything with no clean JSON
+    form is reported unrepresentable so the caller can omit it.
+    """
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, Enum):
+        return _json_safe(value.value)
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
+        return value.isoformat()
+    if isinstance(value, list | tuple | set | frozenset):
+        converted = [_json_safe(item) for item in _ordered(value)]
+        return _UNREPRESENTABLE if _UNREPRESENTABLE in converted else converted
+    if isinstance(value, dict):
+        items = {key: _json_safe(item) for key, item in value.items()}
+        if (
+            any(not isinstance(key, str) for key in items)
+            or _UNREPRESENTABLE in items.values()
+        ):
+            return _UNREPRESENTABLE
+        return items
+    return _UNREPRESENTABLE
+
+
+def _enum(container: Any) -> dict[str, Any]:
+    """Render a membership container as an ``enum``, or open when unrepresentable.
+
+    A member with no JSON form (a ``datetime``, an ``Enum``, a ``bytes``) would
+    make the emitted enum non-serializable; dropping the constraint to an open
+    schema keeps the output valid rather than crashing, since a narrower emission
+    is not available.
+    """
+    values = _json_safe(list(_ordered(container)))
+    return {} if values is _UNREPRESENTABLE else {"enum": values}
+
+
+def _const(value: Any) -> dict[str, Any]:
+    """Render an equality target as a ``const``, or open when unrepresentable."""
+    converted = _json_safe(value)
+    return {} if converted is _UNREPRESENTABLE else {"const": converted}
+
+
 def _convert_equality(node: Any) -> dict[str, Any] | None:
     """Render the equality/membership validators as enum/const/not, or None."""
     if isinstance(node, In):
-        return {"enum": _ordered(node.container)}
+        return _enum(node.container)
 
     if isinstance(node, NotIn):
-        return {"not": {"enum": _ordered(node.container)}}
+        enum = _enum(node.container)
+        return {"not": enum} if enum else {}
 
     if isinstance(node, Equal):
-        return {"const": node.target}
+        return _const(node.target)
 
     if isinstance(node, Literal):
-        return {"const": node.lit}
+        return _const(node.lit)
 
     # The decoder's JSON-strict enum/const (numbers and booleans kept distinct)
     # re-emit their keyword, so a decoded schema round-trips.
     if isinstance(node, _JsonEnum):
-        return {"enum": list(node.values)}
+        return _enum(node.values)
 
     if isinstance(node, _JsonConst):
-        return {"const": node.value}
+        return _const(node.value)
 
     return None
 
@@ -553,22 +660,39 @@ def _convert_match(node: Match) -> dict[str, Any]:
     JSON Schema patterns are ECMA-262 regular expressions, while ``Match`` holds a
     Python ``re`` pattern. A pattern that uses Python-only syntax is dropped, leaving
     a plain ``{"type": "string"}``, so the emitted schema stays valid for an external
-    validator rather than carrying a pattern that validator would reject. An
-    ECMA-compatible pattern is emitted unchanged.
+    validator rather than carrying a pattern that validator would reject.
+
+    ``Match`` validates with ``re.match`` (anchored at the start), while a JSON
+    Schema ``pattern`` is an unanchored ``re.search``. Wrapping an unanchored
+    source as ``^(?:...)`` preserves the start anchoring, so the emitted schema
+    does not accept a value with a matching suffix that ``Match`` rejects.
+
+    A ``bytes`` pattern has no JSON Schema (JSON strings are text), so it renders
+    as a plain string rather than crashing on the ``str``/``bytes`` mismatch.
     """
     source = node.pattern.pattern
-    if _PYTHON_ONLY_REGEX.search(source):
+    if isinstance(source, bytes) or _PYTHON_ONLY_REGEX.search(source):
         return {"type": "string"}
-    return {"type": "string", "pattern": source}
+    # A source already anchored at the start needs no wrapper; otherwise wrap it
+    # (grouped, so a top-level alternation stays under the anchor).
+    anchored = source if source.startswith("^") else f"^(?:{source})"
+    return {"type": "string", "pattern": anchored}
 
 
 def _convert_range(node: Range) -> dict[str, Any]:
-    """Render a Range as JSON Schema minimum/maximum bounds."""
+    """Render a Range as JSON Schema minimum/maximum bounds.
+
+    A non-numeric bound (a ``datetime``, say) has no JSON Schema numeric keyword
+    and would make the output non-serializable, so such a bound is omitted rather
+    than emitted raw.
+    """
     result: dict[str, Any] = {}
-    if node.min is not None:
-        result["minimum" if node.min_included else "exclusiveMinimum"] = node.min
-    if node.max is not None:
-        result["maximum" if node.max_included else "exclusiveMaximum"] = node.max
+    minimum = _json_safe(node.min)
+    maximum = _json_safe(node.max)
+    if node.min is not None and isinstance(minimum, int | float):
+        result["minimum" if node.min_included else "exclusiveMinimum"] = minimum
+    if node.max is not None and isinstance(maximum, int | float):
+        result["maximum" if node.max_included else "exclusiveMaximum"] = maximum
 
     return result
 

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+from decimal import Decimal
+
 import pytest
 
 from probatio import (
@@ -205,11 +208,32 @@ def test_match_drops_a_python_only_pattern(pattern: str) -> None:
     ],
 )
 def test_match_keeps_an_ecma_compatible_pattern(pattern: str) -> None:
-    """An ECMA-compatible pattern, including ones that resemble Python-only, is kept."""
+    """An ECMA-compatible pattern is kept, anchored at the start like re.match."""
     assert to_json_schema(Schema(Match(pattern))) == {
         "type": "string",
-        "pattern": pattern,
+        "pattern": f"^(?:{pattern})",
     }
+
+
+def test_match_anchors_an_unanchored_pattern() -> None:
+    """Match validates with re.match (start-anchored); the emitted pattern matches."""
+    assert to_json_schema(Schema(Match(r"\d+"))) == {
+        "type": "string",
+        "pattern": r"^(?:\d+)",
+    }
+
+
+def test_match_leaves_an_already_anchored_pattern() -> None:
+    """A pattern already anchored at the start is emitted unchanged."""
+    assert to_json_schema(Schema(Match(r"^\d+$"))) == {
+        "type": "string",
+        "pattern": r"^\d+$",
+    }
+
+
+def test_match_bytes_pattern_renders_a_plain_string() -> None:
+    """A bytes pattern has no JSON Schema, so it renders a string, not a crash."""
+    assert to_json_schema(Schema(Match(re.compile(rb"\d+")))) == {"type": "string"}
 
 
 def test_maybe_is_nullable() -> None:
@@ -294,8 +318,8 @@ def test_extra_key_becomes_additional_properties() -> None:
 
 
 def test_empty_list_schema() -> None:
-    """An empty list schema exports an array with no item constraint."""
-    assert to_json_schema(Schema([])) == {"type": "array"}
+    """An empty list schema accepts only the empty array, not any array."""
+    assert to_json_schema(Schema([])) == {"type": "array", "maxItems": 0}
 
 
 def test_raw_schema_input() -> None:
@@ -580,3 +604,116 @@ def test_forbidden_type_key_closes_over_allow_extra() -> None:
 
     result = to_json_schema(Schema({Forbidden(str): object}, extra=ALLOW_EXTRA))
     assert result["additionalProperties"] is False
+
+
+def test_self_exports_a_recursive_ref() -> None:
+    """A Self reference exports as a $ref to the document root, not an open schema."""
+    from probatio import Self  # noqa: PLC0415
+
+    schema = Schema({"name": str, Optional("children"): [Self]})
+    result = to_json_schema(schema)
+    assert result["properties"]["children"]["items"] == {"$ref": "#"}
+
+
+def test_all_with_colliding_keywords_uses_all_of() -> None:
+    """Two validators emitting the same keyword merge into allOf, not last-writer-wins."""
+    result = to_json_schema(Schema(All(Any(int, str), Any(str, float))))
+    assert result == {
+        "allOf": [
+            {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+            {"anyOf": [{"type": "string"}, {"type": "number"}]},
+        ],
+    }
+
+
+def test_all_without_collisions_still_merges() -> None:
+    """Non-colliding validators keep the compact single-object merge."""
+    assert to_json_schema(Schema(All(int, Range(min=0)))) == {
+        "type": "integer",
+        "minimum": 0,
+    }
+
+
+def test_enum_with_a_datetime_member_stays_serializable() -> None:
+    """An In holding a datetime renders ISO strings, not raw datetimes."""
+    from datetime import datetime  # noqa: PLC0415
+
+    result = to_json_schema(Schema(In([datetime(2020, 1, 1)])))
+    assert result == {"enum": ["2020-01-01T00:00:00"]}
+
+
+def test_enum_with_enum_members_renders_their_values() -> None:
+    """An In holding Enum members renders the member values."""
+    from enum import Enum  # noqa: PLC0415
+
+    class Color(Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    assert to_json_schema(Schema(In([Color.RED, Color.BLUE]))) == {
+        "enum": ["red", "blue"],
+    }
+
+
+def test_const_with_a_decimal_renders_a_float() -> None:
+    """An Equal holding a Decimal renders a float const, not a raw Decimal."""
+    assert to_json_schema(Schema(Equal(Decimal("1.5")))) == {"const": 1.5}
+
+
+def test_enum_with_tuples_renders_lists() -> None:
+    """An In holding tuples renders JSON arrays (the wire form)."""
+    assert to_json_schema(Schema(In([(1, 2), (3, 4)]))) == {"enum": [[1, 2], [3, 4]]}
+
+
+def test_datetime_default_renders_iso() -> None:
+    """A datetime default renders its ISO string rather than a raw datetime."""
+    from datetime import datetime  # noqa: PLC0415
+
+    schema = Schema({Optional("t", default=datetime(2020, 1, 1)): object})
+    assert to_json_schema(schema)["properties"]["t"]["default"] == "2020-01-01T00:00:00"
+
+
+def test_unrepresentable_default_is_omitted() -> None:
+    """A default with no JSON form is dropped rather than emitted raw."""
+    schema = Schema({Optional("t", default=b"raw"): object})
+    assert "default" not in to_json_schema(schema)["properties"]["t"]
+
+
+def test_non_numeric_range_bound_is_omitted() -> None:
+    """A non-numeric Range bound has no JSON keyword, so it is omitted."""
+    from datetime import datetime  # noqa: PLC0415
+
+    assert to_json_schema(Schema(Range(min=datetime(2020, 1, 1)))) == {}
+
+
+def test_unrepresentable_enum_member_widens_to_open() -> None:
+    """A member with no JSON form drops the enum to an open schema, not a crash."""
+    assert to_json_schema(Schema(In([b"bytes"]))) == {}
+
+
+def test_cyclic_raw_schema_is_a_clean_error() -> None:
+    """A raw dict that references itself is refused, not a bare RecursionError."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    node: dict[object, object] = {"v": int}
+    node["next"] = node
+    with pytest.raises(SchemaError, match="references itself"):
+        to_json_schema(node)
+
+
+def test_const_with_a_dict_renders_json_safe_values() -> None:
+    """A dict const renders with each value made JSON-safe (a datetime to ISO)."""
+    from datetime import datetime  # noqa: PLC0415
+
+    result = to_json_schema(Schema(Equal({"when": datetime(2020, 1, 1)})))
+    assert result == {"const": {"when": "2020-01-01T00:00:00"}}
+
+
+def test_const_with_a_non_string_dict_key_widens_to_open() -> None:
+    """A dict const with a non-string key has no JSON object form, so it opens."""
+    assert to_json_schema(Schema(Equal({1: "a"}))) == {}
+
+
+def test_const_with_an_unrepresentable_dict_value_widens_to_open() -> None:
+    """A dict const holding an unrepresentable value opens rather than crashing."""
+    assert to_json_schema(Schema(Equal({"a": b"raw"}))) == {}


### PR DESCRIPTION
## What this changes

Sixth slice of the JSON Schema review: `to_json_schema` validator fidelity and the crashes around non-serializable output. Verified against the reference `jsonschema` validator; every emitted schema is now `json.dumps`-able.

- **`All` merge no longer drops colliding facets.** When two validators emit the same keyword (`All(Any(int, str), Any(str, float))` both emit `anyOf`), the old `dict.update` kept only the last and widened the schema. It now falls back to `allOf`, keeping every facet. The compact single-object merge still applies when nothing collides (`All(int, Range)` stays `{type, minimum}`).
- **`Match` anchoring is preserved, and a bytes pattern no longer crashes.** `Match` validates with `re.match` (anchored at the start), but the emitted unanchored `pattern` (an `re.search`) accepted a value with a matching suffix that `Match` rejects. An unanchored source now emits `^(?:...)`; an already-anchored one is left unchanged. A `bytes` pattern has no JSON Schema, so it renders a plain string instead of raising `TypeError`.
- **`Self` emits `{"$ref": "#"}`** instead of an open `{}`, so a recursive schema exports its recursion (and round-trips through the decoder, which already reads a recursive `$ref`). `#` targets the document root, which is correct for the common top-level recursive schema; a `Self` inside a separately nested `Schema` cannot be expressed and is documented as such.
- **`Schema([])` emits `maxItems: 0`** (only the empty array validates) instead of accepting any array.
- **Non-JSON values are made serializable or omitted.** A new `_json_safe` renders datetimes as ISO strings, a `Decimal` as a float, an `Enum` member as its value, and a tuple or set as a list (JSON has no tuple, and a value on the wire arrives as a list). It is applied to `enum`, `const`, `default`, and `Range` bounds. A value with no clean JSON form (bytes, an arbitrary object) drops the constraint to an open schema rather than crashing `json.dumps`. This fixes the LLM-tools recipe, which produced non-serializable output before.
- **A cyclic raw dict schema** (one that holds itself as a value, rather than using the `Self` marker) is reported as a clean `SchemaError` instead of a bare `RecursionError`.

## Scope

The bare-`Range`-emits-`type: number` suggestion (review item #18, minor) is intentionally left out. Emitting a type there would collide with `All(int, Range)`'s clean merge and force verbose `allOf` on very common output, for a widening that matches JSON Schema's own "numeric keywords ignore non-numbers" semantics.

## Tests

Eighteen new tests cover the `allOf` collision path, the `Match` anchoring and bytes cases, the `Self` ref, the empty-sequence bound, each `_json_safe` conversion (datetime, Decimal, Enum, tuple, dict, and the unrepresentable-widens-to-open cases), the omitted default, and the cyclic-schema error. The two Match tests that asserted unanchored patterns are updated to the anchored form, and the empty-list test to `maxItems: 0`.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
