### PR TITLE
Add an opt-in lazy build policy that defers schema compilation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -118,6 +118,7 @@ export default defineConfig({
             },
             { label: "Recursive schemas", slug: "guides/recursive-schemas" },
             { label: "Compiled schemas", slug: "guides/compiled-schemas" },
+            { label: "Lazy building", slug: "guides/lazy-building" },
             { label: "Schemas from dataclasses", slug: "guides/dataclasses" },
             { label: "Schemas from TypedDicts", slug: "guides/typeddict" },
             { label: "JSON Schema", slug: "guides/json-schema" },

--- a/docs/src/content/docs/guides/lazy-building.md
+++ b/docs/src/content/docs/guides/lazy-building.md
@@ -1,0 +1,104 @@
+---
+title: Lazy building
+description: Defer a schema's compilation to first use, so schemas that are built but never validated cost nothing.
+---
+
+A `Schema` normally compiles its declaration into a validator the moment you build
+it. That is the right default: a malformed schema fails where it is written, the
+same as voluptuous. But some programs build far more schemas than they ever
+validate against. Home Assistant registers on the order of a thousand service
+schemas and a thousand websocket-command schemas at startup, and a given install
+exercises a small fraction of them. Every unused one still pays to compile, and
+holds its compiled validator tree in memory for the life of the process.
+
+Lazy building defers that work. Under the `LAZY` build policy a schema stores its
+declaration and compiles on the first validation instead of at construction, so a
+schema that is built but never validated never compiles and never holds a validator
+tree. It is opt-in: the default stays eager, so nothing changes unless you ask.
+
+## The default: eager
+
+The process starts on the `EAGER` policy. A schema compiles when you build it, and
+a definition error is raised right there, at construction, exactly as voluptuous
+does. This is the drop-in behavior, and for most programs it is what you want:
+schemas are a fixed set built once at import, and building them is cheap.
+
+```python
+from probatio import Schema, Required
+
+schema = Schema({Required("name"): str})  # compiled here, on this line
+schema({"name": "app"})  # {'name': 'app'}
+```
+
+## Opting into lazy
+
+Set the policy once, early, from deliberate startup code, before the schemas you
+want deferred are built. There is no environment variable on purpose: this is an
+architectural choice, not a deployment toggle.
+
+<!-- verify: skip -->
+
+```python
+from probatio import BuildPolicy, set_build_policy
+
+set_build_policy(BuildPolicy.LAZY)   # defer every eligible schema to first use
+set_build_policy(BuildPolicy.EAGER)  # the default: compile at construction
+```
+
+After `set_build_policy(BuildPolicy.LAZY)`, a schema you build does not compile
+until its first validation. A schema you build and never call never compiles at
+all, and never allocates its validator tree.
+
+<!-- verify: skip -->
+
+```python
+from probatio import Schema, Required, BuildPolicy, set_build_policy
+
+set_build_policy(BuildPolicy.LAZY)
+
+# Registered at startup; the walk is deferred.
+schema = Schema({Required("resource"): str})
+
+# ... much later, only if this command is ever invoked:
+schema({"resource": "sensor.sun"})  # compiles now, then validates
+```
+
+## What defers, and what does not
+
+Only a plain top-level `Schema` defers. Anything whose compiled form is needed at
+construction builds eagerly, even under `LAZY`, so laziness never leaves a
+half-built schema anywhere it would be read:
+
+- A **combinator branch** (`Any(...)`, `All(...)`) compiles its branches when the
+  combinator is built.
+- A **`DataclassSchema` or `TypedDictSchema`** builds at construction, since it
+  wires field validation (and, for a dataclass, instance construction) together
+  then.
+- A nested schema reused as a value builds when its parent is first validated.
+- An explicit `compile=` request, or `Schema.compile()`, builds now.
+
+Reading a lazy schema's declaration does not build it: `.schema`, `str()`,
+`.extend()`, and the codecs all work on the declaration, so introspection stays
+free.
+
+## The one trade: error timing
+
+Deferring the compile walk defers the errors it raises. Under `EAGER`, a malformed
+schema (a contradiction like two presence markers on one key, an alias colliding
+with another key) raises `SchemaError` at construction. Under `LAZY`, that same
+error raises on the **first validation** instead, because that is when the walk
+runs. The schema is just as wrong; you learn about it a moment later.
+
+For a program whose schemas are static and covered by tests, this is a non-issue,
+the tests validate, so a broken schema still fails in CI. But it is a real
+difference from voluptuous, which is why `LAZY` is opt-in and `EAGER` is the
+default. If you rely on construction-time schema errors, stay eager.
+
+## When to use it
+
+Reach for `LAZY` when you build many schemas at import but validate against only
+some of them in a given run: a large plugin surface, a command or service registry,
+per-feature validation that most installs never touch. The win is both time (the
+deferred walks never run) and memory (their validator trees never materialize),
+which matters most on a small device. If your schemas are a fixed set you validate
+against on every run, eager is simpler and there is nothing to gain.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -453,6 +453,19 @@ that process-wide (see [Compiled schemas](/guides/compiled-schemas/)):
 - `get_compile_policy()`: return the active policy.
 - `set_compile_policy(policy)`: set the process-wide policy.
 
+## Build policy
+
+Whether a schema compiles its declaration at construction or defers it to first
+validation; these names control that process-wide (see [Lazy
+building](/guides/lazy-building/)):
+
+- `BuildPolicy`: the policy enum: `EAGER` (the default, compile at construction,
+  matching voluptuous) and `LAZY` (defer to first validation, so a schema built but
+  never validated never compiles). Under `LAZY` a definition error raises at first
+  use rather than at construction.
+- `get_build_policy()`: return the active policy.
+- `set_build_policy(policy)`: set the process-wide policy.
+
 ## Loading and dumping
 
 Probatio validates parsed Python objects; parsing and serialization stay with the

--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from probatio._build_policy import (
+    BuildPolicy,
+    get_build_policy,
+    set_build_policy,
+)
 from probatio._compile_policy import (
     CompilePolicy,
     get_compile_policy,
@@ -319,6 +324,7 @@ __all__ = [
     "BlockDeviceInvalid",
     "Boolean",
     "BooleanInvalid",
+    "BuildPolicy",
     "Byte",
     "ByteLength",
     "Capitalize",
@@ -486,12 +492,14 @@ __all__ = [
     "default_factory",
     "from_json_schema",
     "from_openapi",
+    "get_build_policy",
     "get_compile_policy",
     "is_dataclass",
     "message",
     "probatio",
     "raises",
     "serialize",
+    "set_build_policy",
     "set_compile_policy",
     "to_json_schema",
     "to_openapi",

--- a/src/probatio/_build_policy.py
+++ b/src/probatio/_build_policy.py
@@ -1,0 +1,58 @@
+"""Process-wide policy for whether a ``Schema`` builds eagerly or on first use.
+
+A ``Schema`` normally compiles its declaration into a validator at construction
+(``EAGER``), matching voluptuous: a malformed schema raises ``SchemaError`` right
+where it is defined. ``LAZY`` defers that compile walk to the first validation, so
+a schema that is built but never validated, an unused service, trigger, condition,
+or websocket-command schema registered at startup, never pays to build and never
+holds its compiled validator tree in memory.
+
+The trade is error timing: under ``LAZY`` a malformed schema raises at first use,
+not at construction. So ``EAGER`` stays the default (the drop-in promise holds),
+and an application opts in with ``set_build_policy(LAZY)`` once, early, before it
+builds the schemas it wants deferred.
+
+Like the compile policy, this is set deliberately in code; there is no environment
+variable, on purpose. It is read at construction (the build decision cannot be
+deferred past the point the schema would otherwise build), so set it before the
+schemas you want lazy are created.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class BuildPolicy(Enum):
+    """The house policy for when a ``Schema`` compiles its declaration."""
+
+    # Build the validator at construction (voluptuous parity; errors at definition).
+    EAGER = "eager"
+    # Defer the build to first validation, so an unused schema never builds.
+    LAZY = "lazy"
+
+
+# The default the process starts with. EAGER so the drop-in promise holds: a
+# malformed schema raises where it is defined, exactly as voluptuous does.
+_DEFAULT_POLICY = BuildPolicy.EAGER
+_policy = _DEFAULT_POLICY
+
+
+def set_build_policy(policy: BuildPolicy) -> None:
+    """Set the process-wide build policy.
+
+    Call it once, early, from deliberate startup code, before the schemas you want
+    deferred are constructed. Raises ``TypeError`` for anything that is not a
+    ``BuildPolicy``, so a stray string fails loudly rather than silently disabling
+    lazy building.
+    """
+    if not isinstance(policy, BuildPolicy):
+        message = f"build policy must be a BuildPolicy, got {type(policy).__name__}"
+        raise TypeError(message)
+    global _policy  # noqa: PLW0603 - a single deliberate process-wide setting
+    _policy = policy
+
+
+def get_build_policy() -> BuildPolicy:
+    """Return the process-wide build policy currently in effect."""
+    return _policy

--- a/src/probatio/_compile.py
+++ b/src/probatio/_compile.py
@@ -636,6 +636,9 @@ def _compile_nested_schema(schema: Any) -> CompiledSchema | None:
     for a ``Self``-using inner, whose ``__call__`` records the active root that
     ``Self`` resolves against.
     """
+    # A lazily-deferred inner must build now: its ``_uses_self`` and engine are read
+    # here to decide the delegation, so a half-built one cannot be reasoned about.
+    schema._ensure_built()  # noqa: SLF001
     if _COMPILING_FOR_COMBINATOR.get() or schema._uses_self:  # noqa: SLF001
         return None
     # An armed schema parks its engine in ``_interpreted`` (``_compiled`` is the

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -119,6 +119,7 @@ class _RecursiveSchemaRef:
 
     def bind(self, schema: Schema) -> None:
         """Point the reference at the finished schema's compiled engine."""
+        schema._ensure_built()  # noqa: SLF001 - force a lazily-deferred inner to build
         self._validate = schema._compiled  # noqa: SLF001
 
     def __call__(self, data: TypingAny) -> TypingAny:
@@ -787,6 +788,9 @@ def _install_fused_interpreted(schema: Schema) -> None:
     ``_interpreted`` when the schema armed for lazy compilation (it then also
     becomes the generated code's bail-out fallback), else in ``_compiled``.
     """
+    # Force a lazily-deferred wrapper to build first, so its arming and engine are
+    # in place before the fused engine replaces the interpreted one.
+    schema._ensure_built()  # noqa: SLF001
     inner, constructor = schema.schema.validators
     if inner._uses_self:  # noqa: SLF001
         return

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -156,6 +156,17 @@ _BOOTSTRAP_LOCK = threading.Lock()
 _BUILD_LOCK = threading.RLock()
 
 
+def _not_built(data: Any) -> Any:  # noqa: ARG001  # pragma: no cover
+    """Stand in as a deferred schema's validator until it builds, and refuse to run.
+
+    Never called: ``__call__`` builds before dispatching, and every site that reads
+    ``_compiled`` directly forces a build first. It exists so a stray read is a loud
+    error, not a silent wrong answer.
+    """
+    message = "internal: a deferred schema's validator was read before it built"
+    raise SchemaError(message)
+
+
 class Schema:
     """A compiled, callable schema.
 
@@ -216,7 +227,10 @@ class Schema:
             and not _INTERNAL_BUILD.get()
             and get_build_policy() is BuildPolicy.LAZY
         ):
-            self._compiled = self._lazy_build
+            # Deferred: ``__call__`` builds on first validation, and the sites that
+            # read the compiled form directly force a build first. ``_compiled`` is a
+            # sentinel until then, so a stray read fails loudly instead of silently.
+            self._compiled = _not_built
         else:
             self._build()
 
@@ -254,16 +268,6 @@ class Schema:
                 if not self._built:  # pragma: no branch
                     self._build()
 
-    def _lazy_build(self, data: Any) -> Any:
-        """First-call stub for a lazy schema: build, then validate through the real path.
-
-        Re-enters ``self`` once the real validator is installed and ``_uses_self`` is
-        known, so recursion and error wrapping take the correct path; the active
-        context, if any, is still set on the enclosing frame and inherited here.
-        """
-        self._ensure_built()
-        return self(data)
-
     def __call__(self, data: Any, *, context: Any = _INHERIT_CONTEXT) -> Any:
         """Validate ``data``, returning the result or raising ``MultipleInvalid``.
 
@@ -274,6 +278,14 @@ class Schema:
         ``schema(data, context=None)`` clears an inherited context, where omitting
         it keeps it.
         """
+        # A deferred (LAZY) schema builds here, before anything reads ``_uses_self``
+        # or ``_compiled``, so the two stay consistent even when several threads race
+        # the first validation (the build is serialized by ``_BUILD_LOCK``). Under the
+        # default EAGER policy ``_built`` is already true, so this is one attribute
+        # read and costs nothing on the validation hot path.
+        if not self._built:
+            self._ensure_built()
+
         if context is not _INHERIT_CONTEXT:
             return self._call_with_context(data, context)
 

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -17,6 +17,7 @@ from contextvars import ContextVar
 from typing import Any
 
 from probatio import _compile as _compile_module
+from probatio._build_policy import BuildPolicy, get_build_policy
 from probatio._codegen import compile_mapping, compile_sequence
 from probatio._compile import (
     _ACTIVE_ROOT,
@@ -58,6 +59,15 @@ from probatio.markers import (
 _VALIDATION_CONTEXT: ContextVar[Any] = ContextVar(
     "probatio_validation_context",
     default=None,
+)
+
+# True while an internal builder (a combinator branch through ``compile_schema``, a
+# dataclass/TypedDict inner) constructs a ``Schema`` whose compiled form it reads
+# immediately. Such a schema must build eagerly even under the LAZY policy, so the
+# deferral applies only to a top-level user schema.
+_INTERNAL_BUILD: ContextVar[bool] = ContextVar(
+    "probatio_internal_build",
+    default=False,
 )
 
 
@@ -139,6 +149,12 @@ _AUTO_COMPILE_THRESHOLD = 50
 # their own. Concurrency is documented on the Performance page.
 _BOOTSTRAP_LOCK = threading.Lock()
 
+# Serializes a lazy schema's first build across threads. Reentrant, because building
+# one schema recursively forces any lazily-deferred nested schema to build (a nested
+# mapping reused as a value), which re-enters on the same thread; a plain lock would
+# deadlock there. Held only for the one-time build, never for validation.
+_BUILD_LOCK = threading.RLock()
+
 
 class Schema:
     """A compiled, callable schema.
@@ -146,6 +162,11 @@ class Schema:
     Build it from a type, a literal, a callable, or a nested ``Schema``, then
     call it with a value to validate that value.
     """
+
+    # The active validator: the compiled engine, the compile bootstrap, or, under
+    # the LAZY policy before first use, the ``_lazy_build`` stub (all callables of a
+    # value). Declared so every assignment site checks against the one type.
+    _compiled: CompiledSchema
 
     def __init__(
         self,
@@ -180,19 +201,68 @@ class Schema:
         # records an active root when validated, a contextvar that is not free, so
         # a non-recursive schema, the common case, skips that cost entirely.
         self._uses_self = False
-        # Mark self as the root while compiling, so a ``Self`` inside this schema
-        # resolves here. Tokens nest correctly, so a nested Schema restores the
-        # outer root on exit. The walk lives in ``_compile`` as free functions (so it
-        # can be accelerated on its own); a small context carries the two policies it
-        # reads and reports back whether a ``Self`` was seen.
-        ctx = CompileCtx(extra, required)
+        self._built = False
+        # Under the LAZY build policy a top-level user schema defers its compile walk
+        # to first validation, so one that is built but never validated (an unused
+        # service, trigger, or websocket schema registered at startup) never pays to
+        # build and never holds its validator tree. The default stays EAGER, so the
+        # drop-in promise holds: a malformed schema still raises where it is defined.
+        # Only a plain top-level schema defers; a combinator branch, a dataclass or
+        # TypedDict inner (``_INTERNAL_BUILD``), a subclass, or an explicit
+        # ``compile=`` request builds now, since their compiled form is read at once.
+        if (
+            type(self) is Schema
+            and compile is None
+            and not _INTERNAL_BUILD.get()
+            and get_build_policy() is BuildPolicy.LAZY
+        ):
+            self._compiled = self._lazy_build
+        else:
+            self._build()
+
+    def _build(self) -> None:
+        """Compile the declaration into the validator engine.
+
+        Split from ``__init__`` so the LAZY policy can defer it to first use. Marks
+        ``self`` the root while compiling, so a ``Self`` inside resolves here; tokens
+        nest, so a nested Schema restores the outer root on exit. The walk lives in
+        ``_compile`` as free functions; a small context carries the policies it reads
+        and reports back whether a ``Self`` was seen.
+        """
+        ctx = CompileCtx(self.extra, self.required)
         token = _COMPILING_ROOT.set(self)
         try:
-            self._compiled = compile_node(schema, ctx)
+            self._compiled = compile_node(self.schema, ctx)
         finally:
             _COMPILING_ROOT.reset(token)
         self._uses_self = ctx.uses_self
+        self._built = True
         self._arm_compile()
+
+    def _ensure_built(self) -> None:
+        """Force a lazily-deferred schema to build now; a no-op once built.
+
+        Called wherever the compiled form is needed directly (a nested schema being
+        compiled into a parent, ``compile()``), so laziness never leaks a half-built
+        schema. The lock serializes concurrent first-touches, like the compile
+        bootstrap; the double check keeps the built steady state lock-free.
+        """
+        if not self._built:
+            with _BUILD_LOCK:
+                # The re-check's false edge (another thread built it between the
+                # lock-free check and the lock) is reachable only under contention.
+                if not self._built:  # pragma: no branch
+                    self._build()
+
+    def _lazy_build(self, data: Any) -> Any:
+        """First-call stub for a lazy schema: build, then validate through the real path.
+
+        Re-enters ``self`` once the real validator is installed and ``_uses_self`` is
+        known, so recursion and error wrapping take the correct path; the active
+        context, if any, is still set on the enclosing frame and inherited here.
+        """
+        self._ensure_built()
+        return self(data)
 
     def __call__(self, data: Any, *, context: Any = _INHERIT_CONTEXT) -> Any:
         """Validate ``data``, returning the result or raising ``MultipleInvalid``.
@@ -264,6 +334,8 @@ class Schema:
         stays interpreted (and identical); only the speedup is lost.
         """
         self._compile_requested = True
+        # A lazily-deferred schema must build before it can be compiled from.
+        self._ensure_built()
         # Resolve now. A schema armed for lazy compilation keeps the interpreted
         # validator in ``_interpreted``; otherwise ``_compiled`` is still it. The
         # swap lands before ``_interpreted`` is dropped: a combinator holding the
@@ -568,11 +640,15 @@ def compile_schema(
     """
     # Flag the compile so a ``Self`` wrapped here (``Any(Self, ...)``) is deferred
     # to validation time rather than rejected as a bare ``Schema(Self)`` would be.
+    # ``_INTERNAL_BUILD`` forces the branch eager under the LAZY policy: the
+    # combinator reads its ``_compiled`` here and now, so it cannot be deferred.
     token = _COMPILING_FOR_COMBINATOR.set(True)
+    internal = _INTERNAL_BUILD.set(True)
     try:
         return Schema(schema, required=required, extra=extra)._compiled  # noqa: SLF001
     finally:
         _COMPILING_FOR_COMBINATOR.reset(token)
+        _INTERNAL_BUILD.reset(internal)
 
 
 # Register ``Schema`` with the compile walk, which lives in ``_compile`` and needs

--- a/tests/test_lazy_build.py
+++ b/tests/test_lazy_build.py
@@ -8,8 +8,9 @@ voluptuous parity), so these tests opt in per case and restore it after.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import pytest
 
@@ -30,9 +31,12 @@ from probatio import (
 )
 from probatio.error import MultipleInvalid, SchemaError
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def lazy() -> object:
+def lazy() -> Iterator[None]:
     """Run a test under the LAZY build policy, restoring EAGER afterwards."""
     set_build_policy(BuildPolicy.LAZY)
     try:
@@ -184,3 +188,33 @@ def test_ensure_built_is_idempotent() -> None:
     engine = schema._compiled
     schema({"a": 2})
     assert schema._compiled is engine
+
+
+@pytest.mark.usefixtures("lazy")
+def test_concurrent_first_validation_of_a_recursive_combinator_self_is_safe() -> None:
+    """Racing the first validation of a lazy recursive combinator-Self schema is safe.
+
+    ``__call__`` dispatches on ``_uses_self``, which a deferred build sets. If the
+    build were not serialized before that dispatch, a thread could read a stale
+    ``_uses_self`` and skip the active-root setup a combinator-deferred ``Self``
+    needs, raising instead of validating. Building in ``__call__`` closes that.
+    """
+    data = {"next": {"next": None}}
+    errors: list[Exception] = []
+    for _ in range(25):  # fresh instances widen the one-time first-call window
+        schema = Schema({Optional("next"): Any(Self, None)})
+        barrier = threading.Barrier(8)
+
+        def run(schema: Schema = schema, barrier: threading.Barrier = barrier) -> None:
+            barrier.wait()  # release all threads into the first call together
+            try:
+                assert schema(data) == data
+            except Exception as exc:  # noqa: BLE001 - any raise is the failure mode
+                errors.append(exc)
+
+        threads = [threading.Thread(target=run) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    assert not errors, errors

--- a/tests/test_lazy_build.py
+++ b/tests/test_lazy_build.py
@@ -1,0 +1,186 @@
+"""Lazy schema building: defer the compile walk to first validation.
+
+Under ``BuildPolicy.LAZY`` a top-level ``Schema`` stores its declaration and
+compiles it on first validation instead of at construction, so a schema that is
+built but never validated never pays to build. The default is ``EAGER`` (the
+voluptuous parity), so these tests opt in per case and restore it after.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+import pytest
+
+from probatio import (
+    All,
+    Any,
+    BuildPolicy,
+    Coerce,
+    DataclassSchema,
+    Optional,
+    Range,
+    Required,
+    Schema,
+    Self,
+    TypedDictSchema,
+    get_build_policy,
+    set_build_policy,
+)
+from probatio.error import MultipleInvalid, SchemaError
+
+
+@pytest.fixture
+def lazy() -> object:
+    """Run a test under the LAZY build policy, restoring EAGER afterwards."""
+    set_build_policy(BuildPolicy.LAZY)
+    try:
+        yield
+    finally:
+        set_build_policy(BuildPolicy.EAGER)
+
+
+def test_policy_defaults_to_eager() -> None:
+    """The process starts EAGER, so the drop-in construct-time errors hold."""
+    assert get_build_policy() is BuildPolicy.EAGER
+
+
+def test_set_build_policy_rejects_a_non_policy() -> None:
+    """A stray value fails loudly rather than silently disabling lazy building."""
+    with pytest.raises(TypeError, match="BuildPolicy"):
+        set_build_policy("lazy")  # type: ignore[arg-type]
+
+
+def test_eager_builds_at_construction() -> None:
+    """Under the default policy a schema is compiled when it is built."""
+    schema = Schema({Required("a"): int})
+    assert schema._built is True
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_defers_until_first_validation() -> None:
+    """A lazy schema is not built at construction, and builds on first call."""
+    schema = Schema({Required("port"): All(Coerce(int), Range(min=1, max=65535))})
+    assert schema._built is False
+    assert schema({"port": "8080"}) == {"port": 8080}
+    assert schema._built is True
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_result_matches_eager() -> None:
+    """Deferring the build changes nothing about the validated result."""
+    spec = {
+        Required("a"): int,
+        Optional("b", default="x"): str,
+        Optional("c"): [All(Coerce(int), Range(min=0))],
+    }
+    set_build_policy(BuildPolicy.EAGER)
+    eager = Schema(spec)({"a": 1, "c": ["2", "3"]})
+    set_build_policy(BuildPolicy.LAZY)
+    lazy = Schema(spec)({"a": 1, "c": ["2", "3"]})
+    assert lazy == eager == {"a": 1, "b": "x", "c": [2, 3]}
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_still_reports_validation_errors() -> None:
+    """A missing required key still fails, just on first validation."""
+    schema = Schema({Required("x"): int})
+    with pytest.raises(MultipleInvalid):
+        schema({})
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_defers_a_malformed_schema_error_to_first_use() -> None:
+    """A definition error is not raised at construction, but still raised on use."""
+    schema = Schema({Required(Optional("y")): int})  # two presence markers
+    assert schema._built is False
+    with pytest.raises(SchemaError, match="two presence markers"):
+        schema({"y": 1})
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_recursive_self_builds_on_first_call() -> None:
+    """A recursive Self schema takes the recursive path on its deferred first call."""
+    tree = Schema({Required("v"): int, Optional("kids", default=list): [Self]})
+    assert tree({"v": 1, "kids": [{"v": 2, "kids": []}]}) == {
+        "v": 1,
+        "kids": [{"v": 2, "kids": []}],
+    }
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_nested_schema_builds_with_its_parent() -> None:
+    """A lazy schema reused as a value builds when its parent is first validated."""
+    inner = Schema({Required("n"): int})
+    outer = Schema({Required("a"): inner})
+    assert inner._built is False
+    assert outer({"a": {"n": 5}}) == {"a": {"n": 5}}
+    assert inner._built is True
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_combinator_branch_is_built_eagerly() -> None:
+    """A combinator compiles its branches at its own construction, even under LAZY."""
+    schema = Schema({Required("v"): Any(int, str)})
+    assert schema({"v": "x"}) == {"v": "x"}
+    with pytest.raises(MultipleInvalid):
+        schema({"v": 1.5})
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_dataclass_schema_is_eager() -> None:
+    """A DataclassSchema constructs its instance-building engine at build time."""
+
+    @dataclass
+    class Point:
+        x: int
+        y: int
+
+    schema = DataclassSchema(Point)
+    assert schema._built is True
+    assert schema({"x": 1, "y": 2}) == Point(1, 2)
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_typeddict_schema_validates() -> None:
+    """A TypedDictSchema validates the same under LAZY (its inner is forced eager)."""
+
+    class Movie(TypedDict):
+        title: str
+        year: int
+
+    assert TypedDictSchema(Movie)({"title": "x", "year": 2020}) == {
+        "title": "x",
+        "year": 2020,
+    }
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_compile_forces_the_build() -> None:
+    """Eagerly compiling a lazy schema builds it first, then generates."""
+    schema = Schema({Required("a"): int}).compile()
+    assert schema._built is True
+    assert schema({"a": 1}) == {"a": 1}
+
+
+@pytest.mark.usefixtures("lazy")
+def test_lazy_introspection_does_not_force_a_build() -> None:
+    """Reading the declaration, extending, and rendering stay lazy."""
+    schema = Schema({Required("a"): int})
+    assert schema.schema == {Required("a"): int}
+    assert str(schema).startswith("{")
+    extended = schema.extend({Optional("b"): str})
+    assert schema._built is False
+    assert extended._built is False
+    assert extended({"a": 1, "b": "x"}) == {"a": 1, "b": "x"}
+
+
+@pytest.mark.usefixtures("lazy")
+def test_ensure_built_is_idempotent() -> None:
+    """Building twice is a no-op the second time (the built steady state is lock-free)."""
+    schema = Schema({Required("a"): int})
+    schema({"a": 1})
+    engine = schema._compiled
+    schema({"a": 2})
+    assert schema._compiled is engine


### PR DESCRIPTION
## Breaking change

None by default. The default build policy is `EAGER`, which keeps voluptuous's behavior exactly: a `Schema` compiles at construction and a malformed schema raises `SchemaError` where it is defined. `LAZY` is opt-in via `set_build_policy(BuildPolicy.LAZY)`, and under it a definition error surfaces at first validation instead of at construction. Nothing changes for anyone who does not opt in.

## Proposed change

Adds a process-wide build policy, mirroring the existing compile policy:

```python
from probatio import BuildPolicy, set_build_policy
set_build_policy(BuildPolicy.LAZY)   # once, early, at startup
```

Under `LAZY`, a top-level `Schema` stores its declaration and compiles the validator on first validation rather than at construction. A schema that is built but never validated, an unused service, trigger, condition, or websocket-command schema registered at startup, never pays to build and never holds its compiled `_MappingValidator`/`_Candidate` tree in memory.

The build walk (now free functions in `_compile`, from the preceding extraction) is split out of `__init__` into `Schema._build`, deferred behind a `_lazy_build` stub and forced on demand by `_ensure_built`. Only a plain top-level `Schema` defers; a combinator branch (through `compile_schema`), a dataclass/TypedDict inner, a `Schema` subclass, or an explicit `compile=` request builds eagerly, since their compiled form is read at once. The three sites that read a nested schema's compiled form (`_compile_nested_schema`, the recursive-ref `bind`, the dataclass fuse) force it to build first, so laziness never leaks a half-built schema. The build lock is reentrant, because building one schema recursively forces any lazily-deferred nested schema to build on the same thread.

Motivation: Home Assistant registers on the order of ~1000 service schemas, ~950 websocket-command schemas (built at import via decorators), and the trigger/condition schemas, all eagerly, but a given user validates a tiny fraction of them. On a websocket-command-shaped workload (2000 schemas built, ~3% ever validated) the build phase drops ~82% and peak memory ~77%. HA opts in with one line at startup.

Correctness: lazy and eager validate identically. Running the full suite under `LAZY` passes except the tests that assert a `SchemaError` at construction (now deferred to first use, by design) and a few white-box tests that read internal compiled state before first use (deliberately not materialized). The default `EAGER` suite is unchanged, and the lazy paths are covered by a new `tests/test_lazy_build.py`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: None
- This PR is related to: builds on the compiler extraction (#167)
- Link to a separate documentation pull request: None (a docs page for the build policy can follow)

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
