### PR TITLE
Honor inherited TypedDict totality from __required_keys__

### DIFF
--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -1089,14 +1089,16 @@ class DataclassSchema[DataclassT](Schema):
 
 
 def _typeddict_presence(
-    annotation: TypingAny, *, total: bool
+    annotation: TypingAny, *, default_required: bool
 ) -> tuple[bool, TypingAny]:
     """Read a TypedDict field's required-ness and strip its Required/NotRequired.
 
     ``Required``/``NotRequired`` may wrap the whole annotation or sit inside an
     ``Annotated`` (``Annotated[NotRequired[int], Key(...)]``). Handle both, returning
     the presence and the annotation with the qualifier removed but the ``Annotated``
-    metadata (a ``Key``, a value validator) kept, so it is still read.
+    metadata (a ``Key``, a value validator) kept, so it is still read. Without such a
+    wrapper the field keeps ``default_required``, the presence its class and totality
+    already imply.
     """
     origin = get_origin(annotation)
     if origin is RequiredHint:
@@ -1110,7 +1112,7 @@ def _typeddict_presence(
             return True, Annotated[(get_args(base)[0], *meta)]
         if base_origin is NotRequired:
             return False, Annotated[(get_args(base)[0], *meta)]
-    return total, annotation
+    return default_required, annotation
 
 
 def _typeddict_mapping(
@@ -1127,16 +1129,19 @@ def _typeddict_mapping(
         message = f"cannot resolve type hints for {typeddict_type.__name__!r}: {exc}"
         raise SchemaError(message) from exc
 
-    # Required-ness is read from each resolved annotation, not from
-    # ``__required_keys__``: under ``from __future__ import annotations`` the
-    # annotations are strings at class-creation time, so ``__required_keys__``
-    # cannot see a ``Required``/``NotRequired`` wrapper and comes out wrong. A
-    # field with an explicit wrapper takes it; otherwise the TypedDict's ``total``
-    # decides.
-    total = typeddict_type.__total__
+    # A field's presence comes from two sources, in order. An explicit
+    # ``Required``/``NotRequired`` wrapper on the resolved annotation wins, and it is
+    # the only one ``__required_keys__`` misses: under ``from __future__ import
+    # annotations`` the wrapper is a string at class-creation time, so Python cannot
+    # see it. Otherwise ``__required_keys__`` decides, which stays correct across
+    # inheritance and per-base ``total`` where the class's own ``__total__`` does not
+    # (a required field inherited into a ``total=False`` child, and the reverse).
+    required_keys = typeddict_type.__required_keys__
     mapping: dict[TypingAny, TypingAny] = {}
     for name, annotation in hints.items():
-        required, field_type = _typeddict_presence(annotation, total=total)
+        required, field_type = _typeddict_presence(
+            annotation, default_required=name in required_keys
+        )
         value_schema = _annotation_to_schema(field_type, self_refs)
         if name in constraints:
             value_schema = All(value_schema, constraints[name])

--- a/tests/test_typeddict_schema.py
+++ b/tests/test_typeddict_schema.py
@@ -96,6 +96,48 @@ def test_not_required_makes_a_field_optional() -> None:
     assert TypedDictSchema(Mixed)({"x": 1}) == {"x": 1}
 
 
+class _TotalBase(TypedDict):
+    """A total base: its field is required."""
+
+    a: int
+
+
+class InheritsIntoPartial(_TotalBase, total=False):
+    """A total=False child of a total base: b is optional, a stays required."""
+
+    b: str
+
+
+def test_required_field_inherited_into_a_partial_child_stays_required() -> None:
+    """A required base field keeps its presence under a total=False child."""
+    schema = TypedDictSchema(InheritsIntoPartial)
+    assert schema({"a": 1}) == {"a": 1}  # b is optional
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"b": "x"})  # a is inherited-required, not optional
+    assert caught.value.errors[0].path == ["a"]
+
+
+class _PartialBase(TypedDict, total=False):
+    """A total=False base: its field is optional."""
+
+    x: int
+
+
+class InheritsIntoTotal(_PartialBase):
+    """A total child of a total=False base: y is required, x stays optional."""
+
+    y: int
+
+
+def test_optional_field_inherited_into_a_total_child_stays_optional() -> None:
+    """An optional base field keeps its presence under a total child."""
+    schema = TypedDictSchema(InheritsIntoTotal)
+    assert schema({"y": 1}) == {"y": 1}  # x is inherited-optional, not required
+    with pytest.raises(MultipleInvalid) as caught:
+        schema({"x": 1})  # y is required
+    assert caught.value.errors[0].path == ["y"]
+
+
 class Inner(TypedDict):
     """A nested TypedDict."""
 


### PR DESCRIPTION
## Breaking change

None. This corrects wrong behavior; no API changes.

## Proposed change

A `TypedDictSchema` read each field's required-ness from the class's own `__total__`, applied uniformly to every field. That is wrong under inheritance, because totality is per-defining-class:

- A required field inherited into a `total=False` child was treated as optional, so a missing required key silently passed validation.
- An optional field inherited into a `total=True` child was treated as required, so valid input was wrongly rejected.

```python
class Base(TypedDict):            # total=True
    a: int
class Child(Base, total=False):   # b optional; a must stay required
    b: str

TypedDictSchema(Child)({"b": "x"})   # was ACCEPTED; 'a' is required
```

Python's `__required_keys__` already resolves inheritance and per-base totality correctly, so this uses it for each field's default presence. An explicit `Required[]`/`NotRequired[]` wrapper still wins: that is the one case `__required_keys__` misses under `from __future__ import annotations` (the wrapper is a string at class-creation time), and `_typeddict_presence` recovers it from the resolved annotation via `include_extras`. So both inheritance and future-annotations wrappers are now correct.

Found during a review sweep of `dataclass_schema.py`, which has no voluptuous parity oracle behind it. Two tests cover both inheritance directions; the existing wrapper tests confirm the explicit-wrapper path is unaffected.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: the dataclass/TypedDict builder review
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
