### PR TITLE
Correct stale round-trip and additionalProperties claims in the codec docs

### DIFF
--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -137,29 +137,36 @@ round-trip:
 | `MultipleOf`                  | `multipleOf`                                                                                                                      |
 | `Secret` key                  | its property with `writeOnly: true`                                                                                               |
 | `Base64`                      | `contentEncoding: base64`                                                                                                         |
-| `Duration` / `AsTimedelta`    | `format: duration`                                                                                                                |
 
 Combinators and a few more constructs also render, though most have no inverse
 so they do not round-trip:
 
-| Probatio construct   | JSON Schema output                                                        |
-| -------------------- | ------------------------------------------------------------------------- |
-| `Any` / `Or`         | `anyOf`                                                                   |
-| `Union` / `Switch`   | `anyOf` (the discriminant is an optimization, so any branch is allowed)   |
-| `All` / `And`        | one merged object, or `allOf` when two validators emit the same keyword   |
-| `Maybe`              | `anyOf` with `{"type": "null"}`                                           |
-| `SomeOf`             | `oneOf` (exactly one), `anyOf` (at least one), or `allOf` (all)           |
-| `Msg`                | the wrapped validator's shape (the message has no JSON Schema equivalent) |
-| An `enum.Enum` class | `enum` of the member values                                               |
-| `Self`               | `{"$ref": "#"}` (a recursive reference to the document root)              |
-| `Alias`              | one property per accepted name (plus `anyOf` of `required` when required) |
-| `Inclusive` group    | `dependentRequired` (all-or-none)                                         |
-| `Exclusive` group    | at-most-one (`not` over the pairs), or `oneOf` when the group is required |
+| Probatio construct         | JSON Schema output                                                           |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `Any` / `Or`               | `anyOf`                                                                      |
+| `Union` / `Switch`         | `anyOf` (the discriminant is an optimization, so any branch is allowed)      |
+| `All` / `And`              | one merged object, or `allOf` when two validators emit the same keyword      |
+| `Maybe`                    | `anyOf` with `{"type": "null"}`                                              |
+| `SomeOf`                   | `oneOf` (exactly one), `anyOf` (at least one), or `allOf` (all)              |
+| `Msg`                      | the wrapped validator's shape (the message has no JSON Schema equivalent)    |
+| An `enum.Enum` class       | `enum` of the member values                                                  |
+| `Self`                     | `{"$ref": "#"}` (a recursive reference to the document root)                 |
+| `Alias`                    | one property per accepted name (plus `anyOf` of `required` when required)    |
+| `Inclusive` group          | `dependentRequired` (all-or-none), a keyword the decoder refuses (see below) |
+| `Exclusive` group          | at-most-one (`not` over the pairs), or `oneOf` when the group is required    |
+| `Duration` / `AsTimedelta` | `format: duration`, which has no decoder, so it decodes to a plain string    |
 
 The known widener: JSON Schema has a single `hostname` format, so both
 `Hostname` and `Fqdn` export to it and decode back as `Hostname`, meaning a
 round-tripped `Fqdn` accepts a dotless host the original would reject. Pin it
 with a `pattern` or an explicit check if the distinction matters.
+
+An `Inclusive` group is the one construct whose encoded output the decoder
+refuses rather than widens. It emits `dependentRequired`, an all-or-none
+constraint Probatio cannot honor on decode, so it is one of the [refused
+keywords](#supported-keywords): feeding `to_json_schema`'s own output for an
+`Inclusive` group back into `from_json_schema` raises `SchemaError`. Encode it
+for publication, not for a round trip.
 
 `oneOf` decodes with its exact semantics (a value must match exactly one branch,
 so one matching two or more is rejected), unlike the looser `anyOf`.

--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -29,10 +29,12 @@ to_openapi(schema)
 # {'type': 'object', 'properties': {'name': {'type': 'string'}, 'port': {'type': 'integer', 'default': 8080}}, 'required': ['name'], 'additionalProperties': False}
 ```
 
-Note the missing `additionalProperties`: where `to_json_schema` closes an object
-with an explicit `additionalProperties: False`, `to_openapi` matches
-voluptuous-openapi's output and omits the keyword on a closed object, emitting
-`additionalProperties: True` only when the schema allows extra keys.
+A closed object emits `additionalProperties: False`, the same as `to_json_schema`.
+An `ALLOW_EXTRA` object emits `additionalProperties: True`, and a `REMOVE_EXTRA`
+object omits the keyword (it accepts extra keys but strips them, so the wire shape
+is open). This is one of the places `to_openapi` diverges from voluptuous-openapi,
+which omits the keyword on a closed object: `to_openapi` emits correct OpenAPI even
+where the reference implementation does not.
 
 Going the other way, an OpenAPI Schema object becomes a working validator.
 `nullable` is read back too, so a nullable field accepts both `None` and a real


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

Three stale claims in the codec docs, corrected against actual behavior.

The OpenAPI guide contradicted its own example. It said `to_openapi` "omits the keyword on a closed object" (the old voluptuous-openapi behavior), but since #149 a closed object emits `additionalProperties: False`, which the example right above the prose already shows. Restated to cover the three cases: `PREVENT_EXTRA` emits `additionalProperties: False`, `ALLOW_EXTRA` emits `True`, and `REMOVE_EXTRA` omits it (extra keys are accepted but stripped, so the wire shape is open). Noted that emitting the keyword on a closed object is a deliberate divergence from voluptuous-openapi.

In the JSON Schema guide, `Duration` and `AsTimedelta` sat in the table of constructs that round-trip, but `format: duration` has no decoder, so they decode back to a plain string. Moved them to the no-inverse table with the reason.

Also in the JSON Schema guide, an `Inclusive` group emits `dependentRequired`, which is on the decoder's refused-keywords list. So feeding `to_json_schema`'s own output for an `Inclusive` group back into `from_json_schema` raises `SchemaError`, sharper than the table's generic "no inverse". Added a dedicated note. The encoder producing a construct its own decoder rejects is a real wart; this documents it honestly. Changing the encoder to avoid emitting an unreadable keyword would be a separate code change.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the OpenAPI codec review (#148, #149, #150)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
