### PR TITLE
Keep large integers exact in load_json regardless of backend

### DIFF
--- a/src/probatio/serde/loaders.py
+++ b/src/probatio/serde/loaders.py
@@ -23,6 +23,7 @@ invisible implementation detail.
 from __future__ import annotations
 
 import json
+import re
 import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -33,6 +34,22 @@ from probatio.serde._config import effective_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+# A run of 19 or more digits may be an integer orjson would coerce to a float and
+# lose precision: 2**63 (the signed 64-bit floor a negative literal can cross) has
+# 19 digits, so any shorter run always fits. A match is a cheap, conservative
+# trigger to parse with the arbitrary-precision standard library instead of orjson;
+# it may over-trigger on a long digit run inside a string or a float, which only
+# means the exact-but-slower path runs, never a wrong result.
+_LONG_DIGIT_RUN_STR = re.compile(r"\d{19,}")
+_LONG_DIGIT_RUN_BYTES = re.compile(rb"\d{19,}")
+
+
+def _may_hold_a_big_int(data: str | bytes) -> bool:
+    """Whether the JSON text has a digit run long enough to risk orjson's float coercion."""
+    if isinstance(data, bytes):
+        return _LONG_DIGIT_RUN_BYTES.search(data) is not None
+    return _LONG_DIGIT_RUN_STR.search(data) is not None
 
 
 def _read(source: Any) -> Any:
@@ -108,7 +125,11 @@ def load_json(source: Any, *, options: dict[str, Any] | None = None) -> Any:
         merged: dict[str, Any] = {"parse_constant": _reject_json_constant, **opts}
         return json.loads(data, **merged)
 
-    if _optional.orjson is not None:
+    # orjson coerces an integer >= 2**64 to a float, silently losing precision,
+    # where the standard library keeps arbitrary-precision ints. So a document that
+    # might carry a big integer is parsed by the standard library instead, keeping
+    # the same result regardless of which backend is installed.
+    if _optional.orjson is not None and not _may_hold_a_big_int(data):
         return _optional.orjson.loads(data)
 
     # The standard library accepts the JavaScript constants NaN/Infinity/-Infinity by

--- a/tests/serde/test_loaders.py
+++ b/tests/serde/test_loaders.py
@@ -81,6 +81,38 @@ def test_load_json_falls_back_to_stdlib(monkeypatch: pytest.MonkeyPatch) -> None
     assert load_json('{"a": 1}') == {"a": 1}
 
 
+@pytest.mark.parametrize("with_orjson", [True, False])
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "18446744073709551616",  # 2**64, the first positive value orjson floats
+        "100000000000000000000000000000000000000",  # 10**38
+        "-9223372036854775809",  # one past the signed 64-bit floor
+    ],
+)
+def test_load_json_keeps_big_integers_exact_on_both_paths(
+    literal: str,
+    *,
+    with_orjson: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An integer past 64 bits stays an exact int, not a float, with or without orjson.
+
+    orjson coerces such a value to a float; the loader detects a long digit run and
+    parses with the standard library, so the result is the same either way.
+    """
+    if not with_orjson:
+        monkeypatch.setattr(_optional, "orjson", None)
+    result = load_json(f'{{"n": {literal}}}')
+    assert result == {"n": int(literal)}
+    assert isinstance(result["n"], int)
+
+
+def test_load_json_long_digit_string_is_not_misparsed() -> None:
+    """A 19+ digit run inside a string only triggers the stdlib path, not a wrong value."""
+    assert load_json('{"id": "1234567890123456789"}') == {"id": "1234567890123456789"}
+
+
 @pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
 @pytest.mark.parametrize("with_orjson", [True, False])
 def test_load_json_rejects_non_standard_constants(


### PR DESCRIPTION
## Breaking change

None. An integer >= 2**64 that previously loaded as a `float` under orjson now loads as an exact `int`, matching the standard-library backend and the value in the source text.

## Proposed change

orjson coerces an integer >= 2**64 to a `float`, silently losing precision, while the standard library keeps arbitrary-precision ints. So the same JSON document parsed a big integer differently depending on which backend was installed, breaking the module's "invisible backend" promise (loaders.py:20) and corrupting large IDs or amounts.

`load_json` now checks the raw text for a run of 19 or more digits (`2**63` has 19 digits, so anything shorter always fits a 64-bit int) and, when found, parses with the standard library instead of orjson. So an integer past 64 bits stays an exact `int` regardless of which backend is installed, closing the divergence rather than documenting it.

The trigger is deliberately conservative: it may over-fire on a long digit run inside a string or a float, but that only runs the exact-but-slightly-slower stdlib path, never a wrong result. Standard-library JSON is the fallback (not YAMLRocks, which also preserves big ints but would risk reintroducing a JSON-vs-YAML divergence); NaN/Infinity rejection still applies on that path via `parse_constant`.

Third and last item from the serde review (following #161 and #162). The remaining known backend-variance item, YAML temporal round-trip depending on the dump/load backend pair, is a separate, smaller change.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the serde subsystem review (#161, #162)

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
