### PR TITLE
Round-trip Inclusive groups through dependentRequired

### DIFF
--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -99,17 +99,19 @@ to_json_schema(Schema({"token": str.strip}), custom_serializer=as_password)
 `from_json_schema` understands the keywords below. A purely descriptive keyword
 it does not read (`title`, `examples`) is ignored, so a partial schema still
 yields a usable validator. A _restrictive_ keyword it cannot honor
-(`if`/`then`/`else`, `propertyNames`, `patternProperties`, `dependentRequired`,
-`dependentSchemas`, `dependencies`, `unevaluatedProperties`, `unevaluatedItems`,
-`$dynamicRef`, `$recursiveRef`) is refused with a `SchemaError` rather than
-silently dropped, so an untrusted schema is never quietly widened to accept what
-its author meant to forbid. The object and array keywords apply even on a node
-without a `type` (scoped to instances of their type, as the spec says).
-`to_json_schema` emits the same constructs in the other direction.
+(`if`/`then`/`else`, `propertyNames`, `patternProperties`, `dependentSchemas`,
+`dependencies`, `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`,
+`$recursiveRef`) is refused with a `SchemaError` rather than silently dropped, so
+an untrusted schema is never quietly widened to accept what its author meant to
+forbid. `dependentRequired` is honored only in the symmetric all-or-none form
+that maps to an `Inclusive` group (see below); its asymmetric form is refused the
+same way. The object and array keywords apply even on a node without a `type`
+(scoped to instances of their type, as the spec says). `to_json_schema` emits the
+same constructs in the other direction.
 
 | Area    | Keywords                                                                                                                                                                           |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Objects | `properties`, `required`, `additionalProperties`, `minProperties`, `maxProperties`                                                                                                 |
+| Objects | `properties`, `required`, `additionalProperties`, `minProperties`, `maxProperties`, `dependentRequired` (symmetric all-or-none only)                                               |
 | Arrays  | `items`, `minItems`, `maxItems`, `prefixItems`, `uniqueItems`, `contains`, `minContains`, `maxContains`                                                                            |
 | Strings | `minLength`, `maxLength`, `pattern`, `format` (`date`, `date-time`, `time`, `email`, `uri`, `ipv4`, `ipv6`, `uuid`, `hostname`, `byte`), `writeOnly`, `contentEncoding` (`Base64`) |
 | Numbers | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`                                                                                                         |
@@ -137,36 +139,36 @@ round-trip:
 | `MultipleOf`                  | `multipleOf`                                                                                                                      |
 | `Secret` key                  | its property with `writeOnly: true`                                                                                               |
 | `Base64`                      | `contentEncoding: base64`                                                                                                         |
+| `Inclusive` group             | `dependentRequired` (all-or-none); the symmetric map decodes back to an `Inclusive` group                                         |
 
 Combinators and a few more constructs also render, though most have no inverse
 so they do not round-trip:
 
-| Probatio construct         | JSON Schema output                                                           |
-| -------------------------- | ---------------------------------------------------------------------------- |
-| `Any` / `Or`               | `anyOf`                                                                      |
-| `Union` / `Switch`         | `anyOf` (the discriminant is an optimization, so any branch is allowed)      |
-| `All` / `And`              | one merged object, or `allOf` when two validators emit the same keyword      |
-| `Maybe`                    | `anyOf` with `{"type": "null"}`                                              |
-| `SomeOf`                   | `oneOf` (exactly one), `anyOf` (at least one), or `allOf` (all)              |
-| `Msg`                      | the wrapped validator's shape (the message has no JSON Schema equivalent)    |
-| An `enum.Enum` class       | `enum` of the member values                                                  |
-| `Self`                     | `{"$ref": "#"}` (a recursive reference to the document root)                 |
-| `Alias`                    | one property per accepted name (plus `anyOf` of `required` when required)    |
-| `Inclusive` group          | `dependentRequired` (all-or-none), a keyword the decoder refuses (see below) |
-| `Exclusive` group          | at-most-one (`not` over the pairs), or `oneOf` when the group is required    |
-| `Duration` / `AsTimedelta` | `format: duration`, which has no decoder, so it decodes to a plain string    |
+| Probatio construct         | JSON Schema output                                                        |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `Any` / `Or`               | `anyOf`                                                                   |
+| `Union` / `Switch`         | `anyOf` (the discriminant is an optimization, so any branch is allowed)   |
+| `All` / `And`              | one merged object, or `allOf` when two validators emit the same keyword   |
+| `Maybe`                    | `anyOf` with `{"type": "null"}`                                           |
+| `SomeOf`                   | `oneOf` (exactly one), `anyOf` (at least one), or `allOf` (all)           |
+| `Msg`                      | the wrapped validator's shape (the message has no JSON Schema equivalent) |
+| An `enum.Enum` class       | `enum` of the member values                                               |
+| `Self`                     | `{"$ref": "#"}` (a recursive reference to the document root)              |
+| `Alias`                    | one property per accepted name (plus `anyOf` of `required` when required) |
+| `Exclusive` group          | at-most-one (`not` over the pairs), or `oneOf` when the group is required |
+| `Duration` / `AsTimedelta` | `format: duration`, which has no decoder, so it decodes to a plain string |
 
 The known widener: JSON Schema has a single `hostname` format, so both
 `Hostname` and `Fqdn` export to it and decode back as `Hostname`, meaning a
 round-tripped `Fqdn` accepts a dotless host the original would reject. Pin it
 with a `pattern` or an explicit check if the distinction matters.
 
-An `Inclusive` group is the one construct whose encoded output the decoder
-refuses rather than widens. It emits `dependentRequired`, an all-or-none
-constraint Probatio cannot honor on decode, so it is one of the [refused
-keywords](#supported-keywords): feeding `to_json_schema`'s own output for an
-`Inclusive` group back into `from_json_schema` raises `SchemaError`. Encode it
-for publication, not for a round trip.
+An `Inclusive` group round-trips through `dependentRequired`. `to_json_schema`
+emits the symmetric all-or-none map (every member requires every other), and
+`from_json_schema` reads that shape back into an `Inclusive` group per connected
+set of mutually dependent properties. The general `dependentRequired` is broader:
+an asymmetric dependency (`a` requires `b` but not the reverse) has no `Inclusive`
+equivalent, so it is refused rather than silently widened.
 
 `oneOf` decodes with its exact semantics (a value must match exactly one branch,
 so one matching two or more is rejected), unlike the looser `anyOf`.

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -1831,8 +1831,12 @@ def _apply_inclusive_groups(dependent: Any, mapping: dict[Any, Any]) -> None:
     (asymmetric, a self-dependency, a member that is not a declared optional
     property) is refused, so the decoder never silently widens.
     """
-    for members in _symmetric_groups(dependent):
-        group = "_".join(sorted(members))
+    # An index makes the group id, not the member names joined: a property name
+    # may contain any character, so no join separator is collision-free (``a_b``
+    # plus ``c`` and ``a`` plus ``b_c`` would both read ``a_b_c`` and merge two
+    # unrelated groups). Components are sorted, so the ids are stable.
+    for index, members in enumerate(_symmetric_groups(dependent)):
+        group = f"inclusive_{index}"
         for name in members:
             key = _optional_key(mapping, name)
             replacement = Inclusive(
@@ -1895,7 +1899,11 @@ def _require_symmetric(graph: dict[str, set[str]]) -> None:
 
 
 def _connected_groups(graph: dict[str, set[str]]) -> list[list[str]]:
-    """Return the connected components of a symmetric graph, keeping those of size 2+."""
+    """Return the connected components of a symmetric graph, keeping those of size 2+.
+
+    Each component and the list of components are sorted, so the caller's group
+    ids are stable regardless of the input's key order.
+    """
     seen: set[str] = set()
     groups: list[list[str]] = []
     for start in graph:
@@ -1911,8 +1919,8 @@ def _connected_groups(graph: dict[str, set[str]]) -> list[list[str]]:
             component.append(member)
             stack.extend(graph[member] - seen)
         if len(component) > 1:
-            groups.append(component)
-    return groups
+            groups.append(sorted(component))
+    return sorted(groups)
 
 
 def _optional_key(mapping: dict[Any, Any], name: str) -> Optional:

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -285,31 +285,34 @@ class _Groups:
         )
 
     def constraints(self) -> list[dict[str, Any]]:
-        """Build the object-level JSON Schema constraints for every recorded group."""
+        """Build the ``allOf`` object-level constraints (alias and exclusive groups).
+
+        ``Inclusive`` groups are not here: they render as a ``dependentRequired``
+        sibling (see ``dependent_required``), the idiomatic all-or-none keyword.
+        """
         constraints: list[dict[str, Any]] = [
             # At least one of the alias names must be present.
             {"anyOf": [{"required": [name]} for name in names]}
             for names in self.alias_required
         ]
         constraints += [
-            _inclusive_constraint(members)
-            for members in self.inclusive.values()
-            if len(members) > 1
-        ]
-        constraints += [
             _exclusive_constraint(group) for group in self.exclusive.values()
         ]
         return [constraint for constraint in constraints if constraint]
 
+    def dependent_required(self) -> dict[str, list[str]]:
+        """Merge every multi-member ``Inclusive`` group into one ``dependentRequired``.
 
-def _inclusive_constraint(members: list[str]) -> dict[str, Any]:
-    """Render an ``Inclusive`` group as all-or-none: any member pulls in every other."""
-    return {
-        "dependentRequired": {
-            member: [other for other in members if other != member]
-            for member in members
-        },
-    }
+        Each member requires every other member of its group (all-or-none). Group
+        memberships are disjoint, so the merged map's connected components recover
+        the original groups on decode.
+        """
+        dependent: dict[str, list[str]] = {}
+        for members in self.inclusive.values():
+            if len(members) > 1:
+                for member in members:
+                    dependent[member] = [other for other in members if other != member]
+        return dependent
 
 
 def _exclusive_constraint(group: _ExclusiveGroup) -> dict[str, Any]:
@@ -425,6 +428,9 @@ def _convert_mapping(
     }
     if required:
         result["required"] = required
+    dependent = groups.dependent_required()
+    if dependent:
+        result["dependentRequired"] = dependent
     constraints = groups.constraints()
     if constraints:
         result["allOf"] = constraints
@@ -1340,7 +1346,9 @@ _UNSUPPORTED_KEYWORDS = frozenset(
         "if",
         "propertyNames",
         "patternProperties",
-        "dependentRequired",
+        # ``dependentRequired`` is not blanket-refused: its symmetric all-or-none
+        # form decodes to an ``Inclusive`` group (see ``_from_object``). The
+        # asymmetric form it cannot honor is refused there instead.
         "dependentSchemas",
         "dependencies",
         # Draft 2019-09/2020-12 keywords probatio does not evaluate; ignoring one
@@ -1729,6 +1737,7 @@ _OBJECT_KEYWORDS = frozenset(
         "additionalProperties",
         "minProperties",
         "maxProperties",
+        "dependentRequired",
     },
 )
 _ARRAY_KEYWORDS = frozenset({"items", "prefixItems", "minItems", "maxItems"})
@@ -1812,6 +1821,117 @@ def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
     return constraints
 
 
+def _apply_inclusive_groups(dependent: Any, mapping: dict[Any, Any]) -> None:
+    """Rebuild the ``Inclusive`` groups a symmetric ``dependentRequired`` encodes.
+
+    ``dependentRequired`` is refused in general: its asymmetric form ("a needs b"
+    without the reverse) has no probatio equivalent. The symmetric all-or-none
+    form is exactly an ``Inclusive`` group, so it is honored here: each connected
+    set of mutually dependent optional properties becomes one group. Anything else
+    (asymmetric, a self-dependency, a member that is not a declared optional
+    property) is refused, so the decoder never silently widens.
+    """
+    for members in _symmetric_groups(dependent):
+        group = "_".join(sorted(members))
+        for name in members:
+            key = _optional_key(mapping, name)
+            replacement = Inclusive(
+                name,
+                group,
+                msg=key.msg,
+                default=key.default,
+                description=key.description,
+            )
+            mapping[replacement] = mapping.pop(key)
+
+
+def _symmetric_groups(dependent: Any) -> list[list[str]]:
+    """Validate a ``dependentRequired`` map and return its all-or-none groups.
+
+    Returns one member list per connected group of two or more (a lone or empty
+    dependency is a no-op and yields no group). A connected, symmetric group is
+    all-or-none: any member present forces its neighbours present, and by
+    connectivity the whole group. Raises ``SchemaError`` for any shape that is not
+    a clean symmetric all-or-none.
+    """
+    if not isinstance(dependent, dict):
+        message = (
+            "JSON Schema 'dependentRequired' must be an object, got "
+            f"{type(dependent).__name__}"
+        )
+        raise SchemaError(message)
+
+    graph: dict[str, set[str]] = {}
+    for name, deps in dependent.items():
+        if not isinstance(name, str):
+            message = "JSON Schema 'dependentRequired' keys must be property names"
+            raise SchemaError(message)
+        if not (isinstance(deps, list) and all(isinstance(dep, str) for dep in deps)):
+            message = (
+                f"JSON Schema 'dependentRequired[{name}]' must be an array of "
+                "property names"
+            )
+            raise SchemaError(message)
+        if name in deps:
+            message = f"JSON Schema 'dependentRequired[{name}]' cannot depend on itself"
+            raise SchemaError(message)
+        graph[name] = {str(dep) for dep in deps}
+
+    _require_symmetric(graph)
+    return _connected_groups(graph)
+
+
+def _require_symmetric(graph: dict[str, set[str]]) -> None:
+    """Refuse an asymmetric ``dependentRequired``: it is not an all-or-none group."""
+    for name, deps in graph.items():
+        for dep in deps:
+            if dep not in graph or name not in graph[dep]:
+                message = (
+                    "asymmetric 'dependentRequired' is not supported (only the "
+                    f"symmetric all-or-none form maps to Inclusive): '{name}' "
+                    f"requires '{dep}' but not the reverse"
+                )
+                raise SchemaError(message)
+
+
+def _connected_groups(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Return the connected components of a symmetric graph, keeping those of size 2+."""
+    seen: set[str] = set()
+    groups: list[list[str]] = []
+    for start in graph:
+        if start in seen:
+            continue
+        stack = [start]
+        component: list[str] = []
+        while stack:
+            member = stack.pop()
+            if member in seen:
+                continue
+            seen.add(member)
+            component.append(member)
+            stack.extend(graph[member] - seen)
+        if len(component) > 1:
+            groups.append(component)
+    return groups
+
+
+def _optional_key(mapping: dict[Any, Any], name: str) -> Optional:
+    """Find the plain ``Optional`` marker for ``name``, or refuse the group.
+
+    An ``Inclusive`` member must be a declared optional property. A name that is
+    required, secret, or undeclared cannot form an all-or-none group, so it is
+    refused rather than silently dropped.
+    """
+    for key in mapping:
+        if type(key) is Optional and key.schema == name:
+            return key
+    message = (
+        f"JSON Schema 'dependentRequired' names '{name}', which is not a declared "
+        "optional property, so it cannot form an Inclusive group"
+    )
+    raise SchemaError(message)
+
+
 def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     """Render a JSON Schema object as a mapping schema."""
     properties = node.get("properties", {})
@@ -1857,6 +1977,9 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
 
     if additional_schema is not None:
         mapping[str] = additional_schema
+
+    if "dependentRequired" in node:
+        _apply_inclusive_groups(node["dependentRequired"], mapping)
 
     base = _object_base(mapping, additional, declared="properties" in node)
     min_props = _item_count(node, "minProperties")

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -671,6 +671,108 @@ def test_unsupported_keyword_fails_closed(node: dict[str, object]) -> None:
         from_json_schema(node)
 
 
+def test_symmetric_dependent_required_decodes_to_an_inclusive_group() -> None:
+    """A symmetric all-or-none dependentRequired becomes an Inclusive group."""
+    from probatio.markers import Inclusive  # noqa: PLC0415
+
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {"lat": {"type": "number"}, "lon": {"type": "number"}},
+            "dependentRequired": {"lat": ["lon"], "lon": ["lat"]},
+        },
+    )
+    assert [
+        type(key).__name__ for key in schema.schema if isinstance(key, Inclusive)
+    ] == [
+        "Inclusive",
+        "Inclusive",
+    ]
+    assert schema({"lat": 1.0, "lon": 2.0}) == {"lat": 1.0, "lon": 2.0}
+    assert schema({}) == {}
+    with pytest.raises(Invalid):
+        schema({"lat": 1.0})
+
+
+def test_dependent_required_round_trips_an_inclusive_group() -> None:
+    """to_json_schema then from_json_schema preserves an Inclusive group's behavior."""
+    from probatio.markers import Inclusive  # noqa: PLC0415
+
+    original = Schema(
+        {Inclusive("a", "grp"): int, Inclusive("b", "grp"): int},
+    )
+    rebuilt = from_json_schema(to_json_schema(original))
+    assert rebuilt({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    assert rebuilt({}) == {}
+    with pytest.raises(Invalid):
+        rebuilt({"a": 1})
+
+
+def test_three_member_dependent_required_group_is_all_or_none() -> None:
+    """A three-way symmetric dependentRequired becomes one all-or-none group."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {name: {} for name in ("a", "b", "c")},
+            "dependentRequired": {
+                "a": ["b", "c"],
+                "b": ["a", "c"],
+                "c": ["a", "b"],
+            },
+        },
+    )
+    assert schema({"a": 1, "b": 2, "c": 3}) == {"a": 1, "b": 2, "c": 3}
+    assert schema({}) == {}
+    with pytest.raises(Invalid):
+        schema({"a": 1, "b": 2})
+
+
+def test_vacuous_dependent_required_adds_no_group() -> None:
+    """A member depending on nothing is a no-op: it adds no Inclusive constraint."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "integer"}},
+            "dependentRequired": {"a": []},
+        },
+    )
+    assert schema({}) == {}
+    assert schema({"a": 1}) == {"a": 1}
+
+
+@pytest.mark.parametrize(
+    "dependent",
+    [
+        {"a": ["a"]},  # a self-dependency is not a group
+        {"a": ["b"], "b": ["a"], "c": ["a"]},  # asymmetric: c requires a, not back
+        ["a", "b"],  # not an object
+        {1: ["a"]},  # a non-string key
+        {"a": "b"},  # a dependency list that is not a list
+        {"a": [1]},  # a dependency that is not a property name
+    ],
+)
+def test_malformed_dependent_required_is_refused(dependent: object) -> None:
+    """A dependentRequired that is not a clean symmetric group is refused."""
+    node = {
+        "type": "object",
+        "properties": {name: {} for name in ("a", "b", "c")},
+        "dependentRequired": dependent,
+    }
+    with pytest.raises(SchemaError):
+        from_json_schema(node)
+
+
+def test_dependent_required_naming_an_undeclared_property_is_refused() -> None:
+    """A dependentRequired member without a declared optional property is refused."""
+    node = {
+        "type": "object",
+        "properties": {"a": {}},
+        "dependentRequired": {"a": ["b"], "b": ["a"]},
+    }
+    with pytest.raises(SchemaError, match="not a declared optional property"):
+        from_json_schema(node)
+
+
 def test_exclusive_and_inclusive_bounds_keep_the_tighter_one() -> None:
     """When minimum and exclusiveMinimum are both present, the tighter bound wins."""
     schema = from_json_schema(

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -727,6 +727,32 @@ def test_three_member_dependent_required_group_is_all_or_none() -> None:
         schema({"a": 1, "b": 2})
 
 
+def test_underscored_property_names_do_not_merge_distinct_groups() -> None:
+    """Group ids stay distinct even when member names contain the separator.
+
+    Joining member names would alias ``{a_b, c}`` and ``{a, b_c}`` (both read
+    ``a_b_c``) and merge two unrelated all-or-none groups. Each group must stay
+    independent: satisfying one leaves the other free.
+    """
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {name: {} for name in ("a_b", "c", "a", "b_c")},
+            "dependentRequired": {
+                "a_b": ["c"],
+                "c": ["a_b"],
+                "a": ["b_c"],
+                "b_c": ["a"],
+            },
+        },
+    )
+    # The first group is satisfied and the second is empty: valid only if the two
+    # groups did not merge into one four-way all-or-none.
+    assert schema({"a_b": 1, "c": 2}) == {"a_b": 1, "c": 2}
+    with pytest.raises(Invalid):
+        schema({"a_b": 1})
+
+
 def test_vacuous_dependent_required_adds_no_group() -> None:
     """A member depending on nothing is a no-op: it adds no Inclusive constraint."""
     schema = from_json_schema(

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -742,13 +742,11 @@ def test_required_alias_demands_one_name() -> None:
 
 
 def test_inclusive_group_is_all_or_none() -> None:
-    """An Inclusive group renders dependentRequired, so members come all or none."""
+    """An Inclusive group renders a dependentRequired sibling, all-or-none members."""
     from probatio.markers import Inclusive  # noqa: PLC0415
 
     schema = Schema({Inclusive("a", "g"): int, Inclusive("b", "g"): int})
-    assert to_json_schema(schema)["allOf"] == [
-        {"dependentRequired": {"a": ["b"], "b": ["a"]}},
-    ]
+    assert to_json_schema(schema)["dependentRequired"] == {"a": ["b"], "b": ["a"]}
 
 
 def test_exclusive_group_is_at_most_one() -> None:
@@ -792,7 +790,7 @@ def test_single_member_groups_add_no_vacuous_constraint() -> None:
     """A one-member Inclusive or at-most-one Exclusive group needs no constraint."""
     from probatio.markers import Exclusive, Inclusive  # noqa: PLC0415
 
-    assert "allOf" not in to_json_schema(Schema({Inclusive("a", "g"): int}))
+    assert "dependentRequired" not in to_json_schema(Schema({Inclusive("a", "g"): int}))
     assert "allOf" not in to_json_schema(Schema({Exclusive("a", "g"): int}))
 
 


### PR DESCRIPTION
## Breaking change

None for validation behavior. One output-shape change: an `Inclusive` group now renders `dependentRequired` as a direct object sibling instead of inside `allOf`. The two forms are equivalent JSON Schema, and the sibling form is the idiomatic one.

## Proposed change

An `Inclusive` group encoded with `to_json_schema` and decoded back with `from_json_schema` raised a `SchemaError`: the encoder emitted `dependentRequired`, a keyword the decoder refused wholesale. Round-tripping a schema through its own codec should not raise.

The refusal existed for a reason: the general `dependentRequired` is asymmetric (`{"a": ["b"]}` means "a needs b" but not the reverse), which `Inclusive` cannot express, and the decoder fails closed rather than silently widen an untrusted schema. But the symmetric all-or-none form is exactly an `Inclusive` group. Refusing the whole keyword threw out the subset probatio expresses precisely.

The decoder is the incomplete side, so it is the side that changes. It now honors a symmetric `dependentRequired`, rebuilding one `Inclusive` group per connected set of mutually dependent optional properties (a connected symmetric graph is all-or-none: any member present forces its neighbours, and by connectivity the whole group). Everything it cannot honor still fails closed: asymmetric edges, self-dependencies, malformed shapes, and members that are not declared optional properties. Defaults, descriptions, and messages carry over onto the rebuilt markers.

The encoder now emits `dependentRequired` as a direct object sibling instead of wrapping it in `allOf`. That is the idiomatic keyword and the shape the decoder reads cleanly, so an `Inclusive` group round-trips and re-encodes identically.

The JSON Schema guide is updated to match: `Inclusive` moves into the round-trip table, `dependentRequired` joins the supported object keywords (symmetric form only), and the note added in #151 claiming the decoder refuses its own output is replaced with the symmetric-honored, asymmetric-refused rule.

Not in scope: `to_openapi` still does not emit the `Inclusive` constraint at all (it silently drops all-or-none). That is a separate gap in the OpenAPI encoder, worth its own change.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the codec review series (#147, #151)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
