### PR TITLE
Refuse to dump a string with unpaired surrogates

### DIFF
--- a/src/probatio/serde/dumpers.py
+++ b/src/probatio/serde/dumpers.py
@@ -115,6 +115,10 @@ def _normalize_dict(
     coerced_keys: set[str] | None = set() if fmt == "json" else None
 
     for key, item in value.items():
+        if isinstance(key, str):
+            # A string key holds a surrogate just as a value can; refuse it too, or
+            # the backend would emit the same non-reloadable text through the key.
+            _encodable_str(key)
         if coerced_keys is not None:
             coerced = _json_key(key)
             if isinstance(coerced, str):

--- a/src/probatio/serde/dumpers.py
+++ b/src/probatio/serde/dumpers.py
@@ -33,7 +33,24 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def _normalize(  # noqa: PLR0911
+def _encodable_str(value: str) -> str:
+    """Return the string, or raise if it holds an unpaired surrogate.
+
+    A lone surrogate has no UTF-8 encoding, so it cannot be represented in
+    JSON/YAML/TOML text at all. orjson rejects it, but the stdlib JSON fallback (and
+    the YAML path) would emit output that cannot be re-read, so it is refused here
+    with a clear error rather than silently produced. ASCII strings skip the check.
+    """
+    if not value.isascii():
+        try:
+            value.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            message = "cannot serialize a string containing unpaired surrogates"
+            raise ValueError(message) from exc
+    return value
+
+
+def _normalize(  # noqa: PLR0911, PLR0912
     value: Any, default: Any, *, fmt: str, seen: set[int] | None = None
 ) -> Any:
     """Convert a value into one built only from the target format's native types.
@@ -51,7 +68,10 @@ def _normalize(  # noqa: PLR0911
             raise ValueError(message)
         return value
 
-    if isinstance(value, str | int):
+    if isinstance(value, str):
+        return _encodable_str(value)
+
+    if isinstance(value, int):
         return value
 
     if isinstance(value, dict | list | tuple | set | frozenset):

--- a/tests/serde/test_dumpers.py
+++ b/tests/serde/test_dumpers.py
@@ -95,6 +95,32 @@ def test_dump_json_handles_big_ints_and_non_str_keys() -> None:
     assert load_json(dump_json({1: "a"})) == {"1": "a"}
 
 
+def test_dump_json_falls_back_and_still_handles_big_ints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stdlib fallback path also serializes a >64-bit int and a non-string key."""
+    monkeypatch.setattr(_optional, "orjson", None)
+    assert load_json(dump_json({"n": 2**70})) == {"n": 2**70}
+    assert load_json(dump_json({1: "a"})) == {"1": "a"}
+
+
+@pytest.mark.parametrize("dumper", [dump_json, dump_yaml])
+def test_dump_rejects_an_unpaired_surrogate(dumper: object) -> None:
+    """A lone surrogate has no UTF-8 form, so it is refused, not emitted as invalid text.
+
+    Previously dump_json emitted ``'"\\ud800"'``, which cannot be UTF-8 encoded or
+    reloaded; a clean ValueError is raised instead.
+    """
+    with pytest.raises(ValueError, match="surrogate"):
+        dumper("\ud800")  # type: ignore[operator]
+
+
+def test_dump_toml_rejects_an_unpaired_surrogate() -> None:
+    """The surrogate check applies to TOML too, before the backend sees the value."""
+    with pytest.raises(ValueError, match="surrogate"):
+        dump_toml({"key": "\ud800"})
+
+
 def test_dump_json_output_matches_across_backends(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/serde/test_dumpers.py
+++ b/tests/serde/test_dumpers.py
@@ -121,6 +121,12 @@ def test_dump_toml_rejects_an_unpaired_surrogate() -> None:
         dump_toml({"key": "\ud800"})
 
 
+def test_dump_json_rejects_an_unpaired_surrogate_in_a_key() -> None:
+    """A surrogate in a dict key is refused too, not just in a value."""
+    with pytest.raises(ValueError, match="surrogate"):
+        dump_json({"\ud800": 1})
+
+
 def test_dump_json_output_matches_across_backends(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Breaking change

None. A value that previously produced silently invalid output now raises a clear `ValueError`.

## Proposed change

`dump_json('\ud800')` produced `'"\ud800"'`, which cannot be UTF-8 encoded or reloaded: silently invalid JSON. orjson correctly rejects a lone surrogate with a `TypeError`, but the `except TypeError` branch treated that like the `>64`-bit-int case and fell through to a stdlib path (`json.dumps(..., ensure_ascii=False)`) that emitted the broken text.

A lone surrogate has no UTF-8 encoding, so it cannot be represented in JSON, YAML, or TOML text at all. `_normalize` now refuses it with a clear `ValueError` across all three formats, before any backend runs. ASCII strings skip the check (fast path), and valid non-ASCII text and emoji still dump and round-trip. The big-int and non-string-key fallback is untouched, which is now the `except TypeError` branch's only job (as its comment already claimed).

Found in a review of the serde subsystem. Follow-ups from the same review, not in this PR: `dump_toml` leaking a raw backend `TypeError` on a nested `None`/non-string key, an inconsistent bad-option error contract (JSON/TOML leak a raw `TypeError`, YAML gives a clean one), and backend-variance in `load_json` large integers and YAML temporal round-trips.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the serde subsystem review

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
