### PR TITLE
Round-trip the decoder's not and counted-contains through to_json_schema

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -765,8 +765,34 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     return _convert_named(node)
 
 
+def _convert_contains_count(node: _ContainsCount) -> dict[str, Any]:
+    """Render a decoded counted-contains back to ``contains`` with its count bounds.
+
+    ``minContains`` is emitted only when it differs from the spec default of 1,
+    and ``maxContains`` only when a bound was set, so a plain ``contains`` round
+    trips as a plain ``contains``.
+    """
+    result: dict[str, Any] = {"contains": _child(node.item)}
+    if node.minimum != 1:
+        result["minContains"] = node.minimum
+    if node.maximum is not None:
+        result["maxContains"] = node.maximum
+    return result
+
+
 def _convert_misc(node: Any) -> dict[str, Any] | None:
-    """Render the small single-keyword validators (duration, non-empty, default)."""
+    """Render the small single-keyword validators, or None if not one.
+
+    Includes the decoder's ``not`` and counted-``contains`` wrappers, which
+    re-emit their keyword so a schema decoded from ``{"not": ...}`` or
+    ``{"contains": ...}`` round-trips instead of collapsing to an open schema.
+    """
+    if isinstance(node, _Not):
+        return {"not": _child(node.subschema)}
+
+    if isinstance(node, _ContainsCount):
+        return _convert_contains_count(node)
+
     if isinstance(node, Duration | AsTimedelta):
         # ``duration`` is the standard JSON Schema format for an ISO 8601 duration
         # (draft 2019-09 onward), the string these validators accept.
@@ -1415,6 +1441,8 @@ class _Not:
 
     def __init__(self, subschema: Any) -> None:
         """Compile the subschema the value must NOT match."""
+        # Kept raw (unwrapped) so the encoder can re-emit ``{"not": ...}``.
+        self.subschema = subschema
         self._schema = Schema(subschema)
 
     def __repr__(self) -> str:
@@ -1965,13 +1993,15 @@ class _ContainsCount:
 
     def __init__(self, item_schema: Any, minimum: int, maximum: int | None) -> None:
         """Compile the item schema and store the count bounds."""
+        # ``item`` kept raw so the encoder can re-emit ``{"contains": ...}``.
+        self.item = item_schema
         self._schema = Schema(item_schema)
-        self._min = minimum
-        self._max = maximum
+        self.minimum = minimum
+        self.maximum = maximum
 
     def __repr__(self) -> str:
         """Render readably for error paths."""
-        return f"ContainsCount(min={self._min}, max={self._max})"
+        return f"ContainsCount(min={self.minimum}, max={self.maximum})"
 
     def __call__(self, value: Any) -> Any:
         """Return the value if the matching-item count is in range, else raise."""
@@ -1988,15 +2018,15 @@ class _ContainsCount:
                 continue
             count += 1
 
-        if count < self._min:
+        if count < self.minimum:
             raise ContainsInvalid(
                 translation_key="min_contains",
-                placeholders={"min": self._min},
+                placeholders={"min": self.minimum},
             )
-        if self._max is not None and count > self._max:
+        if self.maximum is not None and count > self.maximum:
             raise ContainsInvalid(
                 translation_key="max_contains",
-                placeholders={"max": self._max},
+                placeholders={"max": self.maximum},
             )
 
         return value

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1273,3 +1273,40 @@ def test_type_null_accepts_only_none() -> None:
     for bad in ([], 0, "x", False):
         with pytest.raises(MultipleInvalid):
             schema(bad)
+
+
+def test_not_round_trips_through_the_encoder() -> None:
+    """A decoded 'not' re-encodes to 'not' instead of collapsing to an open schema."""
+    once = from_json_schema({"not": {"enum": [0]}})
+    assert to_json_schema(once) == {"not": {"enum": [0]}}
+    twice = from_json_schema(to_json_schema(once))
+    assert twice(5) == 5
+    with pytest.raises(MultipleInvalid):
+        twice(0)
+
+
+def test_counted_contains_round_trips_through_the_encoder() -> None:
+    """A decoded counted contains re-encodes with its count bounds."""
+    once = from_json_schema(
+        {"type": "array", "contains": {"const": 9}, "minContains": 2},
+    )
+    encoded = to_json_schema(once)
+    assert encoded["contains"] == {"const": 9}
+    assert encoded["minContains"] == 2
+    assert "maxContains" not in encoded
+
+
+def test_plain_contains_round_trips_without_count_keywords() -> None:
+    """A plain contains re-encodes without min/maxContains (the spec default)."""
+    once = from_json_schema({"type": "array", "contains": {"const": 9}})
+    encoded = to_json_schema(once)
+    assert "minContains" not in encoded
+    assert "maxContains" not in encoded
+
+
+def test_counted_contains_round_trips_max_bound() -> None:
+    """A decoded maxContains bound re-encodes too."""
+    once = from_json_schema(
+        {"type": "array", "contains": {"const": 9}, "maxContains": 3},
+    )
+    assert to_json_schema(once)["maxContains"] == 3


### PR DESCRIPTION
## What this changes

The encoder round-trips the decoder's internal validators (`_JsonEnum`, `_JsonConst`, the JSON-strict number and unique checks) so a decoded schema re-encodes faithfully, but it missed two of them: the `not` wrapper and the counted-`contains` wrapper. A schema decoded from `{"not": ...}` or `{"contains": ...}` re-encoded to an open `{}`, silently losing the constraint.

- A decoded `not` now re-emits `{"not": ...}`.
- A decoded counted `contains` re-emits `{"contains": ...}`, with `minContains` only when it differs from the spec default of 1 and `maxContains` only when a bound was set, so a plain `contains` round-trips as a plain `contains`.

I found this via the round-trip fuzz while building the encoder differential oracle: `NotIn([0])` encodes to `{"not": {"enum": [0]}}`, which decodes to the `not` wrapper, which re-encoded to `{}` (accept-anything), breaking the behavioral fixpoint. It reproduces on main.

The two wrappers gain a raw-subschema accessor for the encoder to read; `_ContainsCount`'s count bounds are renamed from private to public for the same reason.

## Tests

Four tests pin the round trips: `not`, counted `contains` (min and max bounds), and plain `contains` (no count keywords emitted).

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
