### PR TITLE
Correct the codec docs for the decoder type model, encoder coverage, and strict mode

### DIFF
--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -59,11 +59,40 @@ rebuilt({"name": "Ada", "age": 37})  # {'name': 'Ada', 'age': 37}
 
 :::note
 The mapping is not lossless. `to_json_schema` renders what JSON Schema can
-express and turns anything it does not recognize into an open schema (`{}`).
-`from_json_schema` ignores purely descriptive keywords but refuses a restrictive
-keyword it cannot honor (see below). Treat a round trip as "the validatable
-shape survives", not "byte for byte identical".
+express and turns a construct it cannot into an open schema (`{}`). Pass
+`strict=True` to make that a `SchemaError` instead, so a lossy conversion is
+caught rather than accepted silently. `from_json_schema` ignores purely
+descriptive keywords but refuses a restrictive keyword it cannot honor (see
+below). Treat a round trip as "the validatable shape survives", not "byte for
+byte identical".
 :::
+
+## Widening the encoder, and overriding it
+
+By default `to_json_schema` never rejects an input the schema accepts: where it
+cannot express a construct exactly it widens (an open `{}`, or a looser keyword),
+so the emitted schema stays a superset of what Probatio validates. Two options
+tune that:
+
+- `strict=True` raises `SchemaError` for a construct with no JSON Schema form (an
+  unknown validator, a `Coerce` with a non-type target, an `enum` member with no
+  JSON representation), instead of widening to `{}`.
+- `custom_serializer` is called first for each node and may return a dict to
+  override the rendering, or the `UNSUPPORTED` sentinel to defer to the default,
+  the same hook [`to_openapi`](/guides/openapi/) takes.
+
+```python
+from probatio import Schema, to_json_schema
+from probatio.codecs import UNSUPPORTED
+
+def as_password(node):
+    if node is str.strip:
+        return {"type": "string", "writeOnly": True}
+    return UNSUPPORTED
+
+to_json_schema(Schema({"token": str.strip}), custom_serializer=as_password)
+# {'type': 'object', 'properties': {'token': {'type': 'string', 'writeOnly': True}}, 'additionalProperties': False}
+```
 
 ## Supported keywords
 
@@ -108,8 +137,26 @@ round-trip:
 | `MultipleOf`                  | `multipleOf`                                                                                                                      |
 | `Secret` key                  | its property with `writeOnly: true`                                                                                               |
 | `Base64`                      | `contentEncoding: base64`                                                                                                         |
+| `Duration` / `AsTimedelta`    | `format: duration`                                                                                                                |
 
-The one known widener: JSON Schema has a single `hostname` format, so both
+Combinators and a few more constructs also render, though most have no inverse
+so they do not round-trip:
+
+| Probatio construct   | JSON Schema output                                                        |
+| -------------------- | ------------------------------------------------------------------------- |
+| `Any` / `Or`         | `anyOf`                                                                   |
+| `Union` / `Switch`   | `anyOf` (the discriminant is an optimization, so any branch is allowed)   |
+| `All` / `And`        | one merged object, or `allOf` when two validators emit the same keyword   |
+| `Maybe`              | `anyOf` with `{"type": "null"}`                                           |
+| `SomeOf`             | `oneOf` (exactly one), `anyOf` (at least one), or `allOf` (all)           |
+| `Msg`                | the wrapped validator's shape (the message has no JSON Schema equivalent) |
+| An `enum.Enum` class | `enum` of the member values                                               |
+| `Self`               | `{"$ref": "#"}` (a recursive reference to the document root)              |
+| `Alias`              | one property per accepted name (plus `anyOf` of `required` when required) |
+| `Inclusive` group    | `dependentRequired` (all-or-none)                                         |
+| `Exclusive` group    | at-most-one (`not` over the pairs), or `oneOf` when the group is required |
+
+The known widener: JSON Schema has a single `hostname` format, so both
 `Hostname` and `Fqdn` export to it and decode back as `Hostname`, meaning a
 round-tripped `Fqdn` accepts a dotless host the original would reject. Pin it
 with a `pattern` or an explicit check if the distinction matters.
@@ -120,11 +167,13 @@ so one matching two or more is rejected), unlike the looser `anyOf`.
 `from_openapi` adds the OpenAPI `nullable` keyword, covered in
 [OpenAPI](/guides/openapi/).
 
-:::note[Integers and booleans]
-A decoded `{"type": "integer"}` validates with Python's `int`, and in Python
-`bool` is a subclass of `int`. So a decoded integer schema accepts `True` as an
-integer, where a strict JSON Schema validator would not. If that distinction
-matters for your data, add an explicit check.
+:::note[The JSON data model]
+The decoder follows JSON's types, not Python's. A decoded `{"type": "integer"}`
+rejects `True` (a boolean is not a JSON number) and accepts `1.0` (a number with
+no fractional part), and a decoded `enum` or `const` keeps booleans distinct from
+`1` and `0`. On the encode side, `Datetime`, `Date`, and `Time` render ISO
+strings, and a decoded `format: date-time` accepts RFC 3339 timestamps (a `Z` or
+a numeric offset, with or without fractional seconds).
 :::
 
 ## Untrusted input is the default assumption

--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -4,10 +4,13 @@ description: Render a Probatio schema as an OpenAPI Schema object, build one bac
 ---
 
 OpenAPI Schema objects are JSON Schema with a few of their own rules. `to_openapi`
-and `from_openapi` are the OpenAPI pair, exported from the top level. They share
-the JSON Schema codec, so most of the behavior, the supported keywords, the
-round-trip caveats, and the untrusted-input guards, is the same. Read [JSON
-Schema](/guides/json-schema/) first; this page covers what OpenAPI adds.
+and `from_openapi` are the OpenAPI pair, exported from the top level. `from_openapi`
+is the JSON Schema decoder plus the OpenAPI extras, so its supported keywords,
+round-trip caveats, and untrusted-input guards match [JSON
+Schema](/guides/json-schema/); read that page first. The `to_openapi` encoder is a
+separate implementation (it targets OpenAPI 3.0 or 3.1 and takes a
+`custom_serializer`), so its construct coverage differs from `to_json_schema` in
+places. This page covers what OpenAPI adds.
 
 ## Both directions
 


### PR DESCRIPTION
## What this changes

Final slice of the JSON Schema review: brings the codec docs in line with what the preceding PRs shipped. The behavior changed substantially, and several claims on these pages were stale or wrong.

- **Removed the now-wrong "Integers and booleans" note.** It said a decoded `{"type": "integer"}` accepts `True` because Python's `bool` subclasses `int`. That is no longer true (the decoder follows the JSON data model now), so it is replaced with an accurate note: `integer` rejects `True` and accepts `1.0`, `enum`/`const` keep booleans distinct from `1`/`0`, and `format: date-time` decodes RFC 3339.
- **Documented `strict=True` and `custom_serializer`.** A new "Widening the encoder, and overriding it" section explains that `to_json_schema` widens rather than narrows by default, that `strict=True` turns an unrepresentable construct into a `SchemaError`, and that `custom_serializer` overrides a node's rendering (with a runnable example).
- **Expanded the construct table** with everything the encoder emits now: `Union`/`Switch`, `SomeOf`, `Msg`, `Enum` classes, `Self` → `$ref`, `Duration`/`AsTimedelta` → `format: duration`, and the `Alias`/`Inclusive`/`Exclusive` group markers.
- **Scoped the OpenAPI "share the codec" claim.** `from_openapi` is the shared decoder; `to_openapi` is a separate encoder from `to_json_schema` with different construct coverage.

The LLM-tools recipe needed no change: its non-serializable-output concern was fixed by the encoder validator PR (all `to_json_schema` output is now `json.dumps`-able, which the differential oracle enforces).

`just check` passes: full suite, docs build, and all 256 documentation example blocks run.
