### PR TITLE
Convert a __post_init__ error on the compiled path instead of leaking it

### DIFF
--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -645,7 +645,20 @@ def compile_mapping(
         # ``pass`` keeps the block valid and still bails on a non-dict.
         body.append("        pass")
 
-    tail = f"    return _Type({', '.join(kwargs)})" if construct else "    return out"
+    if construct:
+        # Construction runs outside the field try. A dataclass constructor (its
+        # ``__post_init__``) can raise ``ValueError`` or ``Invalid`` on a value the
+        # field checks let through; the interpreted constructor turns those into a
+        # ``ValueInvalid`` / ``MultipleInvalid``. Defer to it so the compiled path
+        # reports the identical error instead of leaking the raw exception. Any other
+        # exception (a genuine constructor ``TypeError``) propagates in both paths.
+        tail = [
+            f"    try:\n        return _Type({', '.join(kwargs)})",
+            "    except (ValueError, _Invalid):",
+            "        return _interpreted(data)",
+        ]
+    else:
+        tail = ["    return out"]
     lines = [
         "def _validate(data):",
         *prologue,
@@ -653,9 +666,7 @@ def compile_mapping(
         *body,
         "    except _Bail:",
         "        return _interpreted(data)",
-        # Construction (if any) runs outside the try, so a dataclass __init__ error
-        # propagates as itself, exactly as the interpreted constructor lets it.
-        tail,
+        *tail,
     ]
 
     exec(_compile_source("\n".join(lines)), namespace)  # noqa: S102 - trusted schema

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -452,6 +452,18 @@ class _Movie(TypedDict):
     year: int
 
 
+@dataclass
+class _Guarded:
+    """A dataclass whose __post_init__ rejects a value the field type accepts."""
+
+    weight: float
+
+    def __post_init__(self) -> None:
+        if self.weight < 0:
+            message = "weight must not be negative"
+            raise ValueError(message)
+
+
 _DC_INPUTS: list[dict[str, object]] = [
     {"name": "ada", "age": 30, "score": 9.5, "nickname": "c"},
     {"name": "ada", "age": 30},
@@ -470,6 +482,22 @@ def test_dataclass_compiled_matches_interpreted(data: dict[str, object]) -> None
     compiled = DataclassSchema(_User, compile=True).compile()
     assert _is_compiled(compiled)
     assert _outcome(interpreted, dict(data)) == _outcome(compiled, dict(data))
+
+
+def test_compiled_dataclass_post_init_error_matches_interpreted() -> None:
+    """A __post_init__ ValueError normalizes identically compiled and interpreted.
+
+    Construction runs outside the field try, so a leaked ValueError would escape the
+    compiled path as itself; it must defer to the interpreted constructor, which
+    reports a ValueInvalid. Regression test for the compiled path leaking a raw
+    __post_init__ error (issue #176); runs in the default gate, not only the
+    ``--compiled`` lane, so CI guards it.
+    """
+    interpreted = DataclassSchema(_Guarded)
+    compiled = DataclassSchema(_Guarded, compile=True).compile()
+    assert _is_compiled(compiled)
+    for data in ({"weight": -1.0}, {"weight": 1.0}):
+        assert _outcome(interpreted, dict(data)) == _outcome(compiled, dict(data))
 
 
 def test_zero_field_dataclass_with_remove_extra_compiles() -> None:


### PR DESCRIPTION
## Breaking change

None. The compiled path is opt-in and default-off; this makes it match the interpreted engine on a case where it previously diverged.

## Proposed change

Fixes #176.

The fused dataclass constructor was emitted as the generated function's tail, outside the field `try` block:

```python
tail = f"    return _Type({', '.join(kwargs)})" if construct else "    return out"
```

So a `ValueError` raised by a dataclass `__post_init__` leaked out of the compiled path as a raw `ValueError`. The interpreted constructor turns that into a `ValueInvalid` (and wraps an `Invalid` into a `MultipleInvalid`), so the two engines diverged, breaking the compiled path's parity contract. The old comment even claimed the interpreted path "lets it propagate", which is not what it does.

```python
from dataclasses import dataclass
from probatio import DataclassSchema, MultipleInvalid
from probatio._compile_policy import CompilePolicy, set_compile_policy

@dataclass
class Guard:
    weight: float
    def __post_init__(self):
        if self.weight < 0:
            raise ValueError("weight must not be negative")

for mode in (CompilePolicy.OFF, CompilePolicy.ON):
    set_compile_policy(mode)
    try:
        DataclassSchema(Guard)({"weight": -1.0})
    except MultipleInvalid as e:
        print(mode.name, "->", e)
    except ValueError as e:
        print(mode.name, "-> RAW ValueError:", repr(e))
```

Before: `OFF` reports `not a valid value: weight must not be negative`; `ON` leaks `ValueError('weight must not be negative')`. After: both report the `MultipleInvalid`.

The fix wraps the construction so a `ValueError` or `Invalid` bails to the interpreted validator, which produces the identical error, path, and cause. A genuine constructor `TypeError` still propagates in both paths, matching the interpreted constructor's own handling (it only catches `ValueError`/`Invalid`/`MultipleInvalid`).

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #176
- This PR is related to: the compiled path (ADR-011)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.