### PR TITLE
Decode type: null to a None-literal check instead of widening to any value

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -980,8 +980,11 @@ _FROM_FORMATS: dict[str, Any] = {
     "uuid": UUID(),
     "hostname": Hostname(),
 }
-# JSON Schema scalar types that map to a fixed probatio fragment.
-_SIMPLE_TYPES: dict[str, Any] = {"boolean": bool, "null": None}
+# JSON Schema scalar types that map to a fixed probatio fragment. ``null`` maps
+# to ``Literal(None)``, not the bare ``None`` schema: ``None`` is also the "no
+# facet" sentinel the facet collector drops, so a bare ``{"type": "null"}`` would
+# otherwise lose its constraint and widen to accept anything.
+_SIMPLE_TYPES: dict[str, Any] = {"boolean": bool, "null": Literal(None)}
 
 
 class _JsonNumberType:

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1264,3 +1264,12 @@ def test_const_rejects_a_hostile_container_value() -> None:
     schema = from_json_schema({"const": [1, 2]})
     with pytest.raises(MultipleInvalid):
         schema(HostileList([1, 2]))
+
+
+def test_type_null_accepts_only_none() -> None:
+    """A bare type: null validates only None, not any value (issue: it widened)."""
+    schema = from_json_schema({"type": "null"})
+    assert schema(None) is None
+    for bad in ([], 0, "x", False):
+        with pytest.raises(MultipleInvalid):
+            schema(bad)


### PR DESCRIPTION
## What this changes

A bare `{"type": "null"}` decoded to a schema that accepts *any* value instead of only `null`. The null type mapped to Python `None`, which the facet collector also uses as its "no facet" sentinel, so the constraint was dropped and the node widened to accept-anything.

Mapping `null` to `Literal(None)` (a validator that matches only `None` and is not the sentinel) fixes it. The type-array form (`["string", "null"]`) took a different path and already worked; it still does.

I found this via the round-trip fuzz while working on the encoder-coverage slice: `Equal(None)` encodes to `{"const": null}`, which decodes to a None matcher, which re-encodes to `{"type": "null"}`, which decoded back to accept-anything, breaking the behavioral fixpoint. The existing `test_primitive_types` only checked that `null` accepts `None`, never that it rejects other values, so the widening slipped through.

## Tests

New test asserts `type: null` accepts `None` and rejects `[]`, `0`, `"x"`, and `False`.

`just check` passes: full suite (including the round-trip fuzz, now stable on this case), 100% coverage, types, spelling, docs example blocks.
