### PR TITLE
Document the As/From validator naming convention

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -21,6 +21,15 @@ Every validator is importable straight from `probatio`, for example
 `from probatio import Range, Coerce`.
 :::
 
+Two naming conventions run through the toolbox, so a name tells you what it does
+with the value. A validator named `As<Type>` (`AsDatetime`, `AsTimedelta`)
+validates the input and returns a real object of that type; its plain sibling
+(`Datetime`, `Duration`) checks the same input but returns it unchanged,
+string-in string-out, for voluptuous compatibility. A validator named
+`From<Source>` (`FromEpoch`, `FromPercentage`, `FromJSONString`) builds a value
+from that source form. So `As` names the type you get out, `From` names the shape
+that goes in.
+
 ## Type and value
 
 These check what a value is, or what it equals.

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -89,7 +89,11 @@ def _iso_field(raw: str | None) -> float:
 
 
 class Datetime(_SafeValidator):
-    """Validate that a string parses as a datetime in the given format."""
+    """Validate that a string parses as a datetime in the given format.
+
+    Returns the string unchanged (voluptuous's string-in, string-out behavior).
+    Use ``AsDatetime`` for the parsed ``datetime.datetime`` object instead.
+    """
 
     DEFAULT_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -116,7 +120,10 @@ class Datetime(_SafeValidator):
 
 
 class Date(Datetime):
-    """Validate that a string parses as a date in the given format."""
+    """Validate that a string parses as a date in the given format.
+
+    Returns the string unchanged. Use ``AsDate`` for the parsed ``datetime.date``.
+    """
 
     DEFAULT_FORMAT = "%Y-%m-%d"
 
@@ -138,6 +145,7 @@ class Time(Datetime):
 
     The sibling of ``Date``/``Datetime`` for a wall-clock time (voluptuous issue
     #335). Defaults to ``%H:%M:%S``; pass ``format="%H:%M"`` to drop the seconds.
+    Returns the string unchanged. Use ``AsTime`` for the parsed ``datetime.time``.
     """
 
     DEFAULT_FORMAT = "%H:%M:%S"
@@ -158,12 +166,13 @@ class Time(Datetime):
 class AsDatetime(_SafeValidator):
     """Parse a string into a ``datetime.datetime``.
 
-    Parses ISO 8601 by default, accepting anything ``datetime.fromisoformat``
-    accepts on this Python (the ``T`` or space separator, a ``Z`` or ``+HH:MM``
-    offset, fractional seconds). Pass ``format=`` to parse a specific ``strptime``
-    layout instead. Returns the parsed ``datetime.datetime``, not the original
-    string. Set ``require_timezone`` to reject a naive result (one without
-    ``tzinfo``); the ISO default reads the offset, so this needs no extra format.
+    The object-returning sibling of ``Datetime``: it returns the parsed
+    ``datetime.datetime`` instead of the original string. Parses ISO 8601 by
+    default, accepting anything ``datetime.fromisoformat`` accepts on this Python
+    (the ``T`` or space separator, a ``Z`` or ``+HH:MM`` offset, fractional
+    seconds). Pass ``format=`` to parse a specific ``strptime`` layout instead. Set
+    ``require_timezone`` to reject a naive result (one without ``tzinfo``); the ISO
+    default reads the offset, so this needs no extra format.
 
     Parsing uses the standard library only, on purpose: a faster backend like
     ciso8601 accepts a different set of strings and returns a different ``tzinfo``


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The `As*` / `From*` naming convention is a probatio-only design choice that the pre-1.0 API review flagged: the parse-vs-validate split was demonstrated case by case across the validators guide, but the rule behind it was never written down. A reader seeing both `Datetime` and `AsDatetime` had to infer why both exist.

This states the convention once, near the top of the built-in validators guide:

- `As<Type>` (`AsDatetime`, `AsTimedelta`) validates the input and returns a real object of that type.
- Its plain sibling (`Datetime`, `Duration`) checks the same input and returns it unchanged, string-in string-out, for voluptuous compatibility.
- `From<Source>` (`FromEpoch`, `FromPercentage`, `FromJSONString`) builds a value from that source form.

It also closes the docstring gaps that made the temporal family read inconsistently. `Datetime`, `Date`, and `Time` now point forward to their `As*` siblings the way `Duration` and `TimeZone` already do, and `AsDatetime` names `Datetime` as its pair the way `AsDate` and `AsTime` already name theirs.

No signatures change, nothing is renamed. Docs and docstrings only.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the pre-1.0 review of the probatio-only public API
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.