### PR TITLE
Add a strict mode to to_openapi

### DIFF
--- a/docs/src/content/docs/guides/openapi.md
+++ b/docs/src/content/docs/guides/openapi.md
@@ -95,6 +95,26 @@ accepts every member present or none present and rejects any partial combination
 The 3.1 `dependentRequired` decodes back to an `Inclusive` group through
 `from_openapi`; the 3.0 form round-trips by behavior, not back to the marker.
 
+## Strict mode
+
+By default a construct with no OpenAPI form widens to an open schema (`{}`), so
+the emitted document stays a superset of what Probatio validates. Pass
+`strict=True` to raise `SchemaError` instead, so a lossy conversion is caught
+rather than silently accepted, the same as [`to_json_schema`](/guides/json-schema/#widening-the-encoder-and-overriding-it):
+
+<!-- verify: raises SchemaError -->
+
+```python
+from probatio import Schema, In, to_openapi
+
+to_openapi(Schema(In([b"raw"])), strict=True)
+```
+
+A faithfully open construct (`object`, a bare `dict`) is not a loss, so it stays
+open even under `strict=True`. Strict catches the constructs that widen to an open
+schema, not a version-specific partial drop (an OpenAPI 3.0 `Contains` still
+renders as a plain array).
+
 ## Customizing the output
 
 `to_openapi` takes a `custom_serializer` hook, the same one `serialize` uses, to

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -14,6 +14,7 @@ this is a distinct codec rather than a tweak of ``to_json_schema``.
 
 from __future__ import annotations
 
+import contextvars
 import itertools
 from dataclasses import dataclass, field
 from enum import Enum
@@ -116,11 +117,35 @@ _OA_PERCENT_MIN = 0
 _OA_PERCENT_MAX = 100
 
 
+# Whether the active ``to_openapi`` call raises on a construct with no OpenAPI
+# form instead of widening it to an open schema. A ``ContextVar`` carries the flag
+# to every node without threading a third argument through the recursive encoder;
+# ``to_openapi`` sets it on entry and resets it on exit.
+_STRICT: contextvars.ContextVar[bool] = contextvars.ContextVar("_STRICT", default=False)
+
+
+def _open(reason: str) -> dict[str, Any]:
+    """Render an open schema for a construct with no OpenAPI form.
+
+    In strict mode the silent widening is an error (the construct's constraint
+    would be dropped); otherwise it widens to accept-anything, the default
+    best-effort behavior. Mirrors ``to_json_schema``'s ``_open``.
+    """
+    if _STRICT.get():
+        message = (
+            f"to_openapi cannot represent {reason}; it would widen to an open "
+            "schema (pass strict=False to allow it)"
+        )
+        raise SchemaError(message)
+    return {}
+
+
 def to_openapi(
     schema: Any,
     *,
     custom_serializer: Any = None,
     openapi_version: str = _V3_0,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """Render a schema as an OpenAPI Schema object.
 
@@ -129,10 +154,16 @@ def to_openapi(
     for each node and may return a dict to override the default, or ``UNSUPPORTED``
     to defer.
 
+    By default a construct with no OpenAPI form widens to an open schema (``{}``).
+    With ``strict=True`` such a construct raises ``SchemaError`` instead, so a
+    lossy conversion is caught rather than silently accepted, the same as
+    ``to_json_schema``.
+
     A raw schema that references itself (a dict holding itself as a value) has no
     finite rendering, so the runaway recursion is reported as a clean
     ``SchemaError`` rather than a bare ``RecursionError``.
     """
+    token = _STRICT.set(strict)
     try:
         rendered = _oa(schema, custom_serializer, openapi_version)
     except RecursionError as exc:
@@ -141,6 +172,8 @@ def to_openapi(
             "marker for a recursive schema"
         )
         raise SchemaError(message) from exc
+    finally:
+        _STRICT.reset(token)
     return cast("dict[str, Any]", _admit_null(rendered, openapi_version))
 
 
@@ -513,10 +546,12 @@ def _oa_leaf(node: Any, custom: Any, version: str) -> dict[str, Any]:
         return _oa_null(version)
 
     typed = _oa_type(node, version)
-    if typed or not callable(node):
+    if typed:
         return typed
+    if callable(node):
+        return _oa_callable(node, custom, version)
 
-    return _oa_callable(node, custom, version)
+    return _open(f"the value {node!r}")
 
 
 def _oa_callable(node: Any, custom: Any, version: str) -> dict[str, Any]:
@@ -532,11 +567,11 @@ def _oa_callable(node: Any, custom: Any, version: str) -> dict[str, Any]:
         )
         params = list(signature(node).parameters.keys())
     except (TypeError, NameError, ValueError):
-        return {}
+        return _open(f"the callable {node!r} (its signature cannot be inspected)")
 
     hint = hints.get(params[0], Any) if params else Any
     if hint is Any or isinstance(hint, TypeVar):
-        return {}
+        return _open(f"the callable {node!r} (its first parameter has no type hint)")
 
     if isinstance(hint, UnionType) or get_origin(hint) is Union:
         members = [arg for arg in get_args(hint) if not isinstance(arg, TypeVar)]
@@ -545,7 +580,7 @@ def _oa_callable(node: Any, custom: Any, version: str) -> dict[str, Any]:
         elif len(members) == 1 and members[0] is not _NONE_TYPE:
             hint = members[0]
         else:
-            return {}
+            return _open(f"the callable {node!r} (its only hint is None or a TypeVar)")
 
     return _ensure_default(_oa(hint, custom, version))
 
@@ -623,7 +658,7 @@ def _oa_some_of(node: SomeOf, custom: Any, version: str) -> dict[str, Any]:
         return {"anyOf": branches}
     if node.min_valid == node.max_valid == count:
         return {"allOf": branches}
-    return {}
+    return _open("a SomeOf with a min/max count OpenAPI cannot express")
 
 
 def _oa_collection(node: Any, custom: Any, version: str) -> dict[str, Any] | None:
@@ -789,6 +824,9 @@ def _oa_enum(values: list[Any]) -> dict[str, Any]:
         # drops the whole enum to open rather than leak an unserializable value.
         safe = _json_safe(value)
         if safe is _UNREPRESENTABLE:
+            # In strict mode this lossy drop is an error; otherwise keep any
+            # nullability the enum still carries.
+            _open("an enum member with no OpenAPI form")
             return {"nullable": True} if has_null else {}
         cleaned.append(safe)
 

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -763,3 +763,43 @@ def test_inclusive_group_round_trips_through_openapi_3_1() -> None:
     assert rebuilt({}) == {}
     with pytest.raises(probatio.Invalid):
         rebuilt({"a": 1})
+
+
+def test_strict_raises_on_an_unrepresentable_validator() -> None:
+    """strict=True refuses a construct that would silently widen to an open schema."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="cannot represent"):
+        to_openapi(Schema(frozenset[int]), strict=True)
+
+
+def test_strict_raises_on_an_unrepresentable_enum_member() -> None:
+    """strict=True refuses an enum member with no OpenAPI form."""
+    from probatio import In  # noqa: PLC0415
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="no OpenAPI form"):
+        to_openapi(Schema(In([b"raw"])), strict=True)
+
+
+def test_strict_raises_on_an_inexpressible_some_of() -> None:
+    """strict=True refuses a SomeOf whose count OpenAPI cannot express."""
+    from probatio import SomeOf  # noqa: PLC0415
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema(SomeOf(validators=[int, str], min_valid=0, max_valid=1))
+    with pytest.raises(SchemaError, match="cannot represent"):
+        to_openapi(schema, strict=True)
+
+
+def test_strict_allows_a_faithfully_open_schema() -> None:
+    """strict=True does not raise for object, which is faithfully an open schema."""
+    assert to_openapi(Schema(object), strict=True) == {
+        "type": "object",
+        "additionalProperties": True,
+    }
+
+
+def test_non_strict_still_widens_by_default() -> None:
+    """Without strict, an unrepresentable construct still widens to an open schema."""
+    assert to_openapi(Schema(frozenset[int])) == {}


### PR DESCRIPTION
## Breaking change

None. `strict` defaults to `False`, and non-strict output is byte-identical to before.

## Proposed change

`to_openapi` widens a construct with no OpenAPI form to an open schema, so a lossy conversion passes silently. This adds `strict=True`, mirroring `to_json_schema`'s `strict=`: it raises `SchemaError` instead, so the widening is caught rather than accepted.

A contextvar-backed `_open(reason)` choke point returns an open schema in the default mode and raises in strict mode, so no third argument threads through the recursive encoder. It raises on:

- an unknown, non-callable value;
- a callable with no usable type hint (its signature cannot be inspected, its first parameter is untyped, or its only hint is `None`/a `TypeVar`);
- a `SomeOf` with a min/max count OpenAPI cannot express;
- an enum member with no OpenAPI form.

A faithfully open construct (`object`, a bare `dict`) is not a loss, so it stays open even under `strict=True`. Like `to_json_schema`, strict catches a widening to an open schema, not a version-specific partial drop (an OpenAPI 3.0 `Contains` still renders as a plain array). Non-strict output is unchanged, since every `_open` returns the same open schema it did before when strict is off.

This is the last parked item from the codec review series (following #153 and #154).

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the codec review series (#146 added to_json_schema strict; #153, #154)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
