### PR TITLE
Reject a validator used as a parameter annotation in @probatio

### DIFF
--- a/src/probatio/decorator.py
+++ b/src/probatio/decorator.py
@@ -52,6 +52,35 @@ def _name(func: typing.Callable[..., typing.Any]) -> str:
     return getattr(func, "__name__", repr(func))
 
 
+def _reject_validator_annotation(
+    func: typing.Callable[..., typing.Any],
+    where: str,
+    annotation: typing.Any,
+    inferred: typing.Any,
+) -> None:
+    """Reject a validator used where a *type* annotation is expected.
+
+    An annotation is mapped like a dataclass field: a type says what the value is.
+    A validator instance (``Range(min=0)``), a ``Schema``, or a bare function is not
+    a type, so ``_annotation_to_schema`` cannot read it and falls back to ``object``
+    (accept anything), which would silently drop all validation. That is almost
+    never what the writer meant, so name the mistake and point at the two places a
+    validator belongs: the ``constraints`` map, or ``Annotated[type, validator]``.
+
+    Gated on the fallback actually firing (``inferred is object``), so an annotation
+    that is callable yet handled, a ``NewType`` (followed to its supertype), a bare
+    type (constructs, so it *is* a type), is left alone. ``typing.Any`` reaches
+    ``object`` too, but on purpose and not callable, so it is not caught.
+    """
+    if inferred is object and callable(annotation) and not isinstance(annotation, type):
+        message = (
+            f"probatio: {where} of {_name(func)!r} is annotated with a validator "
+            f"({annotation!r}), but an annotation must be a type. Put the validator "
+            f"in constraints, or use Annotated[type, validator]."
+        )
+        raise SchemaError(message)
+
+
 def _check_constraints(
     func: typing.Callable[..., typing.Any],
     constraints: dict[str, typing.Any],
@@ -103,6 +132,7 @@ def _resolve_hints(
 
 
 def _parameter_schema(
+    func: typing.Callable[..., typing.Any],
     signature: inspect.Signature,
     constraints: dict[str, typing.Any],
     hints: dict[str, typing.Any],
@@ -117,7 +147,13 @@ def _parameter_schema(
     for name, parameter in signature.parameters.items():
         if parameter.kind not in _VALIDATED_KINDS:
             continue
-        inferred = _annotation_to_schema(hints[name], {}) if name in hints else _UNSET
+        if name in hints:
+            inferred = _annotation_to_schema(hints[name], {})
+            _reject_validator_annotation(
+                func, f"parameter {name!r}", hints[name], inferred
+            )
+        else:
+            inferred = _UNSET
         extra = constraints.get(name, _UNSET)
         if inferred is not _UNSET and extra is not _UNSET:
             mapping[name] = All(inferred, extra)
@@ -146,7 +182,9 @@ def _return_schema(
                 f"probatio: returns=True needs a return annotation on {_name(func)!r}"
             )
             raise SchemaError(message)
-        return Schema(_annotation_to_schema(hints[_RETURN], {}))
+        inferred = _annotation_to_schema(hints[_RETURN], {})
+        _reject_validator_annotation(func, "the return", hints[_RETURN], inferred)
+        return Schema(inferred)
     return Schema(returns)
 
 
@@ -219,7 +257,7 @@ def _decorate[**P, R](
         needed.add(_RETURN)
     hints = _resolve_hints(func, needed)
 
-    parameter_schema = _parameter_schema(signature, constraints, hints)
+    parameter_schema = _parameter_schema(func, signature, constraints, hints)
     input_schema: typing.Callable[[typing.Any], typing.Any] = (
         Schema(parameter_schema, extra=ALLOW_EXTRA) if parameter_schema else _identity
     )

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, NewType
 
 import pytest
 
@@ -303,6 +303,41 @@ def test_annotation_that_cannot_resolve_is_a_schema_error() -> None:
 
     with pytest.raises(SchemaError, match="cannot resolve"):
         probatio(f)
+
+
+def test_a_validator_as_a_parameter_annotation_is_rejected() -> None:
+    """A validator where a type belongs is a loud error, not silently accepted."""
+
+    def f(x: Range(min=0, max=10)) -> int:  # type: ignore[valid-type]
+        return x  # type: ignore[no-any-return]
+
+    with pytest.raises(SchemaError, match="annotated with a validator"):
+        probatio(f)
+
+
+def test_a_validator_as_the_return_annotation_is_rejected() -> None:
+    """A validator return annotation under returns=True is a loud error too."""
+
+    def f(x: int) -> Range(min=0):  # type: ignore[valid-type]
+        return x
+
+    with pytest.raises(SchemaError, match="annotated with a validator"):
+        probatio(returns=True)(f)
+
+
+_UserId = NewType("_UserId", int)
+
+
+def test_a_newtype_annotation_is_not_mistaken_for_a_validator() -> None:
+    """A NewType is callable and not a type, yet a valid annotation, so it is kept."""
+
+    @probatio
+    def f(x: _UserId) -> int:
+        return x
+
+    assert f(5) == 5
+    with pytest.raises(MultipleInvalid):
+        f("not an int")
 
 
 def test_empty_call_form() -> None:


### PR DESCRIPTION
## Breaking change

A call that used a validator directly as a parameter or return annotation used to be accepted and silently validated nothing; it now raises `SchemaError` at decoration time. That only rejects code that was already a silent no-op (and that `ty`/`mypy` flag as an invalid annotation), so nothing that actually validated changes behavior. The migration is to move the validator to `constraints=` or `Annotated[type, validator]`.

## Proposed change

The `@probatio` decorator maps each parameter annotation like a dataclass field: a type says what the value is. A validator instance (`Range(min=0)`), a `Schema`, or a bare function is not a type, so `_annotation_to_schema` could not read it and fell back to `object` (accept anything), silently dropping all validation:

```python
@probatio
def f(x: Range(min=0, max=10)):
    return x

f(999)   # returned 999 — no validation ran at all
```

That is an easy reach for someone coming from voluptuous's `@validate(x=Range(...))`, and a silent no-op is the worst failure mode.

This detects the `object` fallback firing on a callable non-type annotation (a parameter, or the `returns=True` return) and raises `SchemaError`, naming the mistake and pointing at the two places a validator belongs: the `constraints` map, or `Annotated[type, validator]` (both of which already work). The check is gated on `inferred is object`, so a `NewType` (followed to its supertype), a plain type, and `typing.Any` are left alone.

Found during a review sweep of the annotation-driven builders. The decorator is otherwise correct on its documented surface; this was the one silent-no-op edge.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: the annotation-driven builder review (follows #165)
- Link to a separate documentation pull request: None

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
