### PR TITLE
Gate the compiled parity lane in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,40 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  compiled:
+    name: Compiled parity ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.12", "3.13", "3.14", "3.15"]
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up uv and Python ${{ matrix.python }}
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      - name: 🏗 Install dependencies
+        run: uv sync --locked --all-packages --group test
+      # Force schema compilation on for the whole behavioral suite, so the
+      # generated engine is proven byte-identical to the interpreted one. No
+      # coverage here: this is a parity gate, not a coverage one. The conftest
+      # skips the property, fuzz, and compile-specific tests under --compiled.
+      - name: 🚀 Run the compiled parity lane
+        run: >
+          uv run --no-sync pytest --compiled -o addopts=""
+          -p no:cacheprovider --junitxml=junit-compiled.xml
+          -o junit_family=legacy
+      - name: 🧪 Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Breaking change

None. CI only.

## Proposed change

The compiled engine (opt-in codegen, ADR-011) must be byte-identical to the interpreted one, and `just test-compiled` proves it by forcing compilation on across the whole behavioral suite. But nothing ran that lane in CI, so two real compiled-path bugs reached `main` with CI green this cycle, including a `__post_init__` `ValueError` leak (fixed in #177). If schema compilation ships as a 1.0 feature, its parity has to be a gate, not a manual check.

This adds a `Compiled parity` job to the tests workflow: `pytest --compiled` across the same 3.12–3.15 matrix as the interpreted suite (generated code is version-sensitive, so parity is checked per Python version). No coverage step: this is a parity gate, not a coverage one, and the conftest skips the property, fuzz, and compile-specific tests under `--compiled`. The job mirrors the existing `pytest` job's setup (pinned action SHAs, `persist-credentials: false`, `uv sync --locked`).

The lane is green on `main` today (since #177), so this passes on merge and guards against future divergence.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: 1.0 readiness (making the compiled path a gated feature)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.