### PR TITLE
Widen to_json_schema coverage: Union, SomeOf, Msg, Enum, Duration, and more

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -45,6 +45,7 @@ from probatio.validators import (
     AsDate,
     AsDatetime,
     AsTime,
+    AsTimedelta,
     Base64,
     Boolean,
     Capitalize,
@@ -52,6 +53,8 @@ from probatio.validators import (
     Contains,
     Date,
     Datetime,
+    DefaultTo,
+    Duration,
     Email,
     Equal,
     ExactSequence,
@@ -67,7 +70,9 @@ from probatio.validators import (
     Lower,
     Match,
     Maybe,
+    Msg,
     MultipleOf,
+    NonEmpty,
     NotIn,
     Percentage,
     Port,
@@ -76,6 +81,7 @@ from probatio.validators import (
     Strip,
     Time,
     Title,
+    Union,
     Unique,
     Upper,
     Url,
@@ -531,6 +537,11 @@ def _convert_type(node: type) -> dict[str, Any]:
     if node is list:
         return {"type": "array"}
 
+    if isinstance(node, type) and issubclass(node, Enum):
+        # An Enum class accepts its member values on the wire (``Color`` accepts
+        # ``"red"``), so it renders as an enum of those values.
+        return _enum([member.value for member in node])
+
     return {}
 
 
@@ -539,13 +550,42 @@ def _convert_validator(node: Any) -> dict[str, Any] | None:
     if isinstance(node, Coerce):
         return _convert_type(node.type) if isinstance(node.type, type) else {}
 
-    if isinstance(node, AnyValidator):
+    if isinstance(node, Msg):
+        # ``Msg`` only swaps the error message; the shape is the wrapped validator.
+        return _child(node.validator)
+
+    # ``Union``/``Switch`` accept any branch (the discriminant is an
+    # optimization), so they render as ``anyOf`` like ``Any``. Checked with
+    # ``Any`` since both wrap ``.validators``.
+    if isinstance(node, AnyValidator | Union):
         return {"anyOf": [_child(validator) for validator in node.validators]}
+
+    if isinstance(node, SomeOf):
+        return _convert_some_of(node)
 
     if isinstance(node, All):
         return _convert_all(node)
 
     return _convert_constraint(node)
+
+
+def _convert_some_of(node: SomeOf) -> dict[str, Any]:
+    """Render a SomeOf for the counts JSON Schema can express, else an open schema.
+
+    Exactly one branch (``min == max == 1``) is ``oneOf``; at least one
+    (``min == 1``, ``max`` the branch count) is ``anyOf``; every branch
+    (``min == max == count``) is ``allOf``. Any other count has no clean JSON
+    Schema form, so it widens to an open schema.
+    """
+    branches = [_child(validator) for validator in node.validators]
+    count = len(branches)
+    if node.min_valid == node.max_valid == 1:
+        return {"oneOf": branches}
+    if node.min_valid == 1 and node.max_valid == count:
+        return {"anyOf": branches}
+    if node.min_valid == node.max_valid == count:
+        return {"allOf": branches}
+    return {}
 
 
 def _convert_all(node: All) -> dict[str, Any]:
@@ -703,12 +743,9 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     if isinstance(node, FromEpoch):
         return {"type": "number"}
 
-    if isinstance(node, Unique):
-        return {"uniqueItems": True}
-
-    # The decoder's JSON-value uniqueness check re-emits its keyword, so a
-    # decoded schema round-trips.
-    if isinstance(node, _JsonUnique):
+    # ``Unique`` and the decoder's JSON-value uniqueness check (which re-emits its
+    # keyword so a decoded schema round-trips) both render as ``uniqueItems``.
+    if isinstance(node, Unique | _JsonUnique):
         return {"uniqueItems": True}
 
     if isinstance(node, Contains):
@@ -717,11 +754,36 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     if isinstance(node, ExactSequence):
         return _convert_exact_sequence(node)
 
+    misc = _convert_misc(node)
+    if misc is not None:
+        return misc
+
     typed = _convert_typed(node)
     if typed is not None:
         return typed
 
     return _convert_named(node)
+
+
+def _convert_misc(node: Any) -> dict[str, Any] | None:
+    """Render the small single-keyword validators (duration, non-empty, default)."""
+    if isinstance(node, Duration | AsTimedelta):
+        # ``duration`` is the standard JSON Schema format for an ISO 8601 duration
+        # (draft 2019-09 onward), the string these validators accept.
+        return {"type": "string", "format": "duration"}
+
+    if isinstance(node, NonEmpty):
+        # ``NonEmpty`` requires a non-empty value; ``minLength`` carries that for a
+        # string (the common case), and is ignored for a non-string per the spec.
+        return {"minLength": 1}
+
+    if isinstance(node, DefaultTo):
+        # ``DefaultTo`` accepts any value and substitutes its default for a missing
+        # one, so the only JSON Schema it carries is the ``default`` annotation.
+        default = _json_safe(node.default)
+        return {} if default is _UNREPRESENTABLE else {"default": default}
+
+    return None
 
 
 def _convert_typed(node: Any) -> dict[str, Any] | None:

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -804,3 +804,105 @@ def test_required_alias_with_default_adds_no_constraint() -> None:
     result = to_json_schema(schema)
     assert "allOf" not in result
     assert result["properties"]["name"]["default"] == 5
+
+
+def test_union_becomes_any_of() -> None:
+    """Union accepts any branch, so it exports anyOf like Any."""
+    from probatio.validators import Union  # noqa: PLC0415
+
+    assert to_json_schema(Schema(Union(int, str))) == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+    }
+
+
+def test_switch_becomes_any_of() -> None:
+    """Switch is an alias of Union, so it exports anyOf too."""
+    from probatio.validators import Switch  # noqa: PLC0415
+
+    assert to_json_schema(Schema(Switch(int, str))) == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+    }
+
+
+def test_some_of_exactly_one_becomes_one_of() -> None:
+    """SomeOf(min=max=1) is exactly-one, which exports as oneOf."""
+    from probatio.validators import SomeOf  # noqa: PLC0415
+
+    schema = SomeOf([int, str], min_valid=1, max_valid=1)
+    assert to_json_schema(Schema(schema)) == {
+        "oneOf": [{"type": "integer"}, {"type": "string"}],
+    }
+
+
+def test_some_of_at_least_one_becomes_any_of() -> None:
+    """SomeOf(min=1, max=count) is at-least-one, which exports as anyOf."""
+    from probatio.validators import SomeOf  # noqa: PLC0415
+
+    schema = SomeOf([int, str], min_valid=1, max_valid=2)
+    assert to_json_schema(Schema(schema)) == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+    }
+
+
+def test_some_of_all_becomes_all_of() -> None:
+    """SomeOf(min=max=count) requires every branch, which exports as allOf."""
+    from probatio.validators import SomeOf  # noqa: PLC0415
+
+    schema = SomeOf([int, Range(min=0)], min_valid=2, max_valid=2)
+    assert to_json_schema(Schema(schema)) == {
+        "allOf": [{"type": "integer"}, {"minimum": 0}],
+    }
+
+
+def test_some_of_uncommon_count_widens_to_open() -> None:
+    """A SomeOf count JSON Schema cannot express widens to an open schema."""
+    from probatio.validators import SomeOf  # noqa: PLC0415
+
+    schema = SomeOf([int, str, float], min_valid=2, max_valid=2)
+    assert to_json_schema(Schema(schema)) == {}
+
+
+def test_msg_unwraps_to_its_validator() -> None:
+    """Msg only swaps the error message, so it exports the wrapped validator's shape."""
+    from probatio.validators import Msg  # noqa: PLC0415
+
+    assert to_json_schema(Schema(Msg(int, "nope"))) == {"type": "integer"}
+
+
+def test_enum_class_becomes_enum_of_values() -> None:
+    """An Enum class exports an enum of its member values (the wire form)."""
+    from enum import Enum  # noqa: PLC0415
+
+    class Color(Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    assert to_json_schema(Schema(Color)) == {"enum": ["red", "blue"]}
+
+
+def test_duration_exports_format_duration() -> None:
+    """Duration and AsTimedelta export the standard format: duration."""
+    from probatio.validators import AsTimedelta, Duration  # noqa: PLC0415
+
+    assert to_json_schema(Schema(Duration())) == {
+        "type": "string",
+        "format": "duration",
+    }
+    assert to_json_schema(Schema(AsTimedelta())) == {
+        "type": "string",
+        "format": "duration",
+    }
+
+
+def test_non_empty_exports_min_length() -> None:
+    """NonEmpty requires a non-empty value, exported as minLength for strings."""
+    from probatio.validators import NonEmpty  # noqa: PLC0415
+
+    assert to_json_schema(Schema(NonEmpty())) == {"minLength": 1}
+
+
+def test_default_to_exports_a_default() -> None:
+    """DefaultTo carries only its default value into the schema."""
+    from probatio.validators import DefaultTo  # noqa: PLC0415
+
+    assert to_json_schema(Schema(DefaultTo(5))) == {"default": 5}


### PR DESCRIPTION
## What this changes

Widens `to_json_schema` coverage: several constructs that were silently exported as an open `{}` (dropping their whole meaning) now map to real JSON Schema. Every addition is verified against the reference `jsonschema` validator and introduces no narrowing (nothing rejects input probatio accepts).

- **`Union`/`Switch` → `anyOf`.** They accept any branch (the discriminant is an optimization), so they export like `Any`. The whole subtree was dropped before.
- **`SomeOf` → `oneOf`/`anyOf`/`allOf`** for the counts JSON Schema can express: exactly-one (`min == max == 1`), at-least-one (`min == 1`, `max` the branch count), and all (`min == max == count`). Any other count has no clean form and widens to `{}`. This also makes the encoder symmetric with the decoder, which already reads `oneOf` back as `SomeOf(1, 1)`.
- **`Msg` → the wrapped validator's shape.** It only swaps the error message; the whole subtree was dropped before.
- **An Enum class → an `enum` of member values** (`Schema(Color)` accepts `"red"` on the wire).
- **`Duration`/`AsTimedelta` → `format: duration`** (the standard ISO 8601 duration format, draft 2019-09 onward).
- **`NonEmpty` → `minLength: 1`**, and **`DefaultTo` → its `default` annotation** (made JSON-safe, omitted when unrepresentable).

## Deliberately skipped (they would narrow)

Verified against the runtime: `Number` accepts numeric strings (`"5"`), `Clamp` accepts out-of-range values and clamps them, and probatio's engine treats `list[int]`/`dict[str, int]` as bare `list`/`dict` (it accepts `[1, "x"]`). Mapping any of these to a stricter schema would reject input probatio accepts, so they stay open.

## Scope

This is the coverage half of the slice. The loss-signal channel (a `strict=`/warnings mechanism so a silent `{}` widening becomes detectable), a `custom_serializer` escape hatch, and `$schema` emission are a separate API-level change I will do as a follow-up.

## Tests

Twelve new tests pin each mapping, including the three `SomeOf` count shapes and the uncommon-count-widens-to-open case.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
