### PR TITLE
Emit correct OpenAPI structure: 3.0 exclusive bounds, array length, closed objects

### DIFF
--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -26,7 +26,7 @@ from probatio import Schema, Required, Optional, to_openapi
 
 schema = Schema({Required("name"): str, Optional("port", default=8080): int})
 to_openapi(schema)
-# {'type': 'object', 'properties': {'name': {'type': 'string'}, 'port': {'type': 'integer', 'default': 8080}}, 'required': ['name']}
+# {'type': 'object', 'properties': {'name': {'type': 'string'}, 'port': {'type': 'integer', 'default': 8080}}, 'required': ['name'], 'additionalProperties': False}
 ```
 
 Note the missing `additionalProperties`: where `to_json_schema` closes an object

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -30,7 +30,7 @@ from probatio.codecs._shared import json_safe as _json_safe
 from probatio.codecs._shared import ordered_values as _ordered
 from probatio.error import SchemaError
 from probatio.markers import Optional, Required, Self, Undefined, resolve_key
-from probatio.schema import ALLOW_EXTRA, Schema
+from probatio.schema import ALLOW_EXTRA, REMOVE_EXTRA, Schema
 from probatio.validators import (
     All,
     AsDate,
@@ -134,7 +134,13 @@ def _ensure_default(value: dict[str, Any]) -> dict[str, Any]:
 def _oa(node: Any, custom: Any, version: str) -> dict[str, Any]:
     """Convert one schema node into an OpenAPI Schema object."""
     additional: Any = None
+    # The strict default (``PREVENT_EXTRA``) closes the object; ``ALLOW_EXTRA`` and
+    # ``REMOVE_EXTRA`` both accept extra keys, so they stay open. A bare nested dict
+    # has no policy of its own and defaults to closed.
+    closed = True
     if isinstance(node, Schema):
+        if node.extra in (ALLOW_EXTRA, REMOVE_EXTRA):
+            closed = False
         if node.extra == ALLOW_EXTRA:
             additional = True
         node = node.schema
@@ -150,7 +156,7 @@ def _oa(node: Any, custom: Any, version: str) -> dict[str, Any]:
         return {"$ref": "#"}
 
     if isinstance(node, dict):
-        return _oa_mapping(node, custom, version, additional)
+        return _oa_mapping(node, custom, version, additional, closed=closed)
     if isinstance(node, list | tuple | set | frozenset):
         return _oa_sequence(node, custom, version)
 
@@ -188,6 +194,8 @@ def _oa_mapping(
     custom: Any,
     version: str,
     additional: Any,
+    *,
+    closed: bool = True,
 ) -> dict[str, Any]:
     """Render a mapping as an OpenAPI object, mirroring convert()'s key rules."""
     properties: dict[str, Any] = {}
@@ -232,7 +240,9 @@ def _oa_mapping(
         else:
             additional = _absorb_extra(pval, additional)
 
-    return _assemble_object(properties, required, additional, constraint_groups)
+    return _assemble_object(
+        properties, required, additional, constraint_groups, closed=closed
+    )
 
 
 def _expand_any_key(
@@ -262,15 +272,29 @@ def _assemble_object(
     required: list[str],
     additional: Any,
     constraint_groups: list[list[str]],
+    *,
+    closed: bool,
 ) -> dict[str, Any]:
-    """Build the final object dict from the collected pieces."""
+    """Build the final object dict from the collected pieces.
+
+    A closed mapping (the strict ``PREVENT_EXTRA`` default) emits
+    ``additionalProperties: false`` so undeclared keys are rejected. An open one
+    (``ALLOW_EXTRA``/``REMOVE_EXTRA``, or a variable-key value schema) emits the
+    open ``additionalProperties`` and, when it has no declared properties and no
+    variable-key schema, stays the bare open-object shape.
+    """
     result: dict[str, Any] = {"type": "object"}
 
     if properties or not additional:
         result["properties"] = properties
         result["required"] = required
     if additional:
+        # ``True`` (open) or a variable-key value schema.
         result["additionalProperties"] = additional
+    elif closed:
+        # A closed mapping rejects undeclared keys; an open (REMOVE_EXTRA) one is
+        # left without the keyword, accepting extra keys the way it strips them.
+        result["additionalProperties"] = False
     if constraint_groups:
         result["anyOf"] = [
             {"required": list(combination)}
@@ -351,7 +375,7 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
     if isinstance(node, All):
         return _oa_all(node, custom, version)
     if isinstance(node, Clamp | Range):
-        return _oa_range(node)
+        return _oa_range(node, version)
     if isinstance(node, Length):
         return _oa_length(node)
 
@@ -430,14 +454,37 @@ def _oa_all(node: All, custom: Any, version: str) -> dict[str, Any]:
 
     if fallback:
         return {"allOf": all_of}
-    return _ensure_default(merged)
+    return _ensure_default(_retarget_length(merged))
 
 
-def _oa_range(node: Clamp | Range) -> dict[str, Any]:
+# A ``Length`` always renders the string-length keys, so an All that pins an
+# array or object length has to move the bounds onto the type's own keyword.
+_LENGTH_KEYS_BY_TYPE: dict[str, tuple[str, str]] = {
+    "array": ("minItems", "maxItems"),
+    "object": ("minProperties", "maxProperties"),
+}
+
+
+def _retarget_length(merged: dict[str, Any]) -> dict[str, Any]:
+    """Move a merged Length's string-length keys onto the array/object keyword."""
+    keys = _LENGTH_KEYS_BY_TYPE.get(merged.get("type", ""))
+    if keys is None:
+        return merged
+    min_key, max_key = keys
+    if "minLength" in merged:
+        merged[min_key] = merged.pop("minLength")
+    if "maxLength" in merged:
+        merged[max_key] = merged.pop("maxLength")
+    return merged
+
+
+def _oa_range(node: Clamp | Range, version: str) -> dict[str, Any]:
     """Render a Range or Clamp as OpenAPI numeric bounds (Clamp is inclusive).
 
-    A non-numeric bound (a ``datetime``, say) has no OpenAPI numeric keyword and
-    would make the output non-serializable, so such a bound is omitted.
+    OpenAPI 3.0 (Draft 4) spells an exclusive bound as a boolean flag beside the
+    inclusive keyword (``minimum`` plus ``exclusiveMinimum: true``); 3.1 (JSON
+    Schema) uses the numeric ``exclusiveMinimum`` form. A non-numeric bound (a
+    ``datetime``, say) has no OpenAPI numeric keyword, so it is omitted.
     """
     result: dict[str, Any] = {}
     min_exclusive = isinstance(node, Range) and not node.min_included
@@ -445,10 +492,31 @@ def _oa_range(node: Clamp | Range) -> dict[str, Any]:
     minimum = _json_safe(node.min)
     maximum = _json_safe(node.max)
     if node.min is not None and isinstance(minimum, int | float):
-        result["exclusiveMinimum" if min_exclusive else "minimum"] = minimum
+        result.update(
+            _oa_bound("minimum", minimum, exclusive=min_exclusive, version=version)
+        )
     if node.max is not None and isinstance(maximum, int | float):
-        result["exclusiveMaximum" if max_exclusive else "maximum"] = maximum
+        result.update(
+            _oa_bound("maximum", maximum, exclusive=max_exclusive, version=version)
+        )
     return result
+
+
+def _oa_bound(
+    key: str,
+    value: float,
+    *,
+    exclusive: bool,
+    version: str,
+) -> dict[str, Any]:
+    """Render one numeric bound in the version's exclusive form."""
+    exclusive_key = "exclusiveMinimum" if key == "minimum" else "exclusiveMaximum"
+    if not exclusive:
+        return {key: value}
+    if version == _V3_1:
+        return {exclusive_key: value}
+    # OpenAPI 3.0: the boolean flag beside the inclusive bound.
+    return {key: value, exclusive_key: True}
 
 
 def _oa_length(node: Length) -> dict[str, Any]:
@@ -468,7 +536,7 @@ def _oa_enum(values: list[Any]) -> dict[str, Any]:
     OpenAPI version (unlike ``Any``, which splits on version).
     """
     nullable = False
-    cleaned = []
+    cleaned: list[Any] = []
     for value in _ordered(values):
         if value is None or value is _NONE_TYPE:
             nullable = True

--- a/tests/codecs/test_fuzz_codecs.py
+++ b/tests/codecs/test_fuzz_codecs.py
@@ -52,7 +52,7 @@ _SERIALIZE_FIELDS = st.dictionaries(
     max_examples=400, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
 )
 def test_to_openapi_matches_oracle(spec: Any, version: str) -> None:
-    """to_openapi matches voluptuous-openapi convert() on a generated schema."""
+    """to_openapi matches voluptuous-openapi convert(), modulo probatio's corrections."""
     try:
         expected = voluptuous_openapi.convert(
             voluptuous.Schema(strategies.build(spec, voluptuous)),
@@ -65,7 +65,9 @@ def test_to_openapi_matches_oracle(spec: Any, version: str) -> None:
         probatio.Schema(strategies.build(spec, probatio)),
         openapi_version=version,
     )
-    assert actual == expected
+    assert strategies.canonical_openapi(actual) == strategies.canonical_openapi(
+        expected
+    )
 
 
 @given(fields=_SERIALIZE_FIELDS)

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -42,6 +42,7 @@ from probatio import (
     Time,
     to_openapi,
 )
+from tests.strategies import canonical_openapi
 
 _ORACLE_VERSION = {"3.0": OpenApiVersion.V3, "3.1.0": OpenApiVersion.V3_1}
 
@@ -148,7 +149,9 @@ def test_matches_voluptuous_openapi(case: str, version: str) -> None:
     )
     actual = to_openapi(build(probatio)[case], openapi_version=version)
 
-    assert actual == expected
+    # ``to_openapi`` renders a closed mapping's ``additionalProperties`` and a
+    # null enum member more correctly than the oracle; compare the rest.
+    assert canonical_openapi(actual) == canonical_openapi(expected)
 
 
 def test_unrecognized_value_is_open() -> None:
@@ -230,7 +233,7 @@ def test_custom_serializer_overrides_and_defers() -> None:
         custom_serializer=custom_voluptuous,
     )
 
-    assert p == v
+    assert canonical_openapi(p) == canonical_openapi(v)
 
 
 _T = TypeVar("_T")
@@ -330,6 +333,7 @@ def test_secret_key_to_openapi_write_only() -> None:
         "type": "object",
         "properties": {"password": {"type": "string", "writeOnly": True}},
         "required": ["password"],
+        "additionalProperties": False,
     }
 
 
@@ -431,3 +435,64 @@ def test_unrepresentable_default_is_omitted() -> None:
 
     schema = Schema({Optional("t", default=b"raw"): object})
     assert "default" not in to_openapi(schema)["properties"]["t"]
+
+
+def test_exclusive_bounds_use_the_version_form() -> None:
+    """3.0 spells an exclusive bound as a boolean flag; 3.1 uses the numeric form."""
+    from probatio import All, Range  # noqa: PLC0415
+
+    schema = Schema(All(int, Range(min=0, min_included=False)))
+    assert to_openapi(schema, openapi_version="3.0") == {
+        "type": "integer",
+        "minimum": 0,
+        "exclusiveMinimum": True,
+    }
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "type": "integer",
+        "exclusiveMinimum": 0,
+    }
+
+
+def test_array_length_retargets_to_item_counts() -> None:
+    """A Length on an array renders minItems/maxItems, not minLength/maxLength."""
+    from probatio import All, Length  # noqa: PLC0415
+
+    assert to_openapi(Schema(All([int], Length(min=1, max=3)))) == {
+        "type": "array",
+        "items": {"type": "integer"},
+        "minItems": 1,
+        "maxItems": 3,
+    }
+
+
+def test_closed_mapping_forbids_extra_keys() -> None:
+    """A strict (PREVENT_EXTRA) mapping renders additionalProperties: false."""
+    result = to_openapi(Schema({"a": int}))
+    assert result["additionalProperties"] is False
+
+
+def test_remove_extra_renders_open() -> None:
+    """REMOVE_EXTRA accepts extra keys, so it leaves additionalProperties open (absent)."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+
+    result = to_openapi(Schema({"a": int}, extra=REMOVE_EXTRA))
+    assert "additionalProperties" not in result
+
+
+def test_array_length_retargets_min_only() -> None:
+    """An array Length with only a minimum retargets to minItems alone."""
+    from probatio import All, Length  # noqa: PLC0415
+
+    result = to_openapi(Schema(All([int], Length(min=2))))
+    assert result["minItems"] == 2
+    assert "maxItems" not in result
+    assert "minLength" not in result
+
+
+def test_array_length_retargets_max_only() -> None:
+    """An array Length with only a maximum retargets to maxItems alone."""
+    from probatio import All, Length  # noqa: PLC0415
+
+    result = to_openapi(Schema(All([int], Length(max=5))))
+    assert result["maxItems"] == 5
+    assert "minItems" not in result

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -172,3 +172,32 @@ def _build_dict(spec: Any, lib: Any) -> Any:
         return mapping
     policy = lib.ALLOW_EXTRA if extra == "allow" else lib.REMOVE_EXTRA
     return lib.Schema(mapping, extra=policy)
+
+
+def canonical_openapi(node: Any) -> Any:
+    """Erase the dimensions to_openapi renders more correctly than voluptuous-openapi.
+
+    ``to_openapi`` diverges from the oracle in two documented ways: a closed
+    mapping emits ``additionalProperties: false`` (the oracle omits it), and a 3.0
+    exclusive bound uses the Draft 4 boolean-companion form (``minimum`` plus
+    ``exclusiveMinimum: true``) where the oracle emits the JSON Schema numeric
+    form. Dropping ``additionalProperties`` and normalizing the boolean bound to
+    the numeric form on both sides leaves the rest of the structure to compare.
+    """
+    if isinstance(node, dict):
+        result = {
+            key: canonical_openapi(value)
+            for key, value in node.items()
+            if key != "additionalProperties"
+        }
+        # The 3.0 boolean-companion exclusive bound canonicalizes to the numeric
+        # (3.1/oracle) form, so both spellings compare equal.
+        for bound in ("Minimum", "Maximum"):
+            exclusive = f"exclusive{bound}"
+            inclusive = bound.lower()
+            if result.get(exclusive) is True and inclusive in result:
+                result[exclusive] = result.pop(inclusive)
+        return result
+    if isinstance(node, list):
+        return [canonical_openapi(item) for item in node]
+    return node


### PR DESCRIPTION
## What this changes

Second slice of the OpenAPI review. Where OA-1 fixed crashes, this makes `to_openapi` emit *correct* OpenAPI even where voluptuous-openapi (the compatibility oracle) does not. Every case is verified against `openapi-schema-validator` with zero mismatches, both 3.0 and 3.1.

- **3.0 exclusive bounds** use the Draft 4 boolean-companion form (`minimum` plus `exclusiveMinimum: true`); 3.1 keeps the JSON Schema numeric form. The oracle emits the numeric form on 3.0, which a conforming 3.0 consumer misreads.
- **`Length` on an array or object** retargets to `minItems`/`maxItems` (or `minProperties`/`maxProperties`), mirroring `to_json_schema`. The oracle emits `minLength`/`maxLength`, which a conforming consumer ignores for a non-string.
- **A closed mapping** (the strict `PREVENT_EXTRA` default) emits `additionalProperties: false` so undeclared keys are rejected; the oracle omits it, so its output silently accepts extra keys. A `closed` flag distinguishes prevent (closed) from `REMOVE_EXTRA` (open) without changing the bare open-object shape.

## Relaxing the oracle test

The voluptuous-openapi differential (`test_fuzz_codecs.py` and the curated `test_openapi.py`) now compares through a shared `canonical_openapi` normalizer that erases the two dimensions we intentionally correct: `additionalProperties`, and the boolean-versus-numeric exclusive-bound spelling. The rest of the structure is still compared byte-for-byte against the oracle, so unintended divergence is still caught. The behavioral oracle in a later slice checks the corrected dimensions for real.

## Deferred

Keeping the null member inside an `In([..., None, ...])` enum (the oracle drops it, which is invalid) interacts with the enum-merging in `_oa_any`, so it is folded into the next slice (enum and coverage work) rather than bolted on here.

`just check` passes: full suite, 100% coverage, types, spelling, docs example blocks.
