### PR TITLE
Reframe the pydantic comparison around the model framework, not typed objects

### DIFF
--- a/docs/src/content/docs/project/about.md
+++ b/docs/src/content/docs/project/about.md
@@ -37,11 +37,14 @@ Reaching for validation in Python tends to mean one of a few trades:
   in Probatio are borrowed from it with credit (see the architecture decision
   records). It is a codec library more than a free-form validator, though, so the
   schema-is-data model is not the problem it set out to solve.
-- **pydantic** is the heavyweight, class-first choice. It is fast and capable,
-  but it asks you to describe data as typed models, which is a different mental
-  model and a migration, not a drop-in. It has also broken backward compatibility
-  and reshaped its API substantially in the past (the v1 to v2 rewrite), which is
-  not a foundation this project wants to stand on.
+- **pydantic** is the heavyweight, framework choice: a `BaseModel` class that is
+  your schema, type, validator, and serializer at once. It is fast and capable,
+  but it asks you to describe data as pydantic model classes, a different mental
+  model and a migration, not a drop-in. (Probatio also returns typed objects, from
+  your own dataclasses and TypedDicts, without a base class; the
+  [comparison page](/project/comparison/) draws the line.) It has also broken
+  backward compatibility and reshaped its API substantially in the past (the v1 to
+  v2 rewrite), which is not a foundation this project wants to stand on.
 - **marshmallow** validates and (de)serializes through declarative schema
   classes with explicit field objects, built around the load and dump cycle. A
   solid model, but a class you declare, not data you compose.

--- a/docs/src/content/docs/project/comparison.md
+++ b/docs/src/content/docs/project/comparison.md
@@ -13,22 +13,27 @@ and it is pure Python with no native extension.
 That shapes where it fits. Probatio is at home when your data is free-form dicts
 and lists (config files, request bodies, payloads from another system) and you
 want the schema to stay data you can build, pass around, and compose at runtime.
-It is not trying to give you typed model objects. For that, other tools do a
-better job, and this page says where.
+It can also hand back a typed object: point `DataclassSchema` or
+`TypedDictSchema` at a dataclass or `TypedDict` you already own, and you get a
+validated, statically typed result. What it is not is a model _framework_: no
+base class your types inherit, and validation is all it does, with no bundled
+serialization or settings. For that, other tools do a better job, and this page
+says where.
 
 ## The short answer
 
-| Pick this when                                              | Reach for                     |
-| ----------------------------------------------------------- | ----------------------------- |
-| You use voluptuous today and want a maintained replacement  | Probatio                      |
-| Your data is plain dicts and lists, schema as data          | Probatio                      |
-| You want typed model objects with editor and type support   | pydantic                      |
-| You want declarative schema classes with load and dump      | marshmallow                   |
-| Your schemas are cerberus rule dicts                        | cerberus, or port to Probatio |
-| Your contract is a JSON Schema document                     | jsonschema                    |
-| You are (de)serializing your own classes                    | attrs / cattrs                |
-| You (de)serialize dataclasses fast, in a known format       | mashumaro                     |
-| You just need a dict turned into a dataclass, no validation | dacite                        |
+| Pick this when                                                                | Reach for                     |
+| ----------------------------------------------------------------------------- | ----------------------------- |
+| You use voluptuous today and want a maintained replacement                    | Probatio                      |
+| Your data is plain dicts and lists, schema as data                            | Probatio                      |
+| You want validated, typed results from your own dataclasses or TypedDicts     | Probatio                      |
+| You want a model framework: one class for validation, serialization, settings | pydantic                      |
+| You want declarative schema classes with load and dump                        | marshmallow                   |
+| Your schemas are cerberus rule dicts                                          | cerberus, or port to Probatio |
+| Your contract is a JSON Schema document                                       | jsonschema                    |
+| You are (de)serializing your own classes                                      | attrs / cattrs                |
+| You (de)serialize dataclasses fast, in a known format                         | mashumaro                     |
+| You just need a dict turned into a dataclass, no validation                   | dacite                        |
 
 ## voluptuous
 
@@ -52,18 +57,24 @@ schema({"name": "Frenck", "age": 40})
 ## pydantic
 
 Pydantic models your data as classes built on Python type hints, with a native
-(Rust) core and strong editor and type-checker support. You declare a model
-class, and you get typed objects back, with autocompletion and static checking
-that follow from the hints.
+(Rust) core and strong editor and type-checker support. You declare a model class
+that inherits from pydantic's `BaseModel`, and that one class is your schema, your
+type, your validator, and your serializer: typed objects back, with
+autocompletion, static checking, coercion, and `.model_dump()` all following from
+the hints.
 
-That is a real strength, and it is the better choice when you want typed model
-objects to carry through your code and you want your editor and type checker in
-on the deal.
-
-Probatio is the better fit when your data is plain dicts and lists, when you want
-the schema to be data you build and compose at runtime rather than a class you
-declare, or when you are replacing voluptuous. Different shape of problem, not a
-better or worse one.
+Probatio hands back typed objects too, which is newer than its reputation
+suggests: `DataclassSchema` and `TypedDictSchema` validate into a dataclass or
+`TypedDict` you already own, and both are generic, so the result is statically
+typed (a `Config`, not `Any`), editor and checker included. The difference is the
+framework. Pydantic asks your types to be pydantic types, the `BaseModel` base
+class, and bundles serialization and settings on top; Probatio validates
+free-form data, or validates into the plain types you already have, and does
+validation only, you own the serialization. So it is the better fit when your
+data is plain dicts and lists, when the schema should be data you build and
+compose at runtime rather than a class you declare, when you want to validate into
+your own dataclasses without adopting a model framework, or when you are replacing
+voluptuous.
 
 On raw speed the Rust core is genuinely fast, but the advantage is not uniform, and
 it is worth being precise about where it comes from. It is largest on heavy coercion
@@ -79,8 +90,10 @@ parsing-heavy regime, not everywhere, and Probatio stays pure Python with no nat
 extension to build or install.
 
 :::note
-The two can live side by side. Use pydantic where you want typed models, use
-Probatio where you validate free-form data. Picking per use case is fine.
+The two can live side by side. Reach for pydantic when you want its model
+framework, serialization, and settings on a `BaseModel`; reach for Probatio to
+validate free-form data, or to validate into your own plain dataclasses and
+TypedDicts. Picking per use case is fine.
 :::
 
 ## marshmallow


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

The comparison page's intro and pydantic section predated `DataclassSchema` and `TypedDictSchema`. They positioned pydantic as the choice for "typed model objects" and stated Probatio "is not trying to give you typed model objects". That is no longer true: `DataclassSchema` and `TypedDictSchema` validate into a dataclass or `TypedDict` you already own, and both are generic, so the validated result is statically typed (a `Config`, not `Any`), editor and type-checker included. The bottom of the same page (the mashumaro, dacite, and cattrs sections) already described `DataclassSchema` validating into dataclasses, so the top of the page contradicted the bottom.

This reframes the pydantic distinction where it actually is:

- Pydantic is a model framework: a `BaseModel` that is your schema, type, validator, and serializer at once, with the deepest built-in coercion and a native core.
- Probatio validates free-form data, or validates into the plain types you already have, and does validation only (you own the serialization). It returns typed objects too, without a base class.

Changes, all in `comparison.md` plus one bullet in `about.md`:

- Intro: corrected the "not trying to give you typed objects" line.
- Short-answer table: sharpened the pydantic row to the framework framing, and added a Probatio row for "validated, typed results from your own dataclasses or TypedDicts".
- pydantic section and its `:::note`: reframed the distinction; the accurate Rust-speed paragraph is left untouched.
- `about.md` pydantic bullet: aligned terminology, with a pointer to the comparison page.

Audit note: `typing.md`, `performance.md`, and the other library sections were already accurate and were left as they are. The staleness was confined to the two spots above.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: keeping the comparison honest as DataclassSchema/TypedDictSchema landed
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.