### PR TITLE
Expand Alias names in to_openapi

### DIFF
--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -34,6 +34,7 @@ from probatio.codecs._shared import json_safe as _json_safe
 from probatio.codecs._shared import ordered_values as _ordered
 from probatio.error import SchemaError
 from probatio.markers import (
+    Alias,
     Exclusive,
     Inclusive,
     Optional,
@@ -284,7 +285,7 @@ def _oa_mapping(
         pval = _oa(value, custom, version)
         if facets.description:
             pval["description"] = facets.description
-        if isinstance(marker, Required | Optional) and not isinstance(
+        if isinstance(marker, Required | Optional | Alias) and not isinstance(
             marker.default,
             Undefined,
         ):
@@ -312,7 +313,17 @@ def _oa_mapping(
                 marker.default, Undefined
             )
 
-        if isinstance(pkey, AnyValidator):
+        if isinstance(marker, Alias):
+            # Each accepted name renders as a property (the value is the same), and
+            # a required Alias with no default demands at least one of them, an
+            # object-level constraint like a required ``Any`` key. A default fills
+            # the empty case, so a required Alias carrying one demands no name.
+            names = [str(alias_name) for alias_name in marker.input_names]
+            for alias_name in names:
+                properties[alias_name] = pval.copy()
+            if marker.required and isinstance(marker.default, Undefined):
+                constraint_groups.append(names)
+        elif isinstance(pkey, AnyValidator):
             props, any_group = _expand_any_key(
                 pkey,
                 pval,

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -705,6 +705,51 @@ def test_required_exclusive_group_renders_exactly_one() -> None:
     ]
 
 
+def test_alias_key_expands_to_one_property_per_accepted_name() -> None:
+    """An Alias key renders every accepted name as a property with the same schema."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_openapi(Schema({Alias("name", "userName"): str}))
+    assert result["properties"] == {
+        "name": {"type": "string"},
+        "userName": {"type": "string"},
+    }
+    assert "anyOf" not in result
+
+
+def test_required_alias_demands_at_least_one_name() -> None:
+    """A required Alias adds an at-least-one-name constraint over its accepted names."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_openapi(Schema({Alias("name", "userName", required=True): str}))
+    assert result["anyOf"] == [
+        {"required": ["name"]},
+        {"required": ["userName"]},
+    ]
+
+
+def test_required_alias_with_a_default_demands_no_name() -> None:
+    """A required Alias carrying a default fills the empty case, so it demands no name."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_openapi(
+        Schema({Alias("name", "userName", required=True, default="x"): str}),
+    )
+    assert "anyOf" not in result
+    assert result["properties"]["name"]["default"] == "x"
+    assert result["properties"]["userName"]["default"] == "x"
+
+
+def test_alias_without_canonical_only_emits_the_alias_names() -> None:
+    """With accept_canonical=False the canonical name is not an accepted input name."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    result = to_openapi(
+        Schema({Alias("name", "userName", accept_canonical=False): str}),
+    )
+    assert result["properties"] == {"userName": {"type": "string"}}
+
+
 def test_inclusive_group_round_trips_through_openapi_3_1() -> None:
     """A 3.1 Inclusive group decodes back to an Inclusive group via from_openapi."""
     from probatio import Inclusive, from_openapi  # noqa: PLC0415

--- a/tests/codecs/test_openapi_oracle.py
+++ b/tests/codecs/test_openapi_oracle.py
@@ -99,6 +99,23 @@ def test_inclusive_group_agrees_with_the_reference_validator(version: str) -> No
 
 
 @pytest.mark.parametrize("version", ["3.0", "3.1.0"])
+def test_required_alias_agrees_with_the_reference_validator(version: str) -> None:
+    """A required Alias emits valid OpenAPI the reference validator reads as at-least-one."""
+    from probatio.markers import Alias  # noqa: PLC0415
+
+    document = probatio.to_openapi(
+        probatio.Schema({Alias("name", "userName", required=True): str}),
+        openapi_version=version,
+    )
+    validator_cls = _VALIDATOR[version]
+    validator_cls.check_schema(document)
+    validator = validator_cls(document)
+    assert validator.is_valid({"name": "a"})
+    assert validator.is_valid({"userName": "a"})
+    assert not validator.is_valid({})
+
+
+@pytest.mark.parametrize("version", ["3.0", "3.1.0"])
 def test_exclusive_group_agrees_with_the_reference_validator(version: str) -> None:
     """An Exclusive group emits valid OpenAPI the reference validator reads as at-most-one."""
     document = probatio.to_openapi(


### PR DESCRIPTION
## Breaking change

None. `to_openapi` now emits names and a constraint it previously dropped, so an emitted document may accept alias spellings and reject a missing required name where it did not before. That matches what the probatio schema always enforced.

## Proposed change

`to_openapi` handled an `Alias` key by emitting only its canonical name. The alias names, the required at-least-one constraint, and the default were all dropped, so the generated OpenAPI neither accepted the alias spellings nor enforced the rule (a silent widening, plus a missing property).

It now mirrors the JSON Schema codec:

- Every accepted input name (`Alias.input_names`) renders as a property with the same value schema.
- A required `Alias` with no default adds an at-least-one-name constraint (`anyOf` of `required`) over those names. A default fills the empty case, so a required `Alias` carrying one demands no name.
- `accept_canonical=False` emits only the alias names (the canonical name is the output name, not an accepted input).
- `Alias` defaults render, having been excluded from the default handling before.

Every case is checked against the `openapi-schema-validator` reference (`OAS30Validator`/`OAS31Validator`) for validity and accept/reject behavior, and the emitted property set and constraint match `to_json_schema`.

This closes the last `to_openapi` silent-widening gap from the codec review (following #153, which covered `Inclusive`/`Exclusive`). `Alias` name expansion is not version-specific, so no OpenAPI-specific docs change is needed: json-schema.md already documents the shared behavior, which the OpenAPI guide defers to.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the codec review series (#153)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
