### PR TITLE
Inline Length and Match in the compiled path

### DIFF
--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -51,10 +51,17 @@ if TYPE_CHECKING:
     from probatio.validators.coerce import Coerce
     from probatio.validators.combinators import All
     from probatio.validators.combinators import Any as AnyValidator
-    from probatio.validators.comparison import In, Range
+    from probatio.validators.comparison import In, Length, Range
+    from probatio.validators.strings import Match
 
     _ValidatorTypes = tuple[
-        type[Coerce[Any]], type[Range], type[In], type[AnyValidator], type[All]
+        type[Coerce[Any]],
+        type[Range],
+        type[In],
+        type[AnyValidator],
+        type[All],
+        type[Length],
+        type[Match],
     ]
 
 # A missing key, distinct from any real value (a key whose value is ``None`` is
@@ -188,6 +195,57 @@ def _inline_range(schema: Any, *, type_checked: bool = False) -> list[str] | Non
     return lines
 
 
+def _inline_length(schema: Any, tag: str) -> list[str] | None:
+    """Inline a ``Length`` with integer bounds; ``_v`` is unchanged.
+
+    With no bound set the value always passes, so nothing is emitted. A value whose
+    ``len`` raises (no ``__len__``, or a user ``__len__`` that raises) bails to the
+    interpreted ``Length``, which reports the real ``LengthInvalid``; an out-of-range
+    length bails there too. A non-integer bound (unusual for a length) is left to the
+    interpreted validator, so its own type handling stays the single source of truth.
+    """
+    low, high = schema.min, schema.max
+    if low is None and high is None:
+        return []
+    if (low is not None and not isinstance(low, int)) or (
+        high is not None and not isinstance(high, int)
+    ):
+        return None
+    name = f"_len{tag}"
+    lines = [
+        "        try:",
+        f"            {name} = len(_v)",
+        # A len that raises is a failure the interpreted Length reports, not a crash;
+        # match its ``except Exception`` so any __len__ blowup defers, never leaks.
+        "        except Exception:",
+        "            raise _Bail",
+    ]
+    if low is not None:
+        lines += [f"        if {name} < {low!r}:", "            raise _Bail"]
+    if high is not None:
+        lines += [f"        if {name} > {high!r}:", "            raise _Bail"]
+    return lines
+
+
+def _inline_match(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] | None:
+    """Inline a ``Match`` regular-expression check; ``_v`` is unchanged.
+
+    The compiled pattern is bound live (not re-emitted as source), and ``.match`` is
+    used exactly as the interpreted ``Match`` does (anchored at the start). A value the
+    pattern does not match, or one ``.match`` cannot take (a non-string ``TypeError``),
+    bails to the interpreted ``Match`` for the real ``MatchInvalid``.
+    """
+    name = f"_re{tag}"
+    namespace[name] = schema.pattern
+    return [
+        "        try:",
+        f"            if {name}.match(_v) is None:",
+        "                raise _Bail",
+        "        except TypeError:",
+        "            raise _Bail",
+    ]
+
+
 def _emit_membership(name: str) -> list[str]:
     """Emit a membership bail-check that survives a value ``in`` cannot test.
 
@@ -244,7 +302,7 @@ def _inline_all(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] |
     dominant hot-path composition). ``Range`` and ``In`` leave ``_v`` unchanged,
     so the knowledge survives them; any other branch conservatively resets it.
     """
-    coerce_cls, range_cls, in_cls, _, _ = _validator_types()
+    coerce_cls, range_cls, in_cls, _, _, _, _ = _validator_types()
     chained: list[str] = []
     numeric = False
     for position, sub in enumerate(schema.validators):
@@ -318,23 +376,26 @@ _VALIDATOR_TYPES: _ValidatorTypes | None = None
 
 
 def _validator_types() -> _ValidatorTypes:
-    """Return ``(Coerce, Range, In, AnyValidator, All)``, importing them once."""
+    """Return ``(Coerce, Range, In, AnyValidator, All, Length, Match)``, imported once."""
     global _VALIDATOR_TYPES  # noqa: PLW0603 - a write-once import cache
     if _VALIDATOR_TYPES is None:
         from probatio.validators.coerce import Coerce  # noqa: PLC0415
         from probatio.validators.combinators import All  # noqa: PLC0415
         from probatio.validators.combinators import Any as AnyValidator  # noqa: PLC0415
-        from probatio.validators.comparison import In, Range  # noqa: PLC0415
+        from probatio.validators.comparison import In, Length, Range  # noqa: PLC0415
+        from probatio.validators.strings import Match  # noqa: PLC0415
 
-        _VALIDATOR_TYPES = (Coerce, Range, In, AnyValidator, All)
+        _VALIDATOR_TYPES = (Coerce, Range, In, AnyValidator, All, Length, Match)
     return _VALIDATOR_TYPES
 
 
-def _inline_validator(
+def _inline_validator(  # noqa: PLR0911 - a flat one-per-validator type dispatch
     schema: Any, namespace: dict[str, Any], tag: str
 ) -> list[str] | None:
     """Dispatch a non-type value schema to its inline emitter, or ``None``."""
-    coerce_cls, range_cls, in_cls, any_cls, all_cls = _validator_types()
+    coerce_cls, range_cls, in_cls, any_cls, all_cls, length_cls, match_cls = (
+        _validator_types()
+    )
 
     if isinstance(schema, coerce_cls):
         return _inline_coerce(schema.type)
@@ -346,6 +407,10 @@ def _inline_validator(
         return _inline_any(schema, namespace, tag)
     if isinstance(schema, all_cls):
         return _inline_all(schema, namespace, tag)
+    if isinstance(schema, length_cls):
+        return _inline_length(schema, tag)
+    if isinstance(schema, match_cls):
+        return _inline_match(schema, namespace, tag)
     return None
 
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -207,10 +207,12 @@ _INPUTS: list[object] = [
     {"x": "hi"},
     {"x": None},
     # Length/Match: an in-range lowercase hit, an over-length value that still
-    # matches the regex, and (reusing the cases above) a too-short "a", an uppercase
-    # miss "A", an empty "", and a non-string 5 that bails on len/match.
+    # matches the regex, a zero-length string, and (reusing the cases above) a
+    # too-short "a", an uppercase miss "A", and a non-string 5 that bails on
+    # len/match.
     {"x": "abc"},
     {"x": "abcdef"},
+    {"x": ""},
 ]
 
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -27,6 +27,8 @@ from probatio import (
     Exclusive,
     Forbidden,
     In,
+    Length,
+    Match,
     MultipleInvalid,
     Optional,
     Range,
@@ -136,6 +138,16 @@ _BUILDERS = {
     "nested_map": lambda **k: Schema(
         {Required("srv"): {Required("host"): str, "port": int}}, **k
     ),
+    # Length inlining: an integer-bounded len check (both bounds, then each single
+    # bound), a no-bounds Length (always passes, so it emits nothing), and a
+    # non-integer bound (unusual for a length, left to the closure). Match inlining:
+    # an anchored regex, hit and miss and a non-string that bails on the TypeError.
+    "length": lambda **k: Schema({"x": All(str, Length(min=2, max=4))}, **k),
+    "length_min_only": lambda **k: Schema({"x": All(str, Length(min=2))}, **k),
+    "length_max_only": lambda **k: Schema({"x": All(str, Length(max=4))}, **k),
+    "length_no_bounds": lambda **k: Schema({"x": All(str, Length())}, **k),
+    "length_float_bound": lambda **k: Schema({"x": Length(min=1.5)}, **k),
+    "match": lambda **k: Schema({"x": Match(r"^[a-z]+$")}, **k),
 }
 
 
@@ -194,6 +206,11 @@ _INPUTS: list[object] = [
     {"x": 200},
     {"x": "hi"},
     {"x": None},
+    # Length/Match: an in-range lowercase hit, an over-length value that still
+    # matches the regex, and (reusing the cases above) a too-short "a", an uppercase
+    # miss "A", an empty "", and a non-string 5 that bails on len/match.
+    {"x": "abc"},
+    {"x": "abcdef"},
 ]
 
 


### PR DESCRIPTION
## Breaking change

None. The compiled path (opt-in, `CompilePolicy`) stays byte-identical to the interpreted engine; this only changes which validators the success-path generator inlines versus defers to a closure. Default-off behavior is unchanged.

## Proposed change

The codegen success-path generator inlined types, `Coerce`, `Range`, `In`, `All`, `Any`, and list sequences, but `Length` and `Match`, two of the most common leaf validators in real schemas, fell through to a per-field interpreted closure call. Every field carrying one paid a Python call plus the validator's own overhead even when the whole mapping was compiled.

This adds `_inline_length` and `_inline_match`:

- `Length` emits a guarded `len()` range check. A `len` that raises (no `__len__`, or a user `__len__` that raises) or an out-of-range length bails to the interpreted `Length` for the real `LengthInvalid`. A no-bounds `Length` emits nothing (it always passes), and a non-integer bound (unusual for a length) is left to the closure so its own type handling stays the single source of truth.
- `Match` binds the compiled pattern live (not re-emitted as source) and emits an anchored `.match` check, bailing on a miss or a non-string `TypeError`.

Both leave `_v` unchanged and defer on any failure, so the compiled and interpreted engines return the same value and raise the same error, path, and code. The `len()` double-run on the bail path is the side-effect-on-failure seam the module docstring already documents; probatio's own validators are pure.

### Performance

A/B benchmark (best of 7, 200k iters) of a four-field schema dominated by `Length`/`Match` fields:

| | per call |
| --- | --- |
| before (fields bail to interpreted closures) | 1339 ns |
| after (inlined) | 775 ns |

~1.73x. The win scales with how much of a schema uses these two; a lone `Length` field among plain types sees a smaller total, but that field goes from a closure call to inlined.

### Tests

The `test_codegen.py` parity suite drives six new builders (both bounds, each single bound, a no-bounds `Length`, a non-integer bound that stays a closure, and a regex) across the shared input matrix, interpreted versus compiled, and asserts each actually generated code. Full gate green at 100% coverage.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: widening compiled-path coverage (ADR-011)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.