### PR TITLE
Reject fractional MultipleOf factors and out-of-range offset minutes

### DIFF
--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -273,9 +273,17 @@ class MultipleOf(_SafeValidator):
     """Require a number to be an integer multiple of a non-zero factor."""
 
     def __init__(self, factor: typing.Any, msg: str | None = None) -> None:
-        """Store the factor; reject a zero or non-numeric factor at build time."""
-        if not isinstance(factor, int | float) or factor == 0:
-            message = "MultipleOf factor must be a non-zero number"
+        """Store the factor; reject a zero, fractional, or non-numeric factor.
+
+        The check is an *integer* multiple, so a fractional factor (``0.1``) has no
+        meaning here and its float ``%`` would mis-reject exact multiples through
+        representation error; it is refused at build time. An integer-valued float
+        (``2.0``) is accepted and normalized to ``int``.
+        """
+        if isinstance(factor, float) and factor.is_integer():
+            factor = int(factor)
+        if not isinstance(factor, int) or factor == 0:
+            message = "MultipleOf factor must be a non-zero whole number"
             raise SchemaError(message)
         self.factor = factor
         self.msg = msg
@@ -294,9 +302,9 @@ class MultipleOf(_SafeValidator):
             )
 
         try:
-            # ``%`` with a float factor promotes a huge int to float, which can
-            # overflow (an ArithmeticError); an ``int`` subclass can also define a
-            # ``__mod__`` that raises. Report either cleanly, not as a leak.
+            # The factor is a plain non-zero int, so ``%`` on a plain int or float
+            # value cannot raise. An ``int`` subclass can still define a ``__mod__``
+            # that raises, though, so contain that as Invalid rather than leak it.
             remainder = value % self.factor
         except Exception as exc:
             raise MultipleOfInvalid(

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -54,8 +54,11 @@ _ISO8601_DURATION = re.compile(
 )
 
 # A fixed UTC offset: a sign, two-digit hours, optional colon, two-digit minutes.
-# Matched in full, no backtracking, so a crafted string cannot make it hang.
-_UTC_OFFSET = re.compile(r"[+-]\d{2}:?\d{2}")
+# Matched in full, no backtracking, so a crafted string cannot make it hang. Minutes
+# are 00..59: a value like ``+0099`` is rejected here rather than silently rolled into
+# extra hours by ``timedelta``. Out-of-range hours are caught later, when
+# ``datetime.timezone`` refuses an offset of 24 hours or more.
+_UTC_OFFSET = re.compile(r"[+-]\d{2}:?[0-5]\d")
 
 # How many epoch sub-units make one second, per accepted ``FromEpoch`` unit.
 _EPOCH_DIVISORS = {"seconds": 1, "milliseconds": 1000}

--- a/tests/validators/test_comparison.py
+++ b/tests/validators/test_comparison.py
@@ -329,11 +329,37 @@ def test_multiple_of_rejects_a_non_number(value: object) -> None:
     assert isinstance(caught.value.errors[0], MultipleOfInvalid)
 
 
-@pytest.mark.parametrize("factor", [0, "x"])
+@pytest.mark.parametrize("factor", [0, "x", 0.1, 2.5, float("nan"), float("inf")])
 def test_multiple_of_rejects_a_bad_factor_at_build_time(factor: object) -> None:
-    """A zero or non-numeric factor is a schema definition error."""
+    """A zero, fractional, or non-numeric factor is a schema definition error.
+
+    A fractional factor has no meaning for an integer-multiple check, and its float
+    ``%`` would mis-reject exact multiples through representation error, so it is
+    refused at build time rather than silently accepted.
+    """
     with pytest.raises(SchemaError):
         MultipleOf(factor)
+
+
+def test_multiple_of_normalizes_an_integer_valued_float_factor() -> None:
+    """An integer-valued float factor (2.0) is accepted and stored as an int."""
+    validator = MultipleOf(2.0)
+    assert validator.factor == 2
+    assert isinstance(validator.factor, int)
+    assert Schema(validator)(4) == 4
+
+
+def test_multiple_of_contains_a_hostile_int_subclass_mod() -> None:
+    """An int subclass whose __mod__ raises yields Invalid, not a leaked exception."""
+
+    class _BadInt(int):
+        def __mod__(self, _other: object) -> int:
+            message = "hostile mod"
+            raise RuntimeError(message)
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(MultipleOf(3))(_BadInt(9))
+    assert isinstance(caught.value.errors[0], MultipleOfInvalid)
 
 
 def test_percentage_validates_and_returns_unchanged() -> None:

--- a/tests/validators/test_fuzz_new_validators.py
+++ b/tests/validators/test_fuzz_new_validators.py
@@ -102,7 +102,6 @@ _VALIDATORS = (
     Negative(),
     NonNegative(),
     MultipleOf(3),
-    MultipleOf(0.5),  # a float factor overflows on a huge int; must stay clean
     Percentage(),
     NonEmpty(),
     Byte(),

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -378,7 +378,17 @@ def test_astimezone_passes_through_a_native_timezone() -> None:
     assert Schema(AsTimezone())(tz) is tz
 
 
-_INVALID_OFFSETS = ["Europe/Amsterdam", "noon", "", "+25:00", 5]
+_INVALID_OFFSETS = [
+    "Europe/Amsterdam",
+    "noon",
+    "",
+    "+25:00",  # hours out of range
+    "+0099",  # 99 minutes is out of the 0..59 range, not rolled into extra hours
+    "+0060",
+    "+00:60",
+    "-0060",
+    5,
+]
 
 
 @pytest.mark.parametrize("value", _INVALID_OFFSETS)


### PR DESCRIPTION
## Breaking change

Two narrow behavior changes, both turning a silently-wrong result into an explicit error:

- `MultipleOf` with a fractional factor (`MultipleOf(0.1)`) now raises `SchemaError` at construction instead of building and mis-rejecting. An integer-valued float (`2.0`) is still accepted, normalized to `int`.
- `AsTimezone`/`TimeZone` now reject an offset whose minutes are 60–99 (`"+0099"`) instead of rolling them into extra hours.

Both were silently-wrong before, so any code relying on the old behavior was already getting a wrong answer.

## Proposed change

Two correctness slips the validators review turned up:

**`MultipleOf`** accepted a fractional factor its "integer multiple" contract disallows, then silently mis-rejected exact multiples: `0.3 % 0.1` is not `0` under IEEE-754, so `MultipleOf(0.1)(0.3)` failed. A fractional factor is now refused at build time (`SchemaError`); an integer-valued float (`2.0`) is accepted and normalized to `int`. The call-time `%` guard stays, since an `int` subclass can still define a `__mod__` that raises, now with a covering test. The fuzz case that was built on a float factor is dropped, since that path no longer exists.

If fractional steps are ever wanted (money, `0.05`), that is a separate, deliberate feature (Decimal or tolerance based), not something this quietly enables.

**`AsTimezone` / `TimeZone`** accepted minutes 60–99 in a fixed offset and let `timedelta` roll them into extra hours, so `"+0099"` became `+01:39`. The offset regex now pins minutes to `00–59`, rejecting the out-of-range value. Both validators share the regex, so both are fixed. Out-of-range hours are still caught downstream, when `datetime.timezone` refuses an offset of 24 hours or more.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the validators subsystem review (follows #157, #158)

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
