### PR TITLE
Harden to_openapi: JSON-safe values, bytes Match, cyclic guard, list and Self fixes

### DIFF
--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
 from probatio.validators import (
     ASCII,
     E164,
@@ -46,6 +51,56 @@ class _Unsupported:
 # Returned from a ``custom_serializer`` to mean "I do not handle this node, fall
 # back to the default". Shared by ``serialize`` and ``to_openapi``.
 UNSUPPORTED = _Unsupported()
+
+
+# Returned from ``json_safe`` for a value with no JSON representation, so the
+# caller can omit the offending keyword rather than emit an unserializable dict.
+UNREPRESENTABLE = object()
+
+
+def ordered_values(values: Any) -> list[Any]:
+    """List a container's values, sorting a set so the emitted schema is stable.
+
+    A list or tuple keeps the author's order. A set or frozenset has none, so its
+    values are sorted by ``repr`` to keep codec output deterministic across runs
+    (stable snapshots, no spurious schema diffs, no cache misses).
+    """
+    if isinstance(values, set | frozenset):
+        return sorted(values, key=repr)
+    return list(values)
+
+
+def json_safe(value: Any) -> Any:  # noqa: PLR0911
+    """Convert a value to a JSON-representable form, or ``UNREPRESENTABLE``.
+
+    Both codecs must emit a document ``json.dumps`` accepts (an emitted ``const``,
+    ``enum``, ``default``, or numeric bound holding a raw ``datetime``, ``Decimal``,
+    ``Enum`` member, or ``bytes`` would otherwise crash the caller). Datetimes
+    render ISO, a ``Decimal`` renders a float, an ``Enum`` member renders its
+    value, and a tuple or set renders a list (JSON has no tuple, and a value on
+    the wire arrives as a list anyway). Anything with no clean JSON form is
+    reported unrepresentable so the caller can omit it.
+    """
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, Enum):
+        return json_safe(value.value)
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
+        return value.isoformat()
+    if isinstance(value, list | tuple | set | frozenset):
+        converted = [json_safe(item) for item in ordered_values(value)]
+        return UNREPRESENTABLE if UNREPRESENTABLE in converted else converted
+    if isinstance(value, dict):
+        items = {key: json_safe(item) for key, item in value.items()}
+        if any(not isinstance(key, str) for key in items) or (
+            UNREPRESENTABLE in items.values()
+        ):
+            return UNREPRESENTABLE
+        return items
+    return UNREPRESENTABLE
+
 
 # How a network/identifier validator renders as a string, shared by the JSON
 # Schema and OpenAPI codecs so the two cannot drift. ``FORMAT_BY_TYPE`` carries a

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -18,12 +18,18 @@ import contextvars
 import datetime
 import re
 from dataclasses import dataclass, field
-from decimal import Decimal
 from enum import Enum
 from typing import Any, cast
 
 from probatio.codecs._regex_safety import is_catastrophic
-from probatio.codecs._shared import FORMAT_BY_TYPE, STRING_TYPES, UNSUPPORTED
+from probatio.codecs._shared import (
+    FORMAT_BY_TYPE,
+    STRING_TYPES,
+    UNSUPPORTED,
+)
+from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
+from probatio.codecs._shared import json_safe as _json_safe
+from probatio.codecs._shared import ordered_values as _ordered
 from probatio.error import ContainsInvalid, Invalid, SchemaError
 from probatio.markers import (
     Alias,
@@ -516,18 +522,6 @@ def _decorate_property(
     return prop
 
 
-def _ordered(values: Any) -> list[Any]:
-    """List a container's values, sorting a set so the emitted schema is stable.
-
-    A list or tuple keeps the author's order. A set or frozenset has none, so its
-    values are sorted by ``repr`` to keep ``to_json_schema`` output deterministic
-    across runs (stable snapshots, no spurious schema diffs, no cache misses).
-    """
-    if isinstance(values, set | frozenset):
-        return sorted(values, key=repr)
-    return list(values)
-
-
 def _convert_sequence(
     node: Any,
     *,
@@ -703,42 +697,6 @@ def _retarget_length(merged: dict[str, Any]) -> dict[str, Any]:
         merged[max_key] = merged.pop("maxLength")
 
     return merged
-
-
-_UNREPRESENTABLE = object()
-
-
-def _json_safe(value: Any) -> Any:
-    """Convert a value to a JSON-representable form, or ``_UNREPRESENTABLE``.
-
-    ``to_json_schema`` must emit a document ``json.dumps`` accepts (an emitted
-    ``const``, ``enum``, ``default``, or numeric bound holding a raw ``datetime``,
-    ``Decimal``, ``Enum`` member, or ``bytes`` would otherwise crash the caller).
-    Datetimes render ISO, a ``Decimal`` renders a float, an ``Enum`` member
-    renders its value, and a tuple or set renders a list (JSON has no tuple, and
-    a value on the wire arrives as a list anyway). Anything with no clean JSON
-    form is reported unrepresentable so the caller can omit it.
-    """
-    if value is None or isinstance(value, bool | int | float | str):
-        return value
-    if isinstance(value, Enum):
-        return _json_safe(value.value)
-    if isinstance(value, Decimal):
-        return float(value)
-    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
-        return value.isoformat()
-    if isinstance(value, list | tuple | set | frozenset):
-        converted = [_json_safe(item) for item in _ordered(value)]
-        return _UNREPRESENTABLE if _UNREPRESENTABLE in converted else converted
-    if isinstance(value, dict):
-        items = {key: _json_safe(item) for key, item in value.items()}
-        if (
-            any(not isinstance(key, str) for key in items)
-            or _UNREPRESENTABLE in items.values()
-        ):
-            return _UNREPRESENTABLE
-        return items
-    return _UNREPRESENTABLE
 
 
 def _enum(container: Any) -> dict[str, Any]:

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -20,8 +20,16 @@ from inspect import isroutine, signature
 from types import UnionType
 from typing import Any, TypeVar, Union, cast, get_args, get_origin, get_type_hints
 
-from probatio.codecs._shared import FORMAT_BY_TYPE, STRING_TYPES, UNSUPPORTED
-from probatio.markers import Optional, Required, Undefined, resolve_key
+from probatio.codecs._shared import (
+    FORMAT_BY_TYPE,
+    STRING_TYPES,
+    UNSUPPORTED,
+)
+from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
+from probatio.codecs._shared import json_safe as _json_safe
+from probatio.codecs._shared import ordered_values as _ordered
+from probatio.error import SchemaError
+from probatio.markers import Optional, Required, Self, Undefined, resolve_key
 from probatio.schema import ALLOW_EXTRA, Schema
 from probatio.validators import (
     All,
@@ -96,12 +104,27 @@ def to_openapi(
     ``"3.1.0"`` (emitting ``type: null``). ``custom_serializer`` is called first
     for each node and may return a dict to override the default, or ``UNSUPPORTED``
     to defer.
+
+    A raw schema that references itself (a dict holding itself as a value) has no
+    finite rendering, so the runaway recursion is reported as a clean
+    ``SchemaError`` rather than a bare ``RecursionError``.
     """
-    return _oa(schema, custom_serializer, openapi_version)
+    try:
+        return _oa(schema, custom_serializer, openapi_version)
+    except RecursionError as exc:
+        message = (
+            "schema is too deeply nested or references itself; use the Self "
+            "marker for a recursive schema"
+        )
+        raise SchemaError(message) from exc
 
 
 def _ensure_default(value: dict[str, Any]) -> dict[str, Any]:
     """Give a value a type when it has none, the way voluptuous-openapi does."""
+    # A ``$ref`` (a recursive ``Self``) is a complete schema on its own; adding a
+    # ``type`` beside it would contradict the reference.
+    if "$ref" in value:
+        return value
     if all(key not in value for key in ("type", "anyOf", "oneOf", "allOf", "not")):
         bounds = ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum")
         value["type"] = "number" if any(key in value for key in bounds) else "string"
@@ -120,6 +143,11 @@ def _oa(node: Any, custom: Any, version: str) -> dict[str, Any]:
         result = custom(node)
         if result is not UNSUPPORTED:
             return cast("dict[str, Any]", result)
+
+    if node is Self:
+        # ``Self`` is the recursive reference to the whole enclosing schema; ``#``
+        # targets the document root, the common top-level recursive-schema case.
+        return {"$ref": "#"}
 
     if isinstance(node, dict):
         return _oa_mapping(node, custom, version, additional)
@@ -177,7 +205,12 @@ def _oa_mapping(
             marker.default,
             Undefined,
         ):
-            pval["default"] = marker.default()
+            # A non-JSON default (a ``datetime``, say) is rendered JSON-safe, or
+            # omitted when it has no representation, so the emitted document never
+            # crashes ``json.dumps``.
+            default = _json_safe(marker.default())
+            if default is not _UNREPRESENTABLE:
+                pval["default"] = default
         if facets.secret:
             pval["writeOnly"] = True
         if isinstance(marker, Required) and not isinstance(pkey, AnyValidator):
@@ -247,17 +280,19 @@ def _assemble_object(
 
 
 def _oa_sequence(node: Any, custom: Any, version: str) -> dict[str, Any]:
-    """Render a sequence schema as an OpenAPI array."""
-    items = list(node)
+    """Render a sequence schema as an OpenAPI array.
+
+    A single element schema is the item schema. Several elements ([int, str])
+    mean "each item matches any of these", so they merge into an ``anyOf`` item
+    schema, not a positional ``items`` array (which would wrongly constrain by
+    position). An empty sequence accepts only the empty array.
+    """
+    items = [_ensure_default(_oa(item, custom, version)) for item in _ordered(node)]
     if len(items) == 1:
-        return {
-            "type": "array",
-            "items": _ensure_default(_oa(items[0], custom, version)),
-        }
-    return {
-        "type": "array",
-        "items": [_ensure_default(_oa(item, custom, version)) for item in items],
-    }
+        return {"type": "array", "items": items[0]}
+    if not items:
+        return {"type": "array", "maxItems": 0}
+    return {"type": "array", "items": {"anyOf": items}}
 
 
 def _oa_leaf(node: Any, custom: Any, version: str) -> dict[str, Any]:
@@ -334,7 +369,12 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
         # fractional-second float); the datetime is internal.
         return {"type": "number"}
     if isinstance(node, Match):
-        return {"pattern": node.pattern.pattern}
+        source = node.pattern.pattern
+        # A bytes pattern has no OpenAPI form (schema strings are text), so it
+        # renders as a plain string rather than crashing on the missing ``.pattern``.
+        if isinstance(source, bytes):
+            return {"type": "string"}
+        return {"pattern": source}
     if isinstance(node, In):
         return _oa_enum(list(node.container))
     if node in _OPENAPI_FORMATS:
@@ -394,14 +434,20 @@ def _oa_all(node: All, custom: Any, version: str) -> dict[str, Any]:
 
 
 def _oa_range(node: Clamp | Range) -> dict[str, Any]:
-    """Render a Range or Clamp as OpenAPI numeric bounds (Clamp is inclusive)."""
+    """Render a Range or Clamp as OpenAPI numeric bounds (Clamp is inclusive).
+
+    A non-numeric bound (a ``datetime``, say) has no OpenAPI numeric keyword and
+    would make the output non-serializable, so such a bound is omitted.
+    """
     result: dict[str, Any] = {}
     min_exclusive = isinstance(node, Range) and not node.min_included
     max_exclusive = isinstance(node, Range) and not node.max_included
-    if node.min is not None:
-        result["exclusiveMinimum" if min_exclusive else "minimum"] = node.min
-    if node.max is not None:
-        result["exclusiveMaximum" if max_exclusive else "maximum"] = node.max
+    minimum = _json_safe(node.min)
+    maximum = _json_safe(node.max)
+    if node.min is not None and isinstance(minimum, int | float):
+        result["exclusiveMinimum" if min_exclusive else "minimum"] = minimum
+    if node.max is not None and isinstance(maximum, int | float):
+        result["exclusiveMaximum" if max_exclusive else "maximum"] = maximum
     return result
 
 
@@ -423,11 +469,18 @@ def _oa_enum(values: list[Any]) -> dict[str, Any]:
     """
     nullable = False
     cleaned = []
-    for value in values:
+    for value in _ordered(values):
         if value is None or value is _NONE_TYPE:
             nullable = True
-        else:
-            cleaned.append(value)
+            continue
+        # An enum member with no JSON form (a ``datetime``, an ``Enum``) is
+        # rendered JSON-safe, so the emitted enum never crashes ``json.dumps``. A
+        # member with no representation at all (``bytes``) drops the whole enum to
+        # an open schema rather than leak an unserializable value.
+        safe = _json_safe(value)
+        if safe is _UNREPRESENTABLE:
+            return {"nullable": True} if nullable else {}
+        cleaned.append(safe)
 
     enum_type = _OPENAPI_TYPES.get(type(cleaned[0]), "string") if cleaned else "string"
     result: dict[str, Any] = {"type": enum_type, "enum": cleaned}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -8,6 +8,7 @@ schemas unchanged.
 
 from __future__ import annotations
 
+import json
 from enum import Enum
 from typing import Any, TypeVar
 
@@ -181,15 +182,22 @@ def test_merging_hashable_enums_dedups() -> None:
 
 
 def test_multi_item_array() -> None:
-    """A fixed multi-item array lists a schema per position.
+    """A multi-element list means each item matches any of the element schemas.
 
-    voluptuous-openapi 0.3.0 crashes on this input (it calls ``.items()`` on a
-    list), so this is asserted directly rather than differentially.
+    ``Schema([int, str])`` accepts a list whose elements are each an int or a
+    string, so it renders as an ``anyOf`` item schema, not a positional ``items``
+    array (which would constrain by position and reject ``[1, 2]``).
+    voluptuous-openapi 0.3.0 crashes on this input, so it is asserted directly.
     """
     assert to_openapi(Schema([int, str])) == {
         "type": "array",
-        "items": [{"type": "integer"}, {"type": "string"}],
+        "items": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
     }
+
+
+def test_empty_array_accepts_only_empty() -> None:
+    """An empty list schema accepts only the empty array, not any array."""
+    assert to_openapi(Schema([])) == {"type": "array", "maxItems": 0}
 
 
 def test_default_version_is_3_0() -> None:
@@ -347,3 +355,79 @@ def test_new_string_validators_to_openapi() -> None:
         "type": "string",
         "contentEncoding": "base64",
     }
+
+
+def test_datetime_enum_stays_serializable() -> None:
+    """An In holding a datetime renders ISO strings, not raw datetimes."""
+    from datetime import date  # noqa: PLC0415
+
+    from probatio import In  # noqa: PLC0415
+
+    result = to_openapi(Schema(In([date(2020, 1, 1)])))
+    assert result == {"type": "string", "enum": ["2020-01-01"]}
+    json.dumps(result)
+
+
+def test_enum_members_render_their_values() -> None:
+    """An In holding Enum members renders the member values."""
+    from probatio import In  # noqa: PLC0415
+
+    assert to_openapi(Schema(In([Color.RED, Color.BLUE]))) == {
+        "type": "string",
+        "enum": ["red", "blue"],
+    }
+
+
+def test_unrepresentable_enum_member_widens_to_open() -> None:
+    """A member with no JSON form drops the enum to open, not a crash."""
+    from probatio import In  # noqa: PLC0415
+
+    assert to_openapi(Schema(In([b"raw"]))) == {}
+
+
+def test_non_json_default_is_json_safe() -> None:
+    """A datetime default renders its ISO string rather than a raw datetime."""
+    from datetime import date  # noqa: PLC0415
+
+    from probatio import Optional  # noqa: PLC0415
+
+    schema = Schema({Optional("t", default=date(2020, 1, 1)): object})
+    result = to_openapi(schema)
+    assert result["properties"]["t"]["default"] == "2020-01-01"
+    json.dumps(result)
+
+
+def test_bytes_match_renders_a_plain_string() -> None:
+    """A bytes Match pattern has no OpenAPI form, so it renders a string."""
+    import re  # noqa: PLC0415
+
+    from probatio import Match  # noqa: PLC0415
+
+    assert to_openapi(Schema(Match(re.compile(rb"\d+")))) == {"type": "string"}
+
+
+def test_self_renders_a_recursive_ref() -> None:
+    """A Self reference renders a recursive $ref, not a plain string."""
+    from probatio import Optional, Self  # noqa: PLC0415
+
+    schema = Schema({"name": str, Optional("children"): [Self]})
+    result = to_openapi(schema)
+    assert result["properties"]["children"]["items"] == {"$ref": "#"}
+
+
+def test_cyclic_raw_schema_is_a_clean_error() -> None:
+    """A raw dict that references itself is refused, not a bare RecursionError."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    node: dict[object, object] = {"v": int}
+    node["next"] = node
+    with pytest.raises(SchemaError, match="references itself"):
+        to_openapi(node)
+
+
+def test_unrepresentable_default_is_omitted() -> None:
+    """A mapping default with no JSON form is dropped rather than emitted raw."""
+    from probatio import Optional  # noqa: PLC0415
+
+    schema = Schema({Optional("t", default=b"raw"): object})
+    assert "default" not in to_openapi(schema)["properties"]["t"]


### PR DESCRIPTION
## What this changes

First slice of the OpenAPI codec review, mirroring the JSON Schema exercise. These are the robustness fixes that make `to_openapi` output always serializable and stop it crashing, matching what `to_json_schema` already does. Every case here is one voluptuous-openapi (the differential oracle) crashes on or never generates, so the existing fuzz is unaffected; all are verified against the `openapi-schema-validator` reference.

- **Shared helpers.** `json_safe`, `ordered_values`, and the `UNREPRESENTABLE` sentinel move from `jsonschema.py` into `_shared.py`, so both codecs use one copy.
- **Non-JSON values no longer crash `json.dumps`.** A `datetime`, `Decimal`, or `Enum` member in `In`, a `default`, or a `Range` bound now renders JSON-safe (ISO string / float / member value); a member with no representation at all (`bytes`) drops the enum to an open schema rather than leaking an unserializable value.
- **`Match(bytes)` renders a plain string** instead of raising `AttributeError`.
- **A cyclic raw dict** is reported as a clean `SchemaError` instead of a bare `RecursionError`.
- **A multi-element list `[int, str]`** now renders `items: {anyOf: [...]}` (each item matches any element schema), not a positional `items` array that rejected `[1, 2]` and is invalid OpenAPI. **`Schema([])`** renders `maxItems: 0` (only the empty array).
- **`Self`** renders a recursive `{"$ref": "#"}` (the reference validator confirms it validates recursive data correctly) instead of flattening to `type: string`; `_ensure_default` leaves a `$ref` untouched.

## Tests

The one test that asserted the positional-items bug is corrected to the anyOf semantics, and eight tests pin the robustness behaviors (JSON-safe enum/default/bounds, unrepresentable-widens-to-open, bytes Match, Self ref, cyclic error, empty array).

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
