### PR TITLE
Emit Alias, Inclusive, and Exclusive group markers in to_json_schema

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -188,8 +188,13 @@ class _Groups:
         self.exclusive: dict[str, _ExclusiveGroup] = {}
 
     def add_alias(self, marker: Alias) -> None:
-        """Record a required ``Alias`` (one of its names must be present)."""
-        if marker.required:
+        """Record a required ``Alias`` (one of its names must be present).
+
+        A ``default`` fills the empty case, so a required Alias carrying one does
+        not actually demand a name (the same rule as ``Required`` with a default
+        and a required-with-default ``Exclusive`` group); it adds no constraint.
+        """
+        if marker.required and isinstance(marker.default, Undefined):
             self.alias_required.append(list(marker.input_names))
 
     def add_inclusive(self, marker: Inclusive, name: str) -> None:

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -25,7 +25,10 @@ from probatio.codecs._regex_safety import is_catastrophic
 from probatio.codecs._shared import FORMAT_BY_TYPE, STRING_TYPES
 from probatio.error import ContainsInvalid, Invalid, SchemaError
 from probatio.markers import (
+    Alias,
+    Exclusive,
     Forbidden,
+    Inclusive,
     Marker,
     Optional,
     Remove,
@@ -166,6 +169,89 @@ def _child(node: Any) -> dict[str, Any]:
     return _convert(node, required_default=False, allow_extra=False)
 
 
+@dataclass
+class _ExclusiveGroup:
+    """The members of an ``Exclusive`` group and how an empty group is judged."""
+
+    members: list[str] = field(default_factory=list)
+    required: bool = False
+    has_default: bool = False
+
+
+class _Groups:
+    """Accumulates the group-marker memberships found while walking a mapping."""
+
+    def __init__(self) -> None:
+        """Start with no groups recorded."""
+        self.alias_required: list[list[str]] = []
+        self.inclusive: dict[str, list[str]] = {}
+        self.exclusive: dict[str, _ExclusiveGroup] = {}
+
+    def add_alias(self, marker: Alias) -> None:
+        """Record a required ``Alias`` (one of its names must be present)."""
+        if marker.required:
+            self.alias_required.append(list(marker.input_names))
+
+    def add_inclusive(self, marker: Inclusive, name: str) -> None:
+        """Record an ``Inclusive`` member (all-or-none within its group)."""
+        self.inclusive.setdefault(marker.group_of_inclusion, []).append(name)
+
+    def add_exclusive(self, marker: Exclusive, name: str) -> None:
+        """Record an ``Exclusive`` member (at most one present within its group)."""
+        group = self.exclusive.setdefault(marker.group_of_exclusion, _ExclusiveGroup())
+        group.members.append(name)
+        group.required = group.required or marker.group_required
+        group.has_default = group.has_default or not isinstance(
+            marker.default, Undefined
+        )
+
+    def constraints(self) -> list[dict[str, Any]]:
+        """Build the object-level JSON Schema constraints for every recorded group."""
+        constraints: list[dict[str, Any]] = [
+            # At least one of the alias names must be present.
+            {"anyOf": [{"required": [name]} for name in names]}
+            for names in self.alias_required
+        ]
+        constraints += [
+            _inclusive_constraint(members)
+            for members in self.inclusive.values()
+            if len(members) > 1
+        ]
+        constraints += [
+            _exclusive_constraint(group) for group in self.exclusive.values()
+        ]
+        return [constraint for constraint in constraints if constraint]
+
+
+def _inclusive_constraint(members: list[str]) -> dict[str, Any]:
+    """Render an ``Inclusive`` group as all-or-none: any member pulls in every other."""
+    return {
+        "dependentRequired": {
+            member: [other for other in members if other != member]
+            for member in members
+        },
+    }
+
+
+def _exclusive_constraint(group: _ExclusiveGroup) -> dict[str, Any]:
+    """Render one ``Exclusive`` group as an at-most-one (or exactly-one) constraint.
+
+    A required group with no default demands exactly one member (``oneOf`` over
+    the per-member ``required``). Otherwise the group allows at most one: a
+    default fills the empty group, so the empty object stays valid. At most one
+    is "not any two present", the negation of every pair being present together.
+    """
+    members = group.members
+    if group.required and not group.has_default:
+        return {"oneOf": [{"required": [member]} for member in members]}
+    pairs = [
+        [members[i], members[j]]
+        for i in range(len(members))
+        for j in range(i + 1, len(members))
+    ]
+    return {"not": {"anyOf": [{"required": pair} for pair in pairs]}} if pairs else {}
+
+
 def _convert_mapping(
     node: dict[Any, Any],
     *,
@@ -176,10 +262,13 @@ def _convert_mapping(
 
     Nested dict values and variable-key values inherit the enclosing schema's
     required/extra policy, mirroring the validation engine, so a nested object
-    keeps its own ``required`` list and open/closed shape.
+    keeps its own ``required`` list and open/closed shape. The group markers
+    (``Alias``, ``Inclusive``, ``Exclusive``) add object-level constraints,
+    combined under ``allOf``.
     """
     properties: dict[Any, Any] = {}
     required: list[Any] = []
+    groups = _Groups()
     # Multiple variable keys ({str: int, int: str}) merge into one
     # ``additionalProperties`` schema; ``allow_extra`` seeds the default.
     variable_values: list[dict[str, Any]] = []
@@ -229,17 +318,21 @@ def _convert_mapping(
             properties[name] = value_schema
             continue
 
-        properties[name] = _decorate_property(
+        decorated = _decorate_property(
             value_schema,
             marker,
             secret=facets.secret,
             description=facets.description,
         )
-        # A ``Required`` marker carrying a default does not demand presence (the
-        # default fills the key in), so it stays out of ``required``; the
-        # ``default`` keyword already conveys it.
-        if _is_required(marker, required_default=required_default):
-            required.append(name)
+        _emit_named_key(
+            name,
+            decorated,
+            marker,
+            properties,
+            required,
+            groups,
+            required_default=required_default,
+        )
 
     additional: Any = (
         False
@@ -253,8 +346,43 @@ def _convert_mapping(
     }
     if required:
         result["required"] = required
+    constraints = groups.constraints()
+    if constraints:
+        result["allOf"] = constraints
 
     return result
+
+
+def _emit_named_key(  # noqa: PLR0913
+    name: str,
+    decorated: dict[str, Any],
+    marker: Marker | None,
+    properties: dict[Any, Any],
+    required: list[Any],
+    groups: _Groups,
+    *,
+    required_default: bool,
+) -> None:
+    """Place a decorated property and record any group membership it carries."""
+    if isinstance(marker, Alias):
+        # An aliased key is accepted under any of its names, so each renders as a
+        # property; the "one name must be present" rule (for a required Alias)
+        # becomes an object-level constraint.
+        for alias_name in marker.input_names:
+            properties[alias_name] = decorated
+        groups.add_alias(marker)
+        return
+
+    properties[name] = decorated
+    if isinstance(marker, Inclusive):
+        groups.add_inclusive(marker, name)
+    elif isinstance(marker, Exclusive):
+        groups.add_exclusive(marker, name)
+    # A ``Required`` marker carrying a default does not demand presence (the
+    # default fills the key in), so it stays out of ``required``; the ``default``
+    # keyword already conveys it.
+    elif _is_required(marker, required_default=required_default):
+        required.append(name)
 
 
 def _is_required(marker: Marker | None, *, required_default: bool) -> bool:
@@ -299,13 +427,13 @@ def _decorate_property(
     """Attach a description, default, and secret flag to a rendered value schema."""
     if description is not None:
         prop = {**prop, "description": description}
-    if isinstance(marker, Optional | Required) and not isinstance(
-        marker.default,
-        Undefined,
-    ):
+    # ``Optional``, ``Required``, ``Alias``, ``Inclusive``, and ``Exclusive`` all
+    # carry a ``default``; the others do not.
+    factory = getattr(marker, "default", None)
+    if factory is not None and not isinstance(factory, Undefined):
         # ``default`` is annotation-only, so a non-JSON default (a ``datetime``,
         # say) is omitted rather than emitted raw and crashing ``json.dumps``.
-        default = _json_safe(marker.default())
+        default = _json_safe(factory())
         if default is not _UNREPRESENTABLE:
             prop = {**prop, "default": default}
     if secret:

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -794,3 +794,13 @@ def test_single_member_groups_add_no_vacuous_constraint() -> None:
 
     assert "allOf" not in to_json_schema(Schema({Inclusive("a", "g"): int}))
     assert "allOf" not in to_json_schema(Schema({Exclusive("a", "g"): int}))
+
+
+def test_required_alias_with_default_adds_no_constraint() -> None:
+    """A required Alias with a default fills the empty case, so it demands no name."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    schema = Schema({Alias("name", "userName", required=True, default=5): int})
+    result = to_json_schema(schema)
+    assert "allOf" not in result
+    assert result["properties"]["name"]["default"] == 5

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -717,3 +717,80 @@ def test_const_with_a_non_string_dict_key_widens_to_open() -> None:
 def test_const_with_an_unrepresentable_dict_value_widens_to_open() -> None:
     """A dict const holding an unrepresentable value opens rather than crashing."""
     assert to_json_schema(Schema(Equal({"a": b"raw"}))) == {}
+
+
+def test_alias_emits_every_accepted_name() -> None:
+    """An aliased key renders each of its accepted names as a property."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_json_schema(Schema({Alias("name", "userName"): str}))
+    assert result["properties"] == {
+        "name": {"type": "string"},
+        "userName": {"type": "string"},
+    }
+    assert "allOf" not in result
+
+
+def test_required_alias_demands_one_name() -> None:
+    """A required Alias adds an anyOf requiring at least one of its names."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_json_schema(Schema({Alias("name", "userName", required=True): str}))
+    assert result["allOf"] == [
+        {"anyOf": [{"required": ["name"]}, {"required": ["userName"]}]},
+    ]
+
+
+def test_inclusive_group_is_all_or_none() -> None:
+    """An Inclusive group renders dependentRequired, so members come all or none."""
+    from probatio.markers import Inclusive  # noqa: PLC0415
+
+    schema = Schema({Inclusive("a", "g"): int, Inclusive("b", "g"): int})
+    assert to_json_schema(schema)["allOf"] == [
+        {"dependentRequired": {"a": ["b"], "b": ["a"]}},
+    ]
+
+
+def test_exclusive_group_is_at_most_one() -> None:
+    """An Exclusive group forbids more than one member being present."""
+    from probatio.markers import Exclusive  # noqa: PLC0415
+
+    schema = Schema({Exclusive("a", "g"): int, Exclusive("b", "g"): int})
+    assert to_json_schema(schema)["allOf"] == [
+        {"not": {"anyOf": [{"required": ["a", "b"]}]}},
+    ]
+
+
+def test_required_exclusive_group_is_exactly_one() -> None:
+    """A required Exclusive group (no default) demands exactly one member."""
+    from probatio.markers import Exclusive  # noqa: PLC0415
+
+    schema = Schema(
+        {Exclusive("a", "g", required=True): int, Exclusive("b", "g"): int},
+    )
+    assert to_json_schema(schema)["allOf"] == [
+        {"oneOf": [{"required": ["a"]}, {"required": ["b"]}]},
+    ]
+
+
+def test_required_exclusive_group_with_default_stays_at_most_one() -> None:
+    """A default fills the empty group, so a required-with-default group is at-most-one."""
+    from probatio.markers import Exclusive  # noqa: PLC0415
+
+    schema = Schema(
+        {
+            Exclusive("a", "g", required=True, default=1): int,
+            Exclusive("b", "g"): int,
+        },
+    )
+    result = to_json_schema(schema)
+    assert result["properties"]["a"]["default"] == 1
+    assert result["allOf"] == [{"not": {"anyOf": [{"required": ["a", "b"]}]}}]
+
+
+def test_single_member_groups_add_no_vacuous_constraint() -> None:
+    """A one-member Inclusive or at-most-one Exclusive group needs no constraint."""
+    from probatio.markers import Exclusive, Inclusive  # noqa: PLC0415
+
+    assert "allOf" not in to_json_schema(Schema({Inclusive("a", "g"): int}))
+    assert "allOf" not in to_json_schema(Schema({Exclusive("a", "g"): int}))


### PR DESCRIPTION
## What this changes

Follow-up to the encoder marker fidelity slice: `to_json_schema` now emits the group markers (`Alias`, `Inclusive`, `Exclusive`) instead of dropping their semantics. Each renders as object-level constraints combined under `allOf`. Verified against the reference `jsonschema` validator with zero mismatches across every case below.

- **`Alias`** emits each accepted name (canonical plus aliases) as a property. Before, only the canonical name was emitted, so an input using an alias was rejected as an extra key (a narrowing bug). A required `Alias` adds `anyOf` over per-name `required`, so at least one of its names must be present.
- **`Inclusive`** group emits `dependentRequired`: all-or-none, any member present pulls in every other.
- **`Exclusive`** group emits at-most-one as `not` over every pair being present together. A required group with no default emits exactly-one (`oneOf`). A required group *with* a default stays at-most-one, because the default fills the empty group (so the empty object is valid), and the default renders on its property. This matches probatio's runtime, where a group default wins over group-required.
- A single-member group adds no vacuous constraint.

The `default` decoration is generalized so `Alias`, `Inclusive`, and `Exclusive` (all of which carry a default) emit it, still made JSON-safe and omitted when unrepresentable.

## Round-trip note

The emitted `dependentRequired` (for `Inclusive`) is refused by probatio's own decoder, which fails closed on that keyword, so an `Inclusive` schema does not round-trip through `from_json_schema`. That is acceptable: it did not round-trip before either (it decoded to looser plain optionals), and `dependentRequired` is the idiomatic JSON Schema for the external consumers the encoder serves.

## Tests

Seven new tests pin each marker's emission, including the exactly-one versus at-most-one distinction and the required-with-default nuance, plus the no-vacuous-constraint case for single-member groups.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
