### PR TITLE
Explain why Check requires a message

### DIFF
--- a/src/probatio/validators/conditional.py
+++ b/src/probatio/validators/conditional.py
@@ -246,6 +246,11 @@ class Check(_SafeValidator):
     a predicate that raises (a missing key, a type error), is reported with the
     message, so the value never leaks a raw exception. Use it after a dict schema
     with ``All`` for a cross-field rule the markers cannot express.
+
+    Unlike other validators, ``msg`` is required rather than optional. A bare
+    predicate (often a lambda) has no meaningful default message, so without one a
+    failed check could only report ``not a valid value``, which says nothing about
+    the rule that broke. Requiring the message keeps the error readable.
     """
 
     def __init__(


### PR DESCRIPTION
## Breaking change

None. Docstring only.

## Proposed change

The pre-1.0 API review noted that `Check` is the one validator whose `msg` is required rather than optional, which reads like an oversight next to every sibling that defaults `msg` to `None`. It is deliberate: a bare predicate (usually a lambda) has no meaningful default message, so without one a failed check could only report `not a valid value`, which says nothing about the cross-field rule that broke. Requiring the message keeps the error readable, and it is what separates `Check` from `truth` (which wraps a predicate but raises the bare, message-less error).

This documents that reason on the class so the asymmetry is self-explaining. No signature change.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: the pre-1.0 review of the probatio-only public API
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.