### PR TITLE
Stop four validators leaking non-Invalid exceptions

### DIFF
--- a/src/probatio/_engine.py
+++ b/src/probatio/_engine.py
@@ -764,13 +764,18 @@ class _SequenceValidator:
         # validated items, so return it directly rather than copying it into a new
         # one. Other types are rebuilt as the data's own type (voluptuous semantics),
         # so a subclass or namedtuple round-trips. A namedtuple takes its fields
-        # positionally, not a single iterable, so it is rebuilt with a splat.
+        # positionally, not a single iterable, so it is rebuilt with a splat. A
+        # subclass whose constructor is not ``(iterable)`` cannot be rebuilt that
+        # way, so fall back to the plain base type rather than leak its TypeError.
         out_type = type(data)
         if out_type is list:
             return result
-        if issubclass(out_type, tuple) and hasattr(out_type, "_fields"):
-            return out_type(*result)
-        return out_type(result)
+        try:
+            if issubclass(out_type, tuple) and hasattr(out_type, "_fields"):
+                return out_type(*result)
+            return out_type(result)
+        except TypeError:
+            return list(result) if issubclass(out_type, list) else tuple(result)
 
     def _validate_item(
         self,

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -16,6 +16,7 @@ from probatio.error import (
     EmailInvalid,
     LengthInvalid,
     MatchInvalid,
+    SchemaError,
     SlugInvalid,
     UrlInvalid,
 )
@@ -457,6 +458,18 @@ class Replace(_SafeValidator):
         self.pattern = re.compile(pattern) if isinstance(pattern, str) else pattern
         self.substitution = substitution
         self.msg = msg
+        # Validate the substitution now, not at call time. A bad group reference
+        # (``\2`` with one group) is a schema error, and ``re`` parses the template
+        # eagerly, so a dry run against an empty string surfaces it here as a clean
+        # SchemaError rather than leaking ``re.error`` on the first matching value.
+        try:
+            self.pattern.sub(self.substitution, "")
+        except re.error as exc:
+            message = (
+                f"Replace substitution {substitution!r} is not valid for pattern "
+                f"{self.pattern.pattern!r}: {exc}"
+            )
+            raise SchemaError(message) from exc
 
     def __repr__(self) -> str:
         """Render as a constructor call, matching voluptuous."""

--- a/src/probatio/validators/structural.py
+++ b/src/probatio/validators/structural.py
@@ -88,11 +88,17 @@ class ExactSequence(_SafeValidator):
 
         # Rebuild the sequence as its own type. A namedtuple takes its fields
         # positionally (``Point(*result)``), not as a single iterable, so detect it
-        # the way the sequence engine does rather than leak a TypeError.
+        # the way the sequence engine does rather than leak a TypeError. A list or
+        # tuple subclass whose constructor is not ``(iterable)`` (a custom
+        # ``__init__``/``__new__``) cannot be rebuilt that way, so fall back to the
+        # plain base type rather than leak the TypeError its constructor raises.
         out_type = type(value)
-        if issubclass(out_type, tuple) and hasattr(out_type, "_fields"):
-            return out_type(*result)
-        return out_type(result)
+        try:
+            if issubclass(out_type, tuple) and hasattr(out_type, "_fields"):
+                return out_type(*result)
+            return out_type(result)
+        except TypeError:
+            return list(result) if issubclass(out_type, list) else tuple(result)
 
 
 class Unique(_SafeValidator):

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -368,11 +368,21 @@ class AsTimedelta(_SafeValidator):
             return sign * self._seconds(text)
 
         parts = text.split(":")
-        if len(parts) not in _DURATION_PARTS or not all(p.isdigit() for p in parts):
+        # ``isdecimal`` matches exactly what ``int`` accepts; ``isdigit`` is broader
+        # (it admits superscripts like ``²`` that ``int`` then rejects). A part of
+        # decimal digits can still overflow ``int``'s string-length limit on a
+        # pathologically long string, so the conversion is guarded too, keeping the
+        # parser from leaking a ``ValueError`` on either shape.
+        if len(parts) not in _DURATION_PARTS or not all(p.isdecimal() for p in parts):
             raise DurationInvalid(
                 self.msg, translation_key="expected_duration_detailed"
             )
-        hours, minutes, *rest = (int(part) for part in parts)
+        try:
+            hours, minutes, *rest = (int(part) for part in parts)
+        except ValueError as exc:
+            raise DurationInvalid(
+                self.msg, translation_key="expected_duration_detailed"
+            ) from exc
         seconds = rest[0] if rest else 0
 
         # In clock-style input, minutes and seconds stay in their usual range.

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -77,11 +77,7 @@ def test_namedtuple_schema_accepts_a_plain_tuple() -> None:
 
 
 def test_list_subclass_that_cannot_rebuild_falls_back_to_a_plain_list() -> None:
-    """A list subclass with a non-(iterable) constructor does not leak a TypeError.
-
-    Rebuilding the data as its own type would raise from the subclass constructor;
-    the sequence engine falls back to a plain list instead.
-    """
+    """A list subclass with a non-(iterable) constructor rebuilds to a plain list, not a leak."""
 
     class TaggedList(list):
         def __init__(self, items: object, tag: object) -> None:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -76,6 +76,23 @@ def test_namedtuple_schema_accepts_a_plain_tuple() -> None:
     assert isinstance(rebuilt, point)
 
 
+def test_list_subclass_that_cannot_rebuild_falls_back_to_a_plain_list() -> None:
+    """A list subclass with a non-(iterable) constructor does not leak a TypeError.
+
+    Rebuilding the data as its own type would raise from the subclass constructor;
+    the sequence engine falls back to a plain list instead.
+    """
+
+    class TaggedList(list):
+        def __init__(self, items: object, tag: object) -> None:
+            super().__init__(items)  # type: ignore[arg-type]
+            self.tag = tag
+
+    result = Schema([int])(TaggedList([1, 2], "x"))
+    assert result == [1, 2]
+    assert type(result) is list
+
+
 def test_set_schema_keeps_the_set_type() -> None:
     """A set schema validates a set and returns a set."""
     result = Schema({int})({1, 2, 3})

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -58,12 +58,7 @@ def test_replace_on_non_string(value: object) -> None:
 
 
 def test_replace_rejects_a_bad_backreference_at_build() -> None:
-    """A substitution with an invalid group reference is a build-time SchemaError.
-
-    ``re`` parses the replacement template eagerly, so ``\\2`` against a one-group
-    pattern is caught when the validator is constructed, not leaked as a raw
-    ``re.error`` on the first matching value.
-    """
+    """A substitution with an invalid group reference raises SchemaError at build time."""
     with pytest.raises(SchemaError, match="substitution"):
         Replace(r"(a)", r"\2")
 

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -30,7 +30,13 @@ from probatio import (
     Upper,
     Url,
 )
-from probatio.error import EmailInvalid, MatchInvalid, SlugInvalid, UrlInvalid
+from probatio.error import (
+    EmailInvalid,
+    MatchInvalid,
+    SchemaError,
+    SlugInvalid,
+    UrlInvalid,
+)
 
 
 def test_replace() -> None:
@@ -49,6 +55,17 @@ def test_replace_on_non_string(value: object) -> None:
     with pytest.raises(MultipleInvalid) as caught:
         Schema(Replace(r"x", "y"))(value)
     assert isinstance(caught.value.errors[0], MatchInvalid)
+
+
+def test_replace_rejects_a_bad_backreference_at_build() -> None:
+    """A substitution with an invalid group reference is a build-time SchemaError.
+
+    ``re`` parses the replacement template eagerly, so ``\\2`` against a one-group
+    pattern is caught when the validator is constructed, not leaked as a raw
+    ``re.error`` on the first matching value.
+    """
+    with pytest.raises(SchemaError, match="substitution"):
+        Replace(r"(a)", r"\2")
 
 
 def test_string_transforms() -> None:

--- a/tests/validators/test_structural.py
+++ b/tests/validators/test_structural.py
@@ -56,11 +56,7 @@ def test_exact_sequence_rebuilds_a_namedtuple() -> None:
 
 
 def test_exact_sequence_falls_back_when_a_subclass_cannot_rebuild() -> None:
-    """A list/tuple subclass whose constructor is not (iterable) does not leak.
-
-    ``type(value)(result)`` would raise a raw ``TypeError`` for a subclass with a
-    custom constructor; the rebuild falls back to the plain base type instead.
-    """
+    """A list/tuple subclass with a non-(iterable) constructor rebuilds to the base type."""
 
     class TaggedList(list):
         def __init__(self, items: object, tag: object) -> None:

--- a/tests/validators/test_structural.py
+++ b/tests/validators/test_structural.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from typing import Self
 
 import pytest
 
@@ -52,6 +53,33 @@ def test_exact_sequence_rebuilds_a_namedtuple() -> None:
 
     assert result == point(1, 2)
     assert isinstance(result, point)
+
+
+def test_exact_sequence_falls_back_when_a_subclass_cannot_rebuild() -> None:
+    """A list/tuple subclass whose constructor is not (iterable) does not leak.
+
+    ``type(value)(result)`` would raise a raw ``TypeError`` for a subclass with a
+    custom constructor; the rebuild falls back to the plain base type instead.
+    """
+
+    class TaggedList(list):
+        def __init__(self, items: object, tag: object) -> None:
+            super().__init__(items)  # type: ignore[arg-type]
+            self.tag = tag
+
+    class Pair(tuple):
+        __slots__ = ()
+
+        def __new__(cls, a: object, b: object) -> Self:
+            return super().__new__(cls, (a, b))
+
+    from_list = Schema(ExactSequence([int]))(TaggedList([1], "x"))
+    assert from_list == [1]
+    assert type(from_list) is list
+
+    from_tuple = Schema(ExactSequence([int, int]))(Pair(1, 2))
+    assert from_tuple == (1, 2)
+    assert type(from_tuple) is tuple
 
 
 def test_exact_sequence_item_error_has_index() -> None:

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -275,6 +275,9 @@ _INVALID_DURATIONS = [
     "1:99",  # 99 minutes is out of the 0..59 clock range
     "0:60",  # 60 minutes is out of range
     "1:00:99",  # 99 seconds is out of range
+    "1:²",  # a superscript digit: str.isdigit() admits it, int() does not
+    "1:2:³",
+    "²:00",
     "P",  # a bare designator carries no fields
     "PT",  # a time separator with no time field
     "P1DT",  # a dangling time separator
@@ -291,6 +294,7 @@ _OVERFLOW_DURATIONS = [
     "1e400",
     {"days": 10**20},
     "P999999999999999999W",  # an ISO 8601 duration past timedelta's range
+    "9" * 5000 + ":00",  # decimal digits, but past int()'s string-length limit
 ]
 
 


### PR DESCRIPTION
## Breaking change

None. `Replace` with an invalid substitution now raises `SchemaError` at construction instead of leaking `re.error` at validation time, which only affects a schema that was already broken.

## Proposed change

The safe-validator contract is that a validator raises only `Invalid` (or a subclass) on bad input, never another exception, and never hangs or crashes. `test_safe_contract.py` enforces this structurally by fuzzing every `_SafeValidator` with a hostile value corpus. A subsystem review found four hand-written parser/rebuild paths that sit in that corpus's blind spots and leak a non-`Invalid` exception:

- **`AsTimedelta` / `Duration`** (`temporal.py`): the colon parser gated on `str.isdigit()`, which admits superscript digits (`"1:²"`) that `int()` then rejects with `ValueError`; `int()` also caps string length, so a pathologically long all-digit part overflows the same way. Gated on `isdecimal()` (exactly what `int()` accepts) and the conversion is wrapped, so both shapes raise `DurationInvalid`. This was the one high-severity untrusted-input leak.
- **`Replace`** (`strings.py`): a bad group reference in the substitution (`\2` against a one-group pattern) leaked `re.PatternError` on the first matching value. `re` parses the replacement template eagerly, so a build-time dry run against an empty string surfaces it as a clean `SchemaError` at construction, fail-fast and honest.
- **`ExactSequence`** (`structural.py`) and **the sequence engine** (`_engine.py`): both rebuilt the input as `type(value)(result)`, which leaks `TypeError` for a `list`/`tuple` subclass whose constructor is not `(iterable)`. Both fall back to the plain base type; namedtuples still round-trip.

Regression tests cover each: superscript and oversized durations, the `Replace` build-time rejection, and the subclass-rebuild fallback for both `ExactSequence` and the engine.

Follow-up (separate PR): widen the `test_safe_contract.py` corpus (unicode digit look-alikes, oversized strings, hostile container subclasses) so this whole class of leak is caught structurally rather than by review.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the validators subsystem review

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
