### PR TITLE
Widen to_openapi coverage and pin it with a behavioral oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ test = [
   # it (both that the schema is valid and that it never rejects input probatio
   # accepts). Never a runtime dependency.
   "jsonschema==4.26.0",
+  # openapi-schema-validator is a dev-only oracle: to_openapi output is validated
+  # against it (that it is a valid OpenAPI 3.0/3.1 schema and never rejects input
+  # probatio accepts). Never a runtime dependency.
+  "openapi-schema-validator==0.9.0",
   # mashumaro is a benchmark-only comparison for the dataclass path (its codegen
   # from_dict against DataclassSchema). It is not an oracle: it deserializes rather
   # than validates, so it is never compared for correctness. Never a runtime dep.

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -36,32 +36,43 @@ from probatio.validators import (
     AsDate,
     AsDatetime,
     AsTime,
+    AsTimedelta,
     Base64,
     Capitalize,
     Clamp,
     Coerce,
+    Contains,
     Date,
     Datetime,
+    Duration,
     Email,
+    Equal,
+    ExactSequence,
     FqdnUrl,
     FromEpoch,
     FromPercentage,
     In,
     Length,
+    Literal,
     Lower,
     Match,
     Maybe,
+    Msg,
     MultipleOf,
+    NotIn,
     Percentage,
     Port,
     Range,
+    SomeOf,
     Strip,
     Time,
     Title,
+    Unique,
     Upper,
     Url,
 )
 from probatio.validators import Any as AnyValidator
+from probatio.validators import Union as UnionValidator
 
 _NONE_TYPE = type(None)
 _V3_0 = "3.0"
@@ -110,13 +121,63 @@ def to_openapi(
     ``SchemaError`` rather than a bare ``RecursionError``.
     """
     try:
-        return _oa(schema, custom_serializer, openapi_version)
+        rendered = _oa(schema, custom_serializer, openapi_version)
     except RecursionError as exc:
         message = (
             "schema is too deeply nested or references itself; use the Self "
             "marker for a recursive schema"
         )
         raise SchemaError(message) from exc
+    return cast("dict[str, Any]", _admit_null(rendered, openapi_version))
+
+
+def _admit_null(node: Any, version: str) -> Any:
+    """Make every nullable schema actually accept null, per the OpenAPI version.
+
+    A ``nullable: true`` schema that also carries an ``enum`` rejects null unless
+    null is in the enum (the flag admits the null *type*, not a value outside the
+    enumerated set), so null is added to such an enum. On 3.1 there is no
+    ``nullable`` keyword at all, so it is rewritten as ``"null"`` on the type.
+    """
+    if isinstance(node, dict):
+        result = {key: _admit_null(value, version) for key, value in node.items()}
+        if result.get("nullable") is True:
+            _mark_nullable(result, version)
+        return result
+    if isinstance(node, list):
+        return [_admit_null(item, version) for item in node]
+    return node
+
+
+_COMBINATORS = ("anyOf", "oneOf", "allOf")
+
+
+def _mark_nullable(result: dict[str, Any], version: str) -> None:
+    """Rewrite a ``nullable: true`` dict so it actually accepts null on ``version``.
+
+    A ``nullable`` flag is inert on an ``enum`` (null must be a member) and on a
+    combinator (3.0 ignores it there), so null is added as an enum member or a
+    dedicated branch. On 3.1 there is no ``nullable`` keyword, so it becomes
+    ``"null"`` on the type.
+    """
+    enum = result.get("enum")
+    if isinstance(enum, list) and None not in enum:
+        result["enum"] = [*enum, None]
+
+    combinator = next((key for key in _COMBINATORS if key in result), None)
+    if combinator is not None:
+        # A combinator has no type to carry null, so admit it with a branch.
+        result[combinator] = [*result[combinator], _oa_null(version)]
+        result.pop("nullable", None)
+        return
+
+    if version == _V3_1:
+        del result["nullable"]
+        node_type = result.get("type")
+        # The renderer only ever carries ``nullable`` beside a scalar ``type``; a
+        # type array is produced here, so there is no list case to widen.
+        if isinstance(node_type, str):
+            result["type"] = [node_type, "null"]
 
 
 def _ensure_default(value: dict[str, Any]) -> dict[str, Any]:
@@ -138,11 +199,11 @@ def _oa(node: Any, custom: Any, version: str) -> dict[str, Any]:
     # ``REMOVE_EXTRA`` both accept extra keys, so they stay open. A bare nested dict
     # has no policy of its own and defaults to closed.
     closed = True
-    if isinstance(node, Schema):
-        if node.extra in (ALLOW_EXTRA, REMOVE_EXTRA):
-            closed = False
-        if node.extra == ALLOW_EXTRA:
-            additional = True
+    # A ``Schema`` value is itself a valid validator, so schemas can nest. Unwrap
+    # every layer: the innermost one does the validation, so its extra policy wins.
+    while isinstance(node, Schema):
+        closed = node.extra not in (ALLOW_EXTRA, REMOVE_EXTRA)
+        additional = True if node.extra == ALLOW_EXTRA else None
         node = node.schema
 
     if custom is not None:
@@ -287,7 +348,10 @@ def _assemble_object(
 
     if properties or not additional:
         result["properties"] = properties
-        result["required"] = required
+        # OpenAPI 3.0 requires ``required`` to be non-empty, so an empty list is
+        # omitted rather than emitted (``required: []`` is invalid there).
+        if required:
+            result["required"] = required
     if additional:
         # ``True`` (open) or a variable-key value schema.
         result["additionalProperties"] = additional
@@ -399,17 +463,77 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
         if isinstance(source, bytes):
             return {"type": "string"}
         return {"pattern": source}
+    if isinstance(node, Equal | Literal):
+        return _oa_enum([node.target if isinstance(node, Equal) else node.lit])
     if isinstance(node, In):
         return _oa_enum(list(node.container))
+    if isinstance(node, NotIn):
+        enum = _oa_enum(list(node.container))
+        return {"not": enum} if enum else {}
     if node in _OPENAPI_FORMATS:
         return {"format": _OPENAPI_FORMATS[node]}
 
+    if isinstance(node, Msg):
+        # ``Msg`` only swaps the error message; the shape is the wrapped validator.
+        return _oa(node.validator, custom, version)
     if isinstance(node, Maybe):
         return _oa_any([None, node.validator], custom, version)
-    if isinstance(node, AnyValidator):
+    # ``Union``/``Switch`` accept any branch (the discriminant is an optimization),
+    # so they render like ``Any``, sharing its version-aware nullable handling.
+    if isinstance(node, AnyValidator | UnionValidator):
         return _oa_any(list(node.validators), custom, version)
+    if isinstance(node, SomeOf):
+        return _oa_some_of(node, custom, version)
+
+    collection = _oa_collection(node, custom, version)
+    if collection is not None:
+        return collection
 
     return _oa_typed(node)
+
+
+def _oa_some_of(node: SomeOf, custom: Any, version: str) -> dict[str, Any]:
+    """Render a SomeOf for the counts OpenAPI can express, else an open schema.
+
+    Exactly one branch (``min == max == 1``) is ``oneOf``, at least one
+    (``min == 1``, ``max`` the branch count) is ``anyOf``, and every branch
+    (``min == max == count``) is ``allOf``; any other count widens to open.
+    """
+    branches = [_oa(validator, custom, version) for validator in node.validators]
+    count = len(branches)
+    if node.min_valid == node.max_valid == 1:
+        return {"oneOf": branches}
+    if node.min_valid == 1 and node.max_valid == count:
+        return {"anyOf": branches}
+    if node.min_valid == node.max_valid == count:
+        return {"allOf": branches}
+    return {}
+
+
+def _oa_collection(node: Any, custom: Any, version: str) -> dict[str, Any] | None:
+    """Render the array/string collection constraints, or None if not one.
+
+    ``contains`` and ``prefixItems`` are JSON Schema keywords OpenAPI 3.1 shares
+    but 3.0 lacks (and misreads), so on 3.0 the positional/contains constraint is
+    dropped to a plain array rather than emitted in a form a 3.0 consumer breaks on.
+    """
+    if isinstance(node, Unique):
+        return {"type": "array", "uniqueItems": True}
+    if isinstance(node, Contains):
+        if version == _V3_1:
+            return {
+                "type": "array",
+                "contains": _ensure_default(_oa(node.item, custom, version)),
+            }
+        return {"type": "array"}
+    if isinstance(node, ExactSequence):
+        if version == _V3_1:
+            prefix = [_ensure_default(_oa(v, custom, version)) for v in node.validators]
+            return {"type": "array", "prefixItems": prefix, "items": False}
+        return {"type": "array"}
+    if isinstance(node, Duration | AsTimedelta):
+        return {"type": "string", "format": "duration"}
+    return None
 
 
 def _oa_typed(node: Any) -> dict[str, Any] | None:
@@ -530,29 +654,37 @@ def _oa_length(node: Length) -> dict[str, Any]:
 
 
 def _oa_enum(values: list[Any]) -> dict[str, Any]:
-    """Render an enum (from In or an Enum type), extracting null members.
+    """Render an enum (from In or an Enum type), keeping any null member.
 
-    Like voluptuous-openapi, an enum marks itself ``nullable`` regardless of the
-    OpenAPI version (unlike ``Any``, which splits on version).
+    Null stays *in* the enum (``nullable: true`` admits the null type, not a value
+    outside the enumerated set), and a ``nullable`` flag is added on 3.0 so the
+    null type passes too (``_admit_null`` rewrites it for 3.1). A single member
+    type labels the enum; a mixed-type enum (``In(["a", 1])``) is left untyped so
+    it accepts every listed value rather than mislabel by the first member.
     """
-    nullable = False
+    has_null = False
     cleaned: list[Any] = []
     for value in _ordered(values):
         if value is None or value is _NONE_TYPE:
-            nullable = True
+            has_null = True
             continue
         # An enum member with no JSON form (a ``datetime``, an ``Enum``) is
-        # rendered JSON-safe, so the emitted enum never crashes ``json.dumps``. A
-        # member with no representation at all (``bytes``) drops the whole enum to
-        # an open schema rather than leak an unserializable value.
+        # rendered JSON-safe. A member with no representation at all (``bytes``)
+        # drops the whole enum to open rather than leak an unserializable value.
         safe = _json_safe(value)
         if safe is _UNREPRESENTABLE:
-            return {"nullable": True} if nullable else {}
+            return {"nullable": True} if has_null else {}
         cleaned.append(safe)
 
-    enum_type = _OPENAPI_TYPES.get(type(cleaned[0]), "string") if cleaned else "string"
-    result: dict[str, Any] = {"type": enum_type, "enum": cleaned}
-    if nullable:
+    # OpenAPI requires enum members to be unique, so drop duplicates the container
+    # may hold (``In([0, 0])``), keeping first-seen order.
+    cleaned = _dedup_preserving_order(cleaned)
+    member_types = {type(member) for member in cleaned}
+    result: dict[str, Any] = {}
+    if len(member_types) == 1:
+        result["type"] = _OPENAPI_TYPES.get(cleaned[0].__class__, "string")
+    result["enum"] = [*cleaned, None] if has_null else cleaned
+    if has_null:
         result["nullable"] = True
     return result
 
@@ -576,6 +708,11 @@ def _oa_any(validators: list[Any], custom: Any, version: str) -> dict[str, Any]:
         validators = [v for v in validators if v is not None and v is not _NONE_TYPE]
         nullable = True
 
+    if not validators:
+        # Every branch was ``None`` (an ``Any(None, None)``), so only null is
+        # accepted; an empty ``anyOf`` is invalid, so render the null schema.
+        return _oa_null(version)
+
     if len(validators) == 1:
         result = _oa(validators[0], custom, version)
         if nullable:
@@ -587,11 +724,6 @@ def _oa_any(validators: list[Any], custom: Any, version: str) -> dict[str, Any]:
     )
     nullable = nullable or nested_nullable
 
-    if _OPEN_OBJECT in any_of:
-        result = dict(_OPEN_OBJECT)
-        if nullable:
-            result["nullable"] = True
-        return result
     return _collapse_any(_dedup_any(any_of), nullable=nullable)
 
 

--- a/tests/codecs/test_fuzz_codecs.py
+++ b/tests/codecs/test_fuzz_codecs.py
@@ -1,10 +1,15 @@
-"""Property-based differential fuzzing of the codecs against their oracles.
+"""Property-based differential fuzzing of ``serialize`` against its oracle.
 
-``to_openapi`` is compared to voluptuous-openapi's ``convert`` (both OpenAPI
-versions) and ``serialize`` to voluptuous-serialize's ``convert``, on the same
+``serialize`` is compared to voluptuous-serialize's ``convert`` on the same
 generated schema built in each library. When the oracle itself raises (it has
-bugs probatio does not, like crashing on a multi-item array), the example is
-skipped rather than counted against probatio.
+bugs probatio does not), the example is skipped rather than counted against
+probatio.
+
+``to_openapi`` is no longer fuzzed against voluptuous-openapi: it now emits
+correct OpenAPI even where the oracle is buggy, so a byte-for-byte comparison
+fails on the oracle's own errors. Its property-based gate lives in
+``test_openapi_oracle.py``, which validates the emitted document against the
+``openapi-schema-validator`` reference implementation instead.
 """
 
 from __future__ import annotations
@@ -12,16 +17,12 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous
-import voluptuous_openapi
 import voluptuous_serialize
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
-from voluptuous_openapi import OpenApiVersion
 
 import probatio
 from tests import strategies
-
-_ORACLE_VERSION = {"3.0": OpenApiVersion.V3, "3.1.0": OpenApiVersion.V3_1}
 
 # serialize works on a mapping of fields; keep the values to the leaf validators
 # both it and voluptuous-serialize handle (no nested mappings or sequences).
@@ -45,29 +46,6 @@ _SERIALIZE_FIELDS = st.dictionaries(
     st.tuples(st.sampled_from(["required", "optional"]), _SERIALIZE_VALUES),
     max_size=4,
 )
-
-
-@given(spec=strategies.specs(), version=st.sampled_from(["3.0", "3.1.0"]))
-@settings(
-    max_examples=400, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
-)
-def test_to_openapi_matches_oracle(spec: Any, version: str) -> None:
-    """to_openapi matches voluptuous-openapi convert(), modulo probatio's corrections."""
-    try:
-        expected = voluptuous_openapi.convert(
-            voluptuous.Schema(strategies.build(spec, voluptuous)),
-            openapi_version=_ORACLE_VERSION[version],
-        )
-    except Exception:  # noqa: BLE001
-        assume(False)
-        return
-    actual = probatio.to_openapi(
-        probatio.Schema(strategies.build(spec, probatio)),
-        openapi_version=version,
-    )
-    assert strategies.canonical_openapi(actual) == strategies.canonical_openapi(
-        expected
-    )
 
 
 @given(fields=_SERIALIZE_FIELDS)

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -1,9 +1,12 @@
-"""Tests for to_openapi(): the voluptuous-openapi convert() shape.
+"""Tests for to_openapi(): the OpenAPI Schema object shape.
 
-These are differential: the same schema is built in both libraries, converted by
-each (in both OpenAPI 3.0 and 3.1 modes), and the output compared. to_openapi must
-match voluptuous-openapi so LLM tool calling and MCP consumers work on probatio
-schemas unchanged.
+Most cases are differential: the same schema is built in both libraries, converted
+by each (in both OpenAPI 3.0 and 3.1 modes), and the output compared, so probatio
+stays a drop-in for voluptuous-openapi where the oracle is correct. Where probatio
+deliberately emits correct OpenAPI the oracle gets wrong (an ``anyOf`` with an open
+or nullable branch, the widened constraint validators), the expected output is
+asserted directly instead, and ``test_openapi_oracle.py`` covers it property-based
+against the ``openapi-schema-validator`` reference implementation.
 """
 
 from __future__ import annotations
@@ -136,7 +139,16 @@ def build(lib: Any) -> dict[str, Any]:
     }
 
 
-_CASES = list(build(voluptuous))
+# These cases render correct OpenAPI that voluptuous-openapi gets wrong, so a
+# comparison against the oracle is meaningless: an ``Any`` with an open-object
+# branch keeps that branch (the oracle collapses the whole ``anyOf`` to the open
+# object) and a nullable ``Any`` admits null with a dedicated branch (the oracle
+# emits an inert top-level ``nullable``). They are asserted directly below, and
+# the behavioral oracle in ``test_openapi_oracle.py`` covers them property-based.
+_DIVERGING = frozenset(
+    {"any_three", "any_open", "any_open_nullable", "any_nested_nullable"},
+)
+_CASES = [case for case in build(voluptuous) if case not in _DIVERGING]
 
 
 @pytest.mark.parametrize("version", ["3.0", "3.1.0"])
@@ -152,6 +164,41 @@ def test_matches_voluptuous_openapi(case: str, version: str) -> None:
     # ``to_openapi`` renders a closed mapping's ``additionalProperties`` and a
     # null enum member more correctly than the oracle; compare the rest.
     assert canonical_openapi(actual) == canonical_openapi(expected)
+
+
+def test_any_with_null_branch_admits_null_directly() -> None:
+    """Any(int, str, None) renders a dedicated null branch, not an inert nullable.
+
+    voluptuous-openapi hangs the null on a top-level ``nullable``, which an ``anyOf``
+    ignores (each branch decides its own nullability). probatio adds a branch that
+    actually accepts null: ``type: null`` on 3.1, the nullable-object idiom on 3.0.
+    """
+    schema = Schema(probatio.Any(int, str, None))
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}],
+    }
+    assert to_openapi(schema, openapi_version="3.0") == {
+        "anyOf": [
+            {"type": "integer"},
+            {"type": "string"},
+            {"type": "object", "nullable": True, "description": "Must be null"},
+        ],
+    }
+
+
+def test_any_with_open_object_keeps_all_branches() -> None:
+    """Any(dict, int) keeps both branches instead of collapsing to the open object.
+
+    voluptuous-openapi short-circuits the whole ``anyOf`` to the open object as soon
+    as one branch is open, dropping the ``int`` branch. probatio keeps every branch,
+    so the ``anyOf`` still documents the alternatives.
+    """
+    assert to_openapi(Schema(probatio.Any(dict, int))) == {
+        "anyOf": [
+            {"type": "object", "additionalProperties": True},
+            {"type": "integer"},
+        ],
+    }
 
 
 def test_unrecognized_value_is_open() -> None:
@@ -496,3 +543,78 @@ def test_array_length_retargets_max_only() -> None:
     result = to_openapi(Schema(All([int], Length(max=5))))
     assert result["maxItems"] == 5
     assert "minItems" not in result
+
+
+def test_msg_renders_its_wrapped_validator() -> None:
+    """Msg only swaps the error message, so it renders as the wrapped validator."""
+    from probatio import Msg, Range  # noqa: PLC0415
+
+    assert to_openapi(Schema(Msg(Range(min=1), "too small"))) == {"minimum": 1}
+
+
+@pytest.mark.parametrize(
+    ("some_of", "expected"),
+    [
+        ((1, 1), {"oneOf": [{"type": "integer"}, {"type": "string"}]}),
+        ((1, 2), {"anyOf": [{"type": "integer"}, {"type": "string"}]}),
+        ((2, 2), {"allOf": [{"type": "integer"}, {"type": "string"}]}),
+        ((0, 1), {}),
+    ],
+)
+def test_some_of_maps_counts_to_combinators(
+    some_of: tuple[int, int],
+    expected: dict,
+) -> None:
+    """SomeOf renders oneOf/anyOf/allOf for the counts OpenAPI expresses, else open."""
+    from probatio import SomeOf  # noqa: PLC0415
+
+    min_valid, max_valid = some_of
+    schema = Schema(
+        SomeOf(validators=[int, str], min_valid=min_valid, max_valid=max_valid),
+    )
+    assert to_openapi(schema) == expected
+
+
+def test_unique_renders_a_unique_item_array() -> None:
+    """Unique renders an array with uniqueItems set."""
+    from probatio import Unique  # noqa: PLC0415
+
+    assert to_openapi(Schema(Unique())) == {"type": "array", "uniqueItems": True}
+
+
+def test_contains_uses_the_keyword_only_on_3_1() -> None:
+    """Contains renders the 3.1 ``contains`` keyword; 3.0 drops it to a plain array.
+
+    OpenAPI 3.0 lacks ``contains`` and misreads it, so on 3.0 the constraint widens
+    to a bare array rather than emitting a keyword a 3.0 consumer breaks on.
+    """
+    from probatio import Contains  # noqa: PLC0415
+
+    schema = Schema(Contains(int))
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "type": "array",
+        "contains": {"type": "integer"},
+    }
+    assert to_openapi(schema, openapi_version="3.0") == {"type": "array"}
+
+
+def test_exact_sequence_uses_prefix_items_only_on_3_1() -> None:
+    """ExactSequence renders 3.1 prefixItems; 3.0 lacks it, so it drops to an array."""
+    from probatio import ExactSequence  # noqa: PLC0415
+
+    schema = Schema(ExactSequence([int, str]))
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}, {"type": "string"}],
+        "items": False,
+    }
+    assert to_openapi(schema, openapi_version="3.0") == {"type": "array"}
+
+
+def test_duration_renders_a_duration_string() -> None:
+    """Duration and AsTimedelta both render a string with the duration format."""
+    from probatio import AsTimedelta, Duration  # noqa: PLC0415
+
+    expected = {"type": "string", "format": "duration"}
+    assert to_openapi(Schema(Duration())) == expected
+    assert to_openapi(Schema(AsTimedelta())) == expected

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -201,6 +201,46 @@ def test_any_with_open_object_keeps_all_branches() -> None:
     }
 
 
+def test_any_open_and_nullable_keeps_the_open_branch_and_admits_null() -> None:
+    """Any(dict, int, None) keeps the open branch and adds a dedicated null branch."""
+    schema = Schema(probatio.Any(dict, int, None))
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "anyOf": [
+            {"type": "object", "additionalProperties": True},
+            {"type": "integer"},
+            {"type": "null"},
+        ],
+    }
+    assert to_openapi(schema, openapi_version="3.0") == {
+        "anyOf": [
+            {"type": "object", "additionalProperties": True},
+            {"type": "integer"},
+            {"type": "object", "nullable": True, "description": "Must be null"},
+        ],
+    }
+
+
+def test_nested_nullable_any_flattens_and_admits_null_once() -> None:
+    """Any(Any(int, str, None), bool) flattens to one anyOf with a single null branch."""
+    schema = Schema(probatio.Any(probatio.Any(int, str, None), bool))
+    assert to_openapi(schema, openapi_version="3.1.0") == {
+        "anyOf": [
+            {"type": "integer"},
+            {"type": "string"},
+            {"type": "null"},
+            {"type": "boolean"},
+        ],
+    }
+    assert to_openapi(schema, openapi_version="3.0") == {
+        "anyOf": [
+            {"type": "integer"},
+            {"type": "string"},
+            {"type": "boolean"},
+            {"type": "object", "nullable": True, "description": "Must be null"},
+        ],
+    }
+
+
 def test_unrecognized_value_is_open() -> None:
     """An unrecognized, non-callable value renders as an open schema."""
     assert to_openapi(Schema(object())) == {}

--- a/tests/codecs/test_openapi_oracle.py
+++ b/tests/codecs/test_openapi_oracle.py
@@ -1,0 +1,74 @@
+"""Behavioral oracle for ``to_openapi`` against the reference validator.
+
+``to_openapi`` now emits correct OpenAPI even where it diverges from
+voluptuous-openapi, so a byte-for-byte comparison is no longer the right gate.
+These properties validate the emitted document against ``openapi-schema-validator``
+(the reference implementation), in both OpenAPI 3.0 and 3.1:
+
+- the document is a valid OpenAPI Schema Object (``check_schema``) and is
+  serializable (``json.dumps``);
+- it never rejects an input probatio accepts (no narrowing). Widening (the schema
+  accepts what probatio rejects) is expected where OpenAPI cannot express a
+  construct exactly, so the check is one-directional.
+
+The no-narrowing check drops booleans and floats from the value battery: Python's
+numeric equality (``0 == 0.0``, ``1 == True``) makes probatio's ``==`` accept a
+cross-type number an ``enum`` encodes under the strict JSON type model, which
+would read as a spurious narrowing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from openapi_schema_validator import OAS30Validator, OAS31Validator
+
+import probatio
+from tests import strategies
+
+_VALIDATOR = {"3.0": OAS30Validator, "3.1.0": OAS31Validator}
+
+
+def _probatio_accepts(schema: Any, value: Any) -> bool:
+    """Whether the probatio schema accepts the value."""
+    try:
+        schema(value)
+    except probatio.Invalid:
+        return False
+    return True
+
+
+@given(spec=strategies.specs(), version=st.sampled_from(["3.0", "3.1.0"]))
+@settings(
+    max_examples=500, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
+)
+def test_emitted_openapi_is_valid_and_serializable(spec: Any, version: str) -> None:
+    """to_openapi always yields a serializable, valid OpenAPI Schema Object."""
+    schema = probatio.Schema(strategies.build(spec, probatio))
+    document = probatio.to_openapi(schema, openapi_version=version)
+
+    json.dumps(document)
+    _VALIDATOR[version].check_schema(document)
+
+
+@given(
+    spec=strategies.specs(no_narrowing=True),
+    value=strategies.data(booleans=False, floats=False),
+    version=st.sampled_from(["3.0", "3.1.0"]),
+)
+@settings(
+    max_examples=800, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
+)
+def test_emitted_openapi_never_narrows(spec: Any, value: Any, version: str) -> None:
+    """The emitted schema never rejects an input probatio accepts (no narrowing)."""
+    schema = probatio.Schema(strategies.build(spec, probatio))
+    document = probatio.to_openapi(schema, openapi_version=version)
+
+    if _probatio_accepts(schema, value):
+        assert _VALIDATOR[version](document).is_valid(value), (
+            f"emitted schema narrows: probatio accepts {value!r} but the "
+            f"{version} schema {document!r} rejects it"
+        )

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -102,18 +102,18 @@ def specs(*, no_narrowing: bool = False) -> st.SearchStrategy[Any]:
     )
 
 
-def data(*, booleans: bool = True) -> st.SearchStrategy[Any]:
+def data(*, booleans: bool = True, floats: bool = True) -> st.SearchStrategy[Any]:
     """JSON-shaped values: scalars, lists, and string-keyed dicts (no NaN/inf).
 
-    ``booleans=False`` drops bare booleans, for the differential oracle where the
-    bool-is-int impedance would otherwise read as a spurious narrowing.
+    ``booleans=False`` drops bare booleans and ``floats=False`` drops floats, for
+    a differential oracle where Python's numeric equality (``0 == 0.0``,
+    ``1 == True``) would read a strict-typed schema's rejection as a spurious
+    narrowing (an ``enum`` member matches a cross-type number under probatio's
+    ``==`` but not under the JSON type model the schema encodes).
     """
-    scalars = (
-        st.none()
-        | st.integers(min_value=-12, max_value=12)
-        | st.floats(allow_nan=False, allow_infinity=False)
-        | st.text(max_size=3)
-    )
+    scalars = st.none() | st.integers(min_value=-12, max_value=12) | st.text(max_size=3)
+    if floats:
+        scalars |= st.floats(allow_nan=False, allow_infinity=False)
     if booleans:
         scalars |= st.booleans()
     return st.recursive(
@@ -177,19 +177,33 @@ def _build_dict(spec: Any, lib: Any) -> Any:
 def canonical_openapi(node: Any) -> Any:
     """Erase the dimensions to_openapi renders more correctly than voluptuous-openapi.
 
-    ``to_openapi`` diverges from the oracle in two documented ways: a closed
-    mapping emits ``additionalProperties: false`` (the oracle omits it), and a 3.0
-    exclusive bound uses the Draft 4 boolean-companion form (``minimum`` plus
-    ``exclusiveMinimum: true``) where the oracle emits the JSON Schema numeric
-    form. Dropping ``additionalProperties`` and normalizing the boolean bound to
-    the numeric form on both sides leaves the rest of the structure to compare.
+    ``to_openapi`` diverges from the oracle in a few documented ways: a closed
+    mapping emits ``additionalProperties: false`` (the oracle omits it), an empty
+    ``required`` is omitted (the oracle emits ``required: []``, invalid on 3.0),
+    a nullable enum keeps null as a member (the oracle drops it), and a 3.0
+    exclusive bound uses the Draft 4 boolean-companion form where the oracle emits
+    the numeric form. Normalizing those away on both sides leaves the rest of the
+    structure to compare; the behavioral oracle checks the corrected dimensions.
     """
     if isinstance(node, dict):
         result = {
             key: canonical_openapi(value)
             for key, value in node.items()
-            if key != "additionalProperties"
+            if key not in ("additionalProperties", "nullable")
         }
+        # An omitted empty ``required`` and an emitted ``required: []`` are equal.
+        if result.get("required") == []:
+            del result["required"]
+        # An enum's ``type`` diverges (probatio drops it for a mixed-type enum,
+        # and omits duplicates and orders members differently from the oracle's
+        # ``set``), so compare an enum by its sorted, null-free member set alone.
+        if isinstance(result.get("enum"), list):
+            members = {v for v in result["enum"] if v is not None}
+            result["enum"] = sorted(members, key=repr)
+            result.pop("type", None)
+        if isinstance(result.get("type"), list):
+            kept = [t for t in result["type"] if t != "null"]
+            result["type"] = kept[0] if len(kept) == 1 else kept
         # The 3.0 boolean-companion exclusive bound canonicalizes to the numeric
         # (3.1/oracle) form, so both spellings compare equal.
         for bound in ("Minimum", "Maximum"):

--- a/uv.lock
+++ b/uv.lock
@@ -763,6 +763,23 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/e8/ab3f27dbca54ec645f7fab714b640907d5d36c2ebb07e87eebd30bd5c81b/openapi_schema_validator-0.9.0.tar.gz", hash = "sha256:b72db64315b89d21834cd3ffef37e3e6893bc876327be2d366e8424b1029afd3", size = 24686, upload-time = "2026-04-27T17:31:27.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/5467967d95378b2cfce312e09cbd0c9ab64354a0922379b734f793edd04f/openapi_schema_validator-0.9.0-py3-none-any.whl", hash = "sha256:faa3bbe7c3aa8ca2087ad83f709dc3b7d920283153a570c03e24ea182558aa25", size = 19980, upload-time = "2026-04-27T17:31:25.965Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
@@ -940,6 +957,7 @@ bench-world = [
     { name = "marshmallow" },
     { name = "mashumaro" },
     { name = "matplotlib" },
+    { name = "openapi-schema-validator" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -958,6 +976,7 @@ codspeed = [
     { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "jsonschema" },
     { name = "mashumaro" },
+    { name = "openapi-schema-validator" },
     { name = "orjson" },
     { name = "pytest" },
     { name = "pytest-codspeed" },
@@ -978,6 +997,7 @@ dev = [
     { name = "jsonschema" },
     { name = "mashumaro" },
     { name = "mypy" },
+    { name = "openapi-schema-validator" },
     { name = "orjson" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1004,6 +1024,7 @@ test = [
     { name = "hypothesis", version = "6.156.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
     { name = "jsonschema" },
     { name = "mashumaro" },
+    { name = "openapi-schema-validator" },
     { name = "orjson" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1041,6 +1062,7 @@ bench-world = [
     { name = "marshmallow", specifier = "==3.26.2" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "matplotlib", specifier = "==3.11.0" },
+    { name = "openapi-schema-validator", specifier = "==0.9.0" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -1059,6 +1081,7 @@ codspeed = [
     { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "mashumaro", specifier = "==3.22" },
+    { name = "openapi-schema-validator", specifier = "==0.9.0" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-codspeed", specifier = "==5.0.3" },
@@ -1079,6 +1102,7 @@ dev = [
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "mashumaro", specifier = "==3.22" },
     { name = "mypy", specifier = "==2.1.0" },
+    { name = "openapi-schema-validator", specifier = "==0.9.0" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -1105,6 +1129,7 @@ test = [
     { name = "hypothesis", marker = "python_full_version >= '3.15'", specifier = "==6.155.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "mashumaro", specifier = "==3.22" },
+    { name = "openapi-schema-validator", specifier = "==0.9.0" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -1209,6 +1234,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1318,6 +1357,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1423,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Breaking change

None. `to_openapi` renders more constructs and emits more correct OpenAPI than before, but no existing output that was already correct changes shape, and the public signature is unchanged.

## Proposed change

Two things: widen what `to_openapi` can render, and pin it with an oracle that checks the output is actually valid OpenAPI rather than just byte-equal to voluptuous-openapi.

Coverage widening. These constructs used to fall through to an open schema; now they render:

- `Equal`/`Literal` as an enum, `NotIn` as `{"not": enum}`, `Msg` as its wrapped validator.
- `Union`/`Switch` like `Any` (any branch matches; the discriminant is only an optimization).
- `SomeOf` as `oneOf`/`anyOf`/`allOf` for the counts OpenAPI can express, open otherwise.
- `Unique` as `uniqueItems`, `Contains` and `ExactSequence` as their 3.1 keywords (dropped to a plain array on 3.0, which lacks them and misreads them), `Duration`/`AsTimedelta` as `format: duration`.

A post-pass makes every nullable schema actually accept null, which `nullable: true` alone does not do on a combinator or an enum: a null branch is added to a combinator, a null member to an enum, and on 3.1 it becomes `"type": null`. So `Any(int, str, None)` now admits null with a real branch instead of an inert top-level flag that an `anyOf` ignores.

One robustness fix the oracle surfaced: a nested `Schema` value now unwraps in a loop instead of one level, so `Schema(Schema(...))` no longer crashes with `TypeError: unhashable type: 'Schema'`. A `Schema` is a valid validator value, so this was a genuine gap.

Oracle. The old fuzz compared `to_openapi` byte-for-byte against voluptuous-openapi. That stopped being the right gate once `to_openapi` began emitting correct OpenAPI where voluptuous-openapi is buggy (it collapses an `anyOf` as soon as one branch is open, hangs null on an inert flag, loses a type through nested `Maybe`/`Union`). The new `test_openapi_oracle.py` validates every emitted document against `openapi-schema-validator` (the reference implementation voluptuous-openapi itself relied on): each is a valid OpenAPI 3.0 and 3.1 Schema object, and it never rejects an input probatio accepts. The curated differential keeps the cases where probatio and voluptuous-openapi still agree as a drop-in pin; the four diverging `Any` cases are asserted directly.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the OpenAPI codec review (follows #148 and #149)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
