### PR TITLE
Render Inclusive and Exclusive group constraints in to_openapi

### DIFF
--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -74,6 +74,27 @@ to_openapi(schema)["properties"]["nickname"]
 nullability the JSON Schema way instead, as an `anyOf` with a `{"type": "null"}`
 branch.
 
+## Group constraints across versions
+
+The `Inclusive` (all-or-none) and `Exclusive` (at most one, or exactly one when
+required) dict-group markers render as object-level constraints, and one of them
+splits on version. `Exclusive` uses `oneOf`/`not`, which both OpenAPI versions
+have. `Inclusive` maps to `dependentRequired`, which only OpenAPI 3.1 has:
+
+```python
+from probatio import Schema, Inclusive, to_openapi
+
+schema = Schema({Inclusive("lat", "coords"): float, Inclusive("lon", "coords"): float})
+to_openapi(schema, openapi_version="3.1.0")["dependentRequired"]
+# {'lat': ['lon'], 'lon': ['lat']}
+```
+
+OpenAPI 3.0 has no `dependentRequired` (and silently ignores it), so there the
+same all-or-none is spelled with the keywords 3.0 does have, an `allOf` entry that
+accepts every member present or none present and rejects any partial combination.
+The 3.1 `dependentRequired` decodes back to an `Inclusive` group through
+`from_openapi`; the 3.0 form round-trips by behavior, not back to the marker.
+
 ## Customizing the output
 
 `to_openapi` takes a `custom_serializer` hook, the same one `serialize` uses, to

--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 from probatio.validators import (
     ASCII,
@@ -56,6 +60,53 @@ UNSUPPORTED = _Unsupported()
 # Returned from ``json_safe`` for a value with no JSON representation, so the
 # caller can omit the offending keyword rather than emit an unserializable dict.
 UNREPRESENTABLE = object()
+
+
+@dataclass
+class ExclusiveGroup:
+    """The members of an ``Exclusive`` group and how an empty group is judged.
+
+    Shared by the JSON Schema and OpenAPI codecs: an ``Exclusive`` group is
+    version-independent (``oneOf``/``not`` exist on both), so both codecs must
+    render it identically, and one accumulator here keeps them from drifting.
+    """
+
+    members: list[str] = field(default_factory=list)
+    required: bool = False
+    has_default: bool = False
+
+
+def exclusive_constraint(group: ExclusiveGroup) -> dict[str, Any]:
+    """Render one ``Exclusive`` group as at-most-one, or exactly-one when required.
+
+    A required group with no default demands exactly one member (``oneOf`` over the
+    per-member ``required``). Otherwise at most one member may appear: the negation
+    of any two being present together. Shared so both codecs stay identical.
+    """
+    members = group.members
+    if group.required and not group.has_default:
+        return {"oneOf": [{"required": [member]} for member in members]}
+    pairs = [
+        [members[i], members[j]]
+        for i in range(len(members))
+        for j in range(i + 1, len(members))
+    ]
+    return {"not": {"anyOf": [{"required": pair} for pair in pairs]}} if pairs else {}
+
+
+def merge_dependent_required(groups: Iterable[list[str]]) -> dict[str, list[str]]:
+    """Merge multi-member all-or-none groups into one ``dependentRequired`` map.
+
+    Each member requires every other member of its group. Group memberships are
+    disjoint, so the merged map's connected components recover the original groups
+    on decode. Shared so the JSON Schema and OpenAPI 3.1 encoders cannot drift.
+    """
+    dependent: dict[str, list[str]] = {}
+    for members in groups:
+        if len(members) > 1:
+            for member in members:
+                dependent[member] = [other for other in members if other != member]
+    return dependent
 
 
 def ordered_values(values: Any) -> list[Any]:

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -26,6 +26,9 @@ from probatio.codecs._shared import (
     FORMAT_BY_TYPE,
     STRING_TYPES,
     UNSUPPORTED,
+    ExclusiveGroup,
+    exclusive_constraint,
+    merge_dependent_required,
 )
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
 from probatio.codecs._shared import json_safe as _json_safe
@@ -243,15 +246,6 @@ def _child(node: Any) -> dict[str, Any]:
     return _convert(node, required_default=False, allow_extra=False)
 
 
-@dataclass
-class _ExclusiveGroup:
-    """The members of an ``Exclusive`` group and how an empty group is judged."""
-
-    members: list[str] = field(default_factory=list)
-    required: bool = False
-    has_default: bool = False
-
-
 class _Groups:
     """Accumulates the group-marker memberships found while walking a mapping."""
 
@@ -259,7 +253,7 @@ class _Groups:
         """Start with no groups recorded."""
         self.alias_required: list[list[str]] = []
         self.inclusive: dict[str, list[str]] = {}
-        self.exclusive: dict[str, _ExclusiveGroup] = {}
+        self.exclusive: dict[str, ExclusiveGroup] = {}
 
     def add_alias(self, marker: Alias) -> None:
         """Record a required ``Alias`` (one of its names must be present).
@@ -277,7 +271,7 @@ class _Groups:
 
     def add_exclusive(self, marker: Exclusive, name: str) -> None:
         """Record an ``Exclusive`` member (at most one present within its group)."""
-        group = self.exclusive.setdefault(marker.group_of_exclusion, _ExclusiveGroup())
+        group = self.exclusive.setdefault(marker.group_of_exclusion, ExclusiveGroup())
         group.members.append(name)
         group.required = group.required or marker.group_required
         group.has_default = group.has_default or not isinstance(
@@ -296,42 +290,17 @@ class _Groups:
             for names in self.alias_required
         ]
         constraints += [
-            _exclusive_constraint(group) for group in self.exclusive.values()
+            exclusive_constraint(group) for group in self.exclusive.values()
         ]
         return [constraint for constraint in constraints if constraint]
 
     def dependent_required(self) -> dict[str, list[str]]:
         """Merge every multi-member ``Inclusive`` group into one ``dependentRequired``.
 
-        Each member requires every other member of its group (all-or-none). Group
-        memberships are disjoint, so the merged map's connected components recover
-        the original groups on decode.
+        Group memberships are disjoint, so the merged map's connected components
+        recover the original groups on decode.
         """
-        dependent: dict[str, list[str]] = {}
-        for members in self.inclusive.values():
-            if len(members) > 1:
-                for member in members:
-                    dependent[member] = [other for other in members if other != member]
-        return dependent
-
-
-def _exclusive_constraint(group: _ExclusiveGroup) -> dict[str, Any]:
-    """Render one ``Exclusive`` group as an at-most-one (or exactly-one) constraint.
-
-    A required group with no default demands exactly one member (``oneOf`` over
-    the per-member ``required``). Otherwise the group allows at most one: a
-    default fills the empty group, so the empty object stays valid. At most one
-    is "not any two present", the negation of every pair being present together.
-    """
-    members = group.members
-    if group.required and not group.has_default:
-        return {"oneOf": [{"required": [member]} for member in members]}
-    pairs = [
-        [members[i], members[j]]
-        for i in range(len(members))
-        for j in range(i + 1, len(members))
-    ]
-    return {"not": {"anyOf": [{"required": pair} for pair in pairs]}} if pairs else {}
+        return merge_dependent_required(self.inclusive.values())
 
 
 def _convert_mapping(

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -25,6 +25,9 @@ from probatio.codecs._shared import (
     FORMAT_BY_TYPE,
     STRING_TYPES,
     UNSUPPORTED,
+    ExclusiveGroup,
+    exclusive_constraint,
+    merge_dependent_required,
 )
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
 from probatio.codecs._shared import json_safe as _json_safe
@@ -272,7 +275,7 @@ def _oa_mapping(
     required: list[str] = []
     constraint_groups: list[list[str]] = []
     inclusive: dict[str, list[str]] = {}
-    exclusive: dict[str, _OaExclusiveGroup] = {}
+    exclusive: dict[str, ExclusiveGroup] = {}
 
     for key, value in node.items():
         facets = resolve_key(key)
@@ -302,7 +305,7 @@ def _oa_mapping(
         if isinstance(marker, Inclusive) and isinstance(pkey, str):
             inclusive.setdefault(marker.group_of_inclusion, []).append(pkey)
         elif isinstance(marker, Exclusive) and isinstance(pkey, str):
-            group = exclusive.setdefault(marker.group_of_exclusion, _OaExclusiveGroup())
+            group = exclusive.setdefault(marker.group_of_exclusion, ExclusiveGroup())
             group.members.append(pkey)
             group.required = group.required or marker.group_required
             group.has_default = group.has_default or not isinstance(
@@ -338,15 +341,6 @@ def _oa_mapping(
 
 
 @dataclass
-class _OaExclusiveGroup:
-    """The members of an ``Exclusive`` group and how an empty group is judged."""
-
-    members: list[str] = field(default_factory=list)
-    required: bool = False
-    has_default: bool = False
-
-
-@dataclass
 class _ObjectConstraints:
     """The object-level constraints collected while walking a mapping's keys.
 
@@ -363,7 +357,7 @@ class _ObjectConstraints:
 
 def _group_constraints(
     inclusive: dict[str, list[str]],
-    exclusive: dict[str, _OaExclusiveGroup],
+    exclusive: dict[str, ExclusiveGroup],
     version: str,
 ) -> tuple[dict[str, list[str]], list[dict[str, Any]]]:
     """Build the constraints for the Inclusive and Exclusive groups.
@@ -377,20 +371,19 @@ def _group_constraints(
     always renders under ``allOf``. The ``allOf`` entries never collide on a
     keyword with each other or with the ``dependentRequired`` sibling.
     """
-    groups = [members for members in inclusive.values() if len(members) > 1]
     dependent: dict[str, list[str]] = {}
     all_of: list[dict[str, Any]] = []
     if version == _V3_1:
-        for members in groups:
-            for member in members:
-                dependent[member] = [other for other in members if other != member]
+        dependent = merge_dependent_required(inclusive.values())
     else:
-        all_of += [_oa_inclusive_30(members) for members in groups]
+        all_of += [
+            _oa_inclusive_30(members)
+            for members in inclusive.values()
+            if len(members) > 1
+        ]
     all_of += [
         constraint
-        for constraint in (
-            _oa_exclusive_constraint(group) for group in exclusive.values()
-        )
+        for constraint in (exclusive_constraint(group) for group in exclusive.values())
         if constraint
     ]
     return dependent, all_of
@@ -409,24 +402,6 @@ def _oa_inclusive_30(members: list[str]) -> dict[str, Any]:
             {"not": {"anyOf": [{"required": [member]} for member in members]}},
         ],
     }
-
-
-def _oa_exclusive_constraint(group: _OaExclusiveGroup) -> dict[str, Any]:
-    """Render one ``Exclusive`` group as at-most-one, or exactly-one when required.
-
-    A required group with no default demands exactly one member (``oneOf`` over the
-    per-member ``required``). Otherwise at most one member may appear: the negation
-    of any two being present together.
-    """
-    members = group.members
-    if group.required and not group.has_default:
-        return {"oneOf": [{"required": [member]} for member in members]}
-    pairs = [
-        [members[i], members[j]]
-        for i in range(len(members))
-        for j in range(i + 1, len(members))
-    ]
-    return {"not": {"anyOf": [{"required": pair} for pair in pairs]}} if pairs else {}
 
 
 def _expand_any_key(

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -15,6 +15,7 @@ this is a distinct codec rather than a tweak of ``to_json_schema``.
 from __future__ import annotations
 
 import itertools
+from dataclasses import dataclass, field
 from enum import Enum
 from inspect import isroutine, signature
 from types import UnionType
@@ -29,7 +30,15 @@ from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
 from probatio.codecs._shared import json_safe as _json_safe
 from probatio.codecs._shared import ordered_values as _ordered
 from probatio.error import SchemaError
-from probatio.markers import Optional, Required, Self, Undefined, resolve_key
+from probatio.markers import (
+    Exclusive,
+    Inclusive,
+    Optional,
+    Required,
+    Self,
+    Undefined,
+    resolve_key,
+)
 from probatio.schema import ALLOW_EXTRA, REMOVE_EXTRA, Schema
 from probatio.validators import (
     All,
@@ -262,6 +271,8 @@ def _oa_mapping(
     properties: dict[str, Any] = {}
     required: list[str] = []
     constraint_groups: list[list[str]] = []
+    inclusive: dict[str, list[str]] = {}
+    exclusive: dict[str, _OaExclusiveGroup] = {}
 
     for key, value in node.items():
         facets = resolve_key(key)
@@ -286,24 +297,136 @@ def _oa_mapping(
             required.append(str(pkey))
         pval = _ensure_default(pval)
 
+        # A group marker adds an object-level constraint (all-or-none, at-most-one)
+        # on top of the property it declares, collected here and emitted below.
+        if isinstance(marker, Inclusive) and isinstance(pkey, str):
+            inclusive.setdefault(marker.group_of_inclusion, []).append(pkey)
+        elif isinstance(marker, Exclusive) and isinstance(pkey, str):
+            group = exclusive.setdefault(marker.group_of_exclusion, _OaExclusiveGroup())
+            group.members.append(pkey)
+            group.required = group.required or marker.group_required
+            group.has_default = group.has_default or not isinstance(
+                marker.default, Undefined
+            )
+
         if isinstance(pkey, AnyValidator):
-            props, group = _expand_any_key(
+            props, any_group = _expand_any_key(
                 pkey,
                 pval,
                 required=isinstance(marker, Required),
                 wildcard=value is object,
             )
             properties.update(props)
-            if group is not None:
-                constraint_groups.append(group)
+            if any_group is not None:
+                constraint_groups.append(any_group)
         elif isinstance(pkey, str):
             properties[pkey] = pval
         else:
             additional = _absorb_extra(pval, additional)
 
-    return _assemble_object(
-        properties, required, additional, constraint_groups, closed=closed
+    dependent_required, group_constraints = _group_constraints(
+        inclusive, exclusive, version
     )
+    constraints = _ObjectConstraints(
+        required_any=constraint_groups,
+        dependent_required=dependent_required,
+        all_of=group_constraints,
+    )
+    return _assemble_object(
+        properties, required, additional, constraints, closed=closed
+    )
+
+
+@dataclass
+class _OaExclusiveGroup:
+    """The members of an ``Exclusive`` group and how an empty group is judged."""
+
+    members: list[str] = field(default_factory=list)
+    required: bool = False
+    has_default: bool = False
+
+
+@dataclass
+class _ObjectConstraints:
+    """The object-level constraints collected while walking a mapping's keys.
+
+    ``required_any`` is the list of at-least-one name groups (a required ``Any``
+    key), combined into one ``anyOf``. ``dependent_required`` is the merged 3.1
+    all-or-none map. ``all_of`` holds the remaining group constraints (3.0
+    all-or-none and every ``Exclusive`` group).
+    """
+
+    required_any: list[list[str]] = field(default_factory=list)
+    dependent_required: dict[str, list[str]] = field(default_factory=dict)
+    all_of: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _group_constraints(
+    inclusive: dict[str, list[str]],
+    exclusive: dict[str, _OaExclusiveGroup],
+    version: str,
+) -> tuple[dict[str, list[str]], list[dict[str, Any]]]:
+    """Build the constraints for the Inclusive and Exclusive groups.
+
+    Returns a ``(dependentRequired, allOf)`` pair. An ``Inclusive`` group is
+    all-or-none: on OpenAPI 3.1 (JSON Schema 2020-12) it merges into one
+    ``dependentRequired`` sibling, the idiomatic keyword ``from_openapi`` reads
+    back into an ``Inclusive`` group. OpenAPI 3.0 lacks ``dependentRequired`` (and
+    silently ignores it), so there each group renders under ``allOf`` instead. An
+    ``Exclusive`` group (at most one, or exactly one when required with no default)
+    always renders under ``allOf``. The ``allOf`` entries never collide on a
+    keyword with each other or with the ``dependentRequired`` sibling.
+    """
+    groups = [members for members in inclusive.values() if len(members) > 1]
+    dependent: dict[str, list[str]] = {}
+    all_of: list[dict[str, Any]] = []
+    if version == _V3_1:
+        for members in groups:
+            for member in members:
+                dependent[member] = [other for other in members if other != member]
+    else:
+        all_of += [_oa_inclusive_30(members) for members in groups]
+    all_of += [
+        constraint
+        for constraint in (
+            _oa_exclusive_constraint(group) for group in exclusive.values()
+        )
+        if constraint
+    ]
+    return dependent, all_of
+
+
+def _oa_inclusive_30(members: list[str]) -> dict[str, Any]:
+    """Render an all-or-none group for OpenAPI 3.0, which lacks ``dependentRequired``.
+
+    All-or-none is spelled with the keywords 3.0 does have: exactly one of "every
+    member present" or "no member present" holds, which rejects any partial
+    combination.
+    """
+    return {
+        "oneOf": [
+            {"required": list(members)},
+            {"not": {"anyOf": [{"required": [member]} for member in members]}},
+        ],
+    }
+
+
+def _oa_exclusive_constraint(group: _OaExclusiveGroup) -> dict[str, Any]:
+    """Render one ``Exclusive`` group as at-most-one, or exactly-one when required.
+
+    A required group with no default demands exactly one member (``oneOf`` over the
+    per-member ``required``). Otherwise at most one member may appear: the negation
+    of any two being present together.
+    """
+    members = group.members
+    if group.required and not group.has_default:
+        return {"oneOf": [{"required": [member]} for member in members]}
+    pairs = [
+        [members[i], members[j]]
+        for i in range(len(members))
+        for j in range(i + 1, len(members))
+    ]
+    return {"not": {"anyOf": [{"required": pair} for pair in pairs]}} if pairs else {}
 
 
 def _expand_any_key(
@@ -332,7 +455,7 @@ def _assemble_object(
     properties: dict[str, Any],
     required: list[str],
     additional: Any,
-    constraint_groups: list[list[str]],
+    constraints: _ObjectConstraints,
     *,
     closed: bool,
 ) -> dict[str, Any]:
@@ -359,11 +482,18 @@ def _assemble_object(
         # A closed mapping rejects undeclared keys; an open (REMOVE_EXTRA) one is
         # left without the keyword, accepting extra keys the way it strips them.
         result["additionalProperties"] = False
-    if constraint_groups:
+    if constraints.required_any:
         result["anyOf"] = [
             {"required": list(combination)}
-            for combination in itertools.product(*constraint_groups)
+            for combination in itertools.product(*constraints.required_any)
         ]
+    if constraints.dependent_required:
+        # OpenAPI 3.1 all-or-none: a sibling ``from_openapi`` reads back as Inclusive.
+        result["dependentRequired"] = constraints.dependent_required
+    if constraints.all_of:
+        # The remaining group constraints go under ``allOf`` so they never collide
+        # on a keyword with each other or with the ``anyOf`` above.
+        result["allOf"] = constraints.all_of
     return result
 
 

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -658,3 +658,63 @@ def test_duration_renders_a_duration_string() -> None:
     expected = {"type": "string", "format": "duration"}
     assert to_openapi(Schema(Duration())) == expected
     assert to_openapi(Schema(AsTimedelta())) == expected
+
+
+def test_inclusive_group_renders_all_or_none_per_version() -> None:
+    """An Inclusive group renders dependentRequired on 3.1 and a oneOf form on 3.0.
+
+    OpenAPI 3.0 lacks dependentRequired (and silently ignores it), so all-or-none
+    is spelled with keywords 3.0 has: every member present, or none present.
+    """
+    from probatio import Inclusive  # noqa: PLC0415
+
+    schema = Schema({Inclusive("a", "g"): int, Inclusive("b", "g"): int})
+    assert to_openapi(schema, openapi_version="3.1.0")["dependentRequired"] == {
+        "a": ["b"],
+        "b": ["a"],
+    }
+    assert to_openapi(schema, openapi_version="3.0")["allOf"] == [
+        {
+            "oneOf": [
+                {"required": ["a", "b"]},
+                {"not": {"anyOf": [{"required": ["a"]}, {"required": ["b"]}]}},
+            ],
+        },
+    ]
+
+
+def test_exclusive_group_renders_at_most_one() -> None:
+    """An Exclusive group renders an at-most-one constraint, the same on both versions."""
+    from probatio import Exclusive  # noqa: PLC0415
+
+    schema = Schema({Exclusive("a", "e"): int, Exclusive("b", "e"): int})
+    at_most_one = [{"not": {"anyOf": [{"required": ["a", "b"]}]}}]
+    assert to_openapi(schema, openapi_version="3.0")["allOf"] == at_most_one
+    assert to_openapi(schema, openapi_version="3.1.0")["allOf"] == at_most_one
+
+
+def test_required_exclusive_group_renders_exactly_one() -> None:
+    """A required Exclusive group with no default demands exactly one member."""
+    from probatio import Exclusive  # noqa: PLC0415
+
+    schema = Schema(
+        {Exclusive("a", "e", required=True): int, Exclusive("b", "e"): int},
+    )
+    assert to_openapi(schema)["allOf"] == [
+        {"oneOf": [{"required": ["a"]}, {"required": ["b"]}]},
+    ]
+
+
+def test_inclusive_group_round_trips_through_openapi_3_1() -> None:
+    """A 3.1 Inclusive group decodes back to an Inclusive group via from_openapi."""
+    from probatio import Inclusive, from_openapi  # noqa: PLC0415
+
+    document = to_openapi(
+        Schema({Inclusive("a", "g"): int, Inclusive("b", "g"): int}),
+        openapi_version="3.1.0",
+    )
+    rebuilt = from_openapi(document)
+    assert rebuilt({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    assert rebuilt({}) == {}
+    with pytest.raises(probatio.Invalid):
+        rebuilt({"a": 1})

--- a/tests/codecs/test_openapi_oracle.py
+++ b/tests/codecs/test_openapi_oracle.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from openapi_schema_validator import OAS30Validator, OAS31Validator
@@ -72,3 +73,44 @@ def test_emitted_openapi_never_narrows(spec: Any, value: Any, version: str) -> N
             f"emitted schema narrows: probatio accepts {value!r} but the "
             f"{version} schema {document!r} rejects it"
         )
+
+
+@pytest.mark.parametrize("version", ["3.0", "3.1.0"])
+def test_inclusive_group_agrees_with_the_reference_validator(version: str) -> None:
+    """An Inclusive group emits valid OpenAPI the reference validator reads as all-or-none.
+
+    The all-or-none constraint is spelled differently per version (dependentRequired
+    on 3.1, a oneOf form on 3.0), so both are checked against the matching reference
+    validator for validity and behavior.
+    """
+    document = probatio.to_openapi(
+        probatio.Schema(
+            {probatio.Inclusive("a", "g"): int, probatio.Inclusive("b", "g"): int},
+        ),
+        openapi_version=version,
+    )
+    validator_cls = _VALIDATOR[version]
+    validator_cls.check_schema(document)
+    validator = validator_cls(document)
+    assert validator.is_valid({"a": 1, "b": 2})
+    assert validator.is_valid({})
+    assert not validator.is_valid({"a": 1})
+    assert not validator.is_valid({"b": 2})
+
+
+@pytest.mark.parametrize("version", ["3.0", "3.1.0"])
+def test_exclusive_group_agrees_with_the_reference_validator(version: str) -> None:
+    """An Exclusive group emits valid OpenAPI the reference validator reads as at-most-one."""
+    document = probatio.to_openapi(
+        probatio.Schema(
+            {probatio.Exclusive("a", "e"): int, probatio.Exclusive("b", "e"): int},
+        ),
+        openapi_version=version,
+    )
+    validator_cls = _VALIDATOR[version]
+    validator_cls.check_schema(document)
+    validator = validator_cls(document)
+    assert validator.is_valid({})
+    assert validator.is_valid({"a": 1})
+    assert validator.is_valid({"b": 2})
+    assert not validator.is_valid({"a": 1, "b": 2})


### PR DESCRIPTION
## Breaking change

None. `to_openapi` now emits constraints it previously dropped, so an emitted document may reject inputs it used to accept, but that matches what the probatio schema always enforced. No existing correct output changes shape.

## Proposed change

`to_openapi` silently dropped every dict-group constraint. An `Inclusive` or `Exclusive` group emitted its properties but none of the all-or-none or at-most-one rule, so the OpenAPI document was a silent widening: it accepted inputs the schema rejects.

Both now render:

- `Exclusive` uses `oneOf`/`not`: at most one member, or exactly one when the group is required with no default. Valid on both OpenAPI versions.
- `Inclusive` is all-or-none and splits on version. OpenAPI 3.1 (JSON Schema 2020-12) has `dependentRequired`, emitted as a property sibling that `from_openapi` reads back into an `Inclusive` group. OpenAPI 3.0 has no `dependentRequired` and silently ignores it, so it renders an `allOf` `oneOf`/`not` form that accepts every member or none and rejects any partial combination (round-trips by behavior, not back to the marker).

The group constraints go under `allOf` (except the 3.1 `dependentRequired` sibling) so they never collide on a keyword with each other or with the existing required-`Any` `anyOf`. Every construction is checked against the `openapi-schema-validator` reference (`OAS30Validator`/`OAS31Validator`) for both meta-schema validity and correct accept/reject behavior.

`Alias` is out of scope: `to_openapi` does not expand its alias names at all, which is a separate name-rendering gap rather than a dropped constraint.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the codec review series (#150, #152)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
