### PR TITLE
Reject bad validator constructor args instead of leaking at call time

### DIFF
--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -467,13 +467,23 @@ class Length(_SafeValidator):
         except Exception as exc:
             raise LengthInvalid(self.msg, translation_key="value_no_length") from exc
 
-        if self.min is not None and length < self.min:
+        try:
+            below_min = self.min is not None and length < self.min
+            above_max = self.max is not None and length > self.max
+        except TypeError as exc:
+            # A non-numeric bound makes the comparison raise; report it cleanly like
+            # Range does, rather than leak the TypeError.
+            raise LengthInvalid(
+                self.msg, translation_key="invalid_value_or_type"
+            ) from exc
+
+        if below_min:
             raise LengthInvalid(
                 self.msg,
                 translation_key="length_min",
                 placeholders={"min": self.min},
             )
-        if self.max is not None and length > self.max:
+        if above_max:
             raise LengthInvalid(
                 self.msg,
                 translation_key="length_max",

--- a/src/probatio/validators/comparison.py
+++ b/src/probatio/validators/comparison.py
@@ -470,9 +470,10 @@ class Length(_SafeValidator):
         try:
             below_min = self.min is not None and length < self.min
             above_max = self.max is not None and length > self.max
-        except TypeError as exc:
-            # A non-numeric bound makes the comparison raise; report it cleanly like
-            # Range does, rather than leak the TypeError.
+        except Exception as exc:
+            # A bad bound makes the comparison raise (a str bound a TypeError, a
+            # Decimal('NaN') an ArithmeticError); report it cleanly like Range does,
+            # rather than leak. No intentional Invalid is raised inside this try.
             raise LengthInvalid(
                 self.msg, translation_key="invalid_value_or_type"
             ) from exc

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -195,9 +195,10 @@ class ByteLength(_SafeValidator):
             out_of_bounds = (self.min is not None and size < self.min) or (
                 self.max is not None and size > self.max
             )
-        except TypeError as exc:
-            # A non-numeric bound makes the comparison raise; report it cleanly like
-            # Range does, rather than leak the TypeError.
+        except Exception as exc:
+            # A bad bound makes the comparison raise (a str bound a TypeError, a
+            # Decimal('NaN') an ArithmeticError); report it cleanly like Range does,
+            # rather than leak. No intentional Invalid is raised inside this try.
             raise LengthInvalid(
                 self.msg, translation_key="invalid_value_or_type"
             ) from exc

--- a/src/probatio/validators/strings.py
+++ b/src/probatio/validators/strings.py
@@ -109,11 +109,26 @@ class NoWhitespace(_CharacterClass):
     _translation_key = "expected_no_whitespace"
 
 
+def _is_affix(value: typing.Any) -> bool:
+    """Whether ``value`` is a valid ``startswith``/``endswith`` argument.
+
+    ``str.startswith``/``endswith`` accept a string or a tuple of strings; anything
+    else raises a ``TypeError`` at call time, so it is refused when the validator is
+    built instead.
+    """
+    if isinstance(value, str):
+        return True
+    return isinstance(value, tuple) and all(isinstance(item, str) for item in value)
+
+
 class StartsWith(_SafeValidator):
     """Require a string to start with a given prefix."""
 
     def __init__(self, prefix: str, msg: str | None = None) -> None:
-        """Store the required prefix."""
+        """Store the required prefix, rejecting a non-string one at build time."""
+        if not _is_affix(prefix):
+            message = "StartsWith prefix must be a string or a tuple of strings"
+            raise SchemaError(message)
         self.prefix = prefix
         self.msg = msg
 
@@ -132,7 +147,10 @@ class EndsWith(_SafeValidator):
     """Require a string to end with a given suffix."""
 
     def __init__(self, suffix: str, msg: str | None = None) -> None:
-        """Store the required suffix."""
+        """Store the required suffix, rejecting a non-string one at build time."""
+        if not _is_affix(suffix):
+            message = "EndsWith suffix must be a string or a tuple of strings"
+            raise SchemaError(message)
         self.suffix = suffix
         self.msg = msg
 
@@ -173,9 +191,17 @@ class ByteLength(_SafeValidator):
         # ``surrogatepass`` so a lone surrogate (``'\ud800'``) is measured rather
         # than leaking a UnicodeEncodeError.
         size = len(value.encode("utf-8", "surrogatepass"))
-        if (self.min is not None and size < self.min) or (
-            self.max is not None and size > self.max
-        ):
+        try:
+            out_of_bounds = (self.min is not None and size < self.min) or (
+                self.max is not None and size > self.max
+            )
+        except TypeError as exc:
+            # A non-numeric bound makes the comparison raise; report it cleanly like
+            # Range does, rather than leak the TypeError.
+            raise LengthInvalid(
+                self.msg, translation_key="invalid_value_or_type"
+            ) from exc
+        if out_of_bounds:
             raise LengthInvalid(self.msg, translation_key="byte_length_out_of_bounds")
 
         return value
@@ -203,8 +229,30 @@ class Match(_SafeValidator):
     """Require a string to match a regular expression."""
 
     def __init__(self, pattern: typing.Any, msg: str | None = None) -> None:
-        """Compile ``pattern`` (read its source as ``.pattern.pattern``)."""
-        self.pattern = re.compile(pattern) if isinstance(pattern, str) else pattern
+        """Compile ``pattern`` (read its source as ``.pattern.pattern``).
+
+        A ``str`` or ``bytes`` pattern is compiled now, so an invalid regular
+        expression is a build-time ``SchemaError`` rather than a leaked ``re.error``;
+        an already-compiled pattern is used as is. Anything else (an ``int``, a bare
+        object) would only fail later on ``.match``, so it is refused here.
+        """
+        if isinstance(pattern, str | bytes):
+            try:
+                self.pattern = re.compile(pattern)
+            except re.error as exc:
+                message = (
+                    f"Match pattern {pattern!r} is not a valid regular expression: "
+                    f"{exc}"
+                )
+                raise SchemaError(message) from exc
+        elif isinstance(pattern, re.Pattern):
+            self.pattern = pattern
+        else:
+            message = (
+                "Match pattern must be a string, bytes, or a compiled regular "
+                "expression"
+            )
+            raise SchemaError(message)
         self.msg = msg
 
     def __repr__(self) -> str:

--- a/tests/validators/test_comparison.py
+++ b/tests/validators/test_comparison.py
@@ -147,6 +147,13 @@ def test_length_bounds() -> None:
         Schema(Length(max=2))("abc")
 
 
+def test_length_with_a_non_numeric_bound_is_invalid_not_a_leak() -> None:
+    """A non-numeric bound makes the comparison fail cleanly, like Range, not leak."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Length(min="x"))("abc")
+    assert isinstance(caught.value.errors[0], LengthInvalid)
+
+
 def test_length_without_bounds_never_measures() -> None:
     """With no bound set, Length passes any value, even one without a length."""
     assert Schema(Length())(0.0) == 0.0

--- a/tests/validators/test_comparison.py
+++ b/tests/validators/test_comparison.py
@@ -147,10 +147,11 @@ def test_length_bounds() -> None:
         Schema(Length(max=2))("abc")
 
 
-def test_length_with_a_non_numeric_bound_is_invalid_not_a_leak() -> None:
-    """A non-numeric bound makes the comparison fail cleanly, like Range, not leak."""
+@pytest.mark.parametrize("bound", ["x", Decimal("NaN")])
+def test_length_with_a_bad_bound_is_invalid_not_a_leak(bound: object) -> None:
+    """A bad bound (a str TypeError, a Decimal NaN ArithmeticError) is clean, not a leak."""
     with pytest.raises(MultipleInvalid) as caught:
-        Schema(Length(min="x"))("abc")
+        Schema(Length(min=bound))("abc")
     assert isinstance(caught.value.errors[0], LengthInvalid)
 
 

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from probatio import (
@@ -279,10 +281,11 @@ def test_byte_length() -> None:
         Schema(ByteLength(min=1))(123)
 
 
-def test_byte_length_with_a_non_numeric_bound_is_invalid_not_a_leak() -> None:
-    """A non-numeric bound makes the comparison fail cleanly, like Range, not leak."""
+@pytest.mark.parametrize("bound", ["x", Decimal("NaN")])
+def test_byte_length_with_a_bad_bound_is_invalid_not_a_leak(bound: object) -> None:
+    """A bad bound (a str TypeError, a Decimal NaN ArithmeticError) is clean, not a leak."""
     with pytest.raises(MultipleInvalid) as caught:
-        Schema(ByteLength(min="x"))("abc")
+        Schema(ByteLength(min=bound))("abc")
     assert isinstance(caught.value.errors[0], LengthInvalid)
 
 

--- a/tests/validators/test_strings.py
+++ b/tests/validators/test_strings.py
@@ -32,6 +32,7 @@ from probatio import (
 )
 from probatio.error import (
     EmailInvalid,
+    LengthInvalid,
     MatchInvalid,
     SchemaError,
     SlugInvalid,
@@ -97,6 +98,21 @@ def test_match_on_non_string() -> None:
 def test_match_exposes_the_pattern_source() -> None:
     """Match keeps a compiled pattern whose source is readable."""
     assert Match(r"^\d+$").pattern.pattern == r"^\d+$"
+
+
+def test_match_accepts_a_compiled_or_bytes_pattern() -> None:
+    """A pre-compiled pattern is used as is, and a bytes pattern is compiled."""
+    import re  # noqa: PLC0415
+
+    assert Schema(Match(re.compile(r"^\d+$")))("123") == "123"
+    assert Match(rb"\d+").pattern.pattern == rb"\d+"
+
+
+@pytest.mark.parametrize("pattern", [123, object(), r"("])
+def test_match_rejects_a_bad_pattern_at_build(pattern: object) -> None:
+    """A non-pattern arg, or an invalid regular expression, is a build-time SchemaError."""
+    with pytest.raises(SchemaError):
+        Match(pattern)
 
 
 def test_email_accepts_and_rejects() -> None:
@@ -234,6 +250,21 @@ def test_starts_with_and_ends_with() -> None:
         Schema(EndsWith(".txt"))(123)
 
 
+def test_starts_with_and_ends_with_accept_a_tuple_of_strings() -> None:
+    """A tuple of prefixes/suffixes is accepted (str.startswith/endswith allow it)."""
+    assert Schema(StartsWith(("http://", "https://")))("https://x") == "https://x"
+    assert Schema(EndsWith((".txt", ".md")))("a.md") == "a.md"
+
+
+@pytest.mark.parametrize("affix", [123, None, ("a", 1)])
+def test_starts_with_rejects_a_non_string_affix_at_build(affix: object) -> None:
+    """A non-string prefix/suffix is a schema definition error, not a call-time TypeError."""
+    with pytest.raises(SchemaError):
+        StartsWith(affix)
+    with pytest.raises(SchemaError):
+        EndsWith(affix)
+
+
 def test_byte_length() -> None:
     """ByteLength bounds the UTF-8 byte length, not the code-point count."""
     assert Schema(ByteLength(min=1, max=3))("ab") == "ab"
@@ -246,6 +277,13 @@ def test_byte_length() -> None:
         Schema(ByteLength(min=2))("a")
     with pytest.raises(MultipleInvalid):
         Schema(ByteLength(min=1))(123)
+
+
+def test_byte_length_with_a_non_numeric_bound_is_invalid_not_a_leak() -> None:
+    """A non-numeric bound makes the comparison fail cleanly, like Range, not leak."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(ByteLength(min="x"))("abc")
+    assert isinstance(caught.value.errors[0], LengthInvalid)
 
 
 @pytest.mark.parametrize("value", ["#abc", "#ff8800"])


### PR DESCRIPTION
## Breaking change

Narrow, and each turns a latent crash or silent breakage into an explicit error:

- `StartsWith`/`EndsWith` with a non-string prefix/suffix, and `Match` with a non-pattern arg or an invalid regular expression, now raise `SchemaError` at construction instead of a raw exception (or nothing) at validation time.
- `Match` now compiles a `bytes` pattern (previously stored uncompiled and broken on the first call).

## Proposed change

The validators subsystem review found a class of constructor-argument bugs where a wrong-typed arg surfaces as a raw `TypeError`/`AttributeError`/`re.error` during validation, rather than a clean error when the schema is built. Each is fixed with the pattern that fits its validator:

Fixed-arg validators fail fast at build, consistent with `Replace` and `MultipleOf`:

- `StartsWith`/`EndsWith` reject a non-string prefix/suffix at construction. A tuple of strings stays valid, since `str.startswith`/`endswith` accept it.
- `Match` rejects a non-pattern arg, and catches an invalid regular expression at build (previously a leaked `re.error` on the first matching value). It now also compiles a `bytes` pattern instead of storing it uncompiled and broken.

Bounded validators guard the comparison at call, consistent with their sibling `Range`:

- `Length` and `ByteLength` report a non-numeric bound as `invalid_value_or_type` (the same translation key `Range` already uses) instead of leaking a `TypeError`. `Length` is included alongside the flagged `ByteLength` because it has the identical bug; leaving it would be an obvious inconsistency, and guarding at call (rather than validating at build) keeps all three bounded validators handling a bad bound the same way.

This is the last slice of the validators review (following #157, #158, #159).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the validators subsystem review (#157, #158, #159)

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
