### PR TITLE
Give dump_toml clean errors for None and non-string keys

### DIFF
--- a/src/probatio/serde/dumpers.py
+++ b/src/probatio/serde/dumpers.py
@@ -59,7 +59,18 @@ def _normalize(  # noqa: PLR0911, PLR0912
     structure fails with a clean ``ValueError`` instead of recursing until the
     interpreter raises ``RecursionError`` (or hangs a backend).
     """
-    if isinstance(value, bool) or value is None:
+    if value is None:
+        if fmt == "toml":
+            # TOML has no null, so None is unrepresentable anywhere, not only at the
+            # top level; refuse it here with a clear message rather than let tomli-w
+            # leak a raw TypeError from deep in a nested table.
+            message = (
+                "TOML cannot represent None; omit the key or use a different format"
+            )
+            raise ValueError(message)
+        return value
+
+    if isinstance(value, bool):
         return value
 
     if isinstance(value, float):
@@ -119,6 +130,11 @@ def _normalize_dict(
             # A string key holds a surrogate just as a value can; refuse it too, or
             # the backend would emit the same non-reloadable text through the key.
             _encodable_str(key)
+        elif fmt == "toml":
+            # TOML keys are always strings; a non-string key would leak a cryptic
+            # tomli-w error (JSON coerces one to a string instead, below).
+            message = f"TOML mapping keys must be strings, got {type(key).__name__}"
+            raise TypeError(message)
         if coerced_keys is not None:
             coerced = _json_key(key)
             if isinstance(coerced, str):

--- a/tests/serde/test_dumpers.py
+++ b/tests/serde/test_dumpers.py
@@ -208,11 +208,25 @@ def test_dump_toml_preserves_native_temporal_types() -> None:
     assert isinstance(parsed["at"], datetime.time)
 
 
-@pytest.mark.parametrize("value", [None, 5, [1, 2]])
+@pytest.mark.parametrize("value", [5, [1, 2]])
 def test_dump_toml_rejects_non_mapping_top_level(value: Any) -> None:
     """A TOML document is a table, so a bare scalar or list is refused clearly."""
     with pytest.raises(TypeError, match="top level"):
         dump_toml(value)
+
+
+@pytest.mark.parametrize("value", [None, {"a": None}, {"a": {"b": None}}])
+def test_dump_toml_rejects_none_anywhere(value: Any) -> None:
+    """TOML has no null, so a None value at any depth is refused, not leaked."""
+    with pytest.raises(ValueError, match="cannot represent None"):
+        dump_toml(value)
+
+
+@pytest.mark.parametrize("key", [1, (1, 2), None])
+def test_dump_toml_rejects_a_non_string_key(key: Any) -> None:
+    """TOML keys must be strings; a non-string key is refused, not a cryptic leak."""
+    with pytest.raises(TypeError, match="keys must be strings"):
+        dump_toml({key: "x"})
 
 
 def test_dump_toml_without_a_dumper(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Breaking change

One narrow message change: `dump_toml(None)` now raises `ValueError` ("TOML cannot represent None") instead of the previous `TypeError` ("top level"). Both are clean errors; the new one is more accurate. All other changes turn a leaked backend error into a clear one.

## Proposed change

`dump_toml` guards the top-level type (a document must be a table), but leaked raw `tomli-w` errors for two cases that reach the backend:

- **A `None` value nested anywhere** (`{"a": {"b": None}}`) leaked `TypeError: Object of type 'NoneType' is not TOML serializable`. TOML has no null, so `_normalize` now refuses `None` at any depth with a clear `ValueError`.
- **A non-string mapping key** (`{(1, 2): "x"}`, `{1: "x"}`) leaked a cryptic tomli-w message (`can only concatenate str (not "tuple") to str`). TOML keys must be strings, so a non-string key is refused with a `TypeError` naming the type. JSON still coerces a non-string key to a string, unchanged.

Found in the serde subsystem review, following #161.

Out of scope (deliberately): the low-severity, developer-error case where a bad backend *option* leaks a raw `TypeError` from the JSON/TOML paths while the YAML path gives a clean `ValueError`. Routing the JSON path through the existing `_forward_options` helper is fiddly because of the internal `parse_constant`, and it is not an untrusted-input path, so it was not worth the churn.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the serde subsystem review (#161)

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
