### PR TITLE
Extend the stability policy to the probatio-only surface

### DIFF
--- a/docs/src/content/docs/project/roadmap.md
+++ b/docs/src/content/docs/project/roadmap.md
@@ -27,27 +27,29 @@ The names and signatures every voluptuous user already depends on (`Schema`,
 documented reason, and when they do it is to sit closer to voluptuous, not further
 from it.
 
-**The probatio-only surface** is public too, and there is a lot of it: the parts
+**The Probatio-only surface** is public too, and there is a lot of it: the parts
 voluptuous never had. Schemas built from your own types (`DataclassSchema`,
 `TypedDictSchema`), the extra validators and markers (`AsDatetime`, `Slug`,
-`Secret`, `Alias`, the cross-field rules, and more), the codecs (`to_json_schema`,
-`to_openapi`, `to_field_list`, and their inverses), and the build and compile
-policies. Anything importable straight from `probatio` and listed in `__all__` is
-part of this surface. Before 1.0 it may still shift as it settles under real use;
-at 1.0 it is frozen under semantic versioning like the rest, and a
-[snapshot test](https://github.com/frenck/probatio/blob/main/tests/test_public_surface.py)
-covers the whole of it, so a change can only be deliberate.
+`Secret`, `Alias`, the cross-field rules, and more), the codecs (`to_json_schema`
+and `to_openapi` with their `from_*` inverses, plus the output-only
+`to_field_list`), and the build and compile policies. Anything importable straight
+from `probatio` and listed in `__all__` is part of this surface. Before 1.0 it may
+still shift as it settles under real use; at 1.0 it is frozen under semantic
+versioning like the rest, and a public-surface snapshot test in the suite covers
+the whole of it, so a change can only be deliberate.
 
-**The error model** gets its own line, because it is the largest thing probatio
+**The error model** gets its own line, because it is the largest thing Probatio
 adds over voluptuous. The error classes (`Invalid` and its subclasses) and the
 structured data they carry, the `path` to the offending value, the
-machine-readable `code`, and the `context`, are API: catch them by type, read
-those fields, and rely on them. The human-readable message text is not frozen; it
-can be reworded to read better, the same latitude voluptuous takes with its own
-messages. The `translation_key` behind each message is finer-grained than `code`
-and tracks the message catalog, which is still settling, so treat it as a
-rendering detail rather than a frozen contract: key your own logic and any
-localization on `code`, which is stable.
+machine-readable `code`, the `context`, and the `translation_key`, are the
+contract: catch them by type, read those fields, and rely on them. The
+`translation_key` names the exact sentence of each message, and with its
+`placeholders` it is what a translation keys on, so renaming or removing one is a
+breaking change ([ADR-015](https://github.com/frenck/probatio/blob/main/adr/015-structured-errors-and-localization.md);
+the [translation keys](/reference/translation-keys/) reference lists them all).
+The one thing not frozen is the rendered English text: a custom `msg=` overrides
+it, and a default may be reworded to read better, but the key stays put, so a
+translation follows the key, not the words.
 
 **The internals are not promised.** Before 1.0 they may change while the project
 gathers production feedback and the implementation settles. If you reach past the
@@ -55,7 +57,7 @@ public API into private modules (anything with a leading underscore), that is on
 you.
 
 :::caution[Pre-1.0]
-The probatio-only surface may still shift before 1.0 as production feedback comes
+The Probatio-only surface may still shift before 1.0 as production feedback comes
 in. The voluptuous-compatible surface is already the contract; the internals never
 are.
 :::

--- a/docs/src/content/docs/project/roadmap.md
+++ b/docs/src/content/docs/project/roadmap.md
@@ -19,20 +19,45 @@ The order of work follows from that. Match voluptuous first, then iterate.
 
 ## What stable means here
 
-Two different things, and the distinction matters.
+Three things, and the distinction matters.
 
-The public API tracks voluptuous and is meant to stay stable. The names and
-signatures (`Schema`, `Required`, `All`, `Any`, `Coerce`, `Invalid`, and the
-rest) are what your code depends on, so they do not move without a documented
-reason.
+**The voluptuous-compatible surface** is the contract, and it tracks voluptuous.
+The names and signatures every voluptuous user already depends on (`Schema`,
+`Required`, `All`, `Any`, `Coerce`, `Invalid`, and the rest) do not move without a
+documented reason, and when they do it is to sit closer to voluptuous, not further
+from it.
 
-The internals are not promised. Before 1.0 they may change while the project
-gathers production feedback and the implementation settles. If you reach past
-the public API into private modules, that is on you.
+**The probatio-only surface** is public too, and there is a lot of it: the parts
+voluptuous never had. Schemas built from your own types (`DataclassSchema`,
+`TypedDictSchema`), the extra validators and markers (`AsDatetime`, `Slug`,
+`Secret`, `Alias`, the cross-field rules, and more), the codecs (`to_json_schema`,
+`to_openapi`, `to_field_list`, and their inverses), and the build and compile
+policies. Anything importable straight from `probatio` and listed in `__all__` is
+part of this surface. Before 1.0 it may still shift as it settles under real use;
+at 1.0 it is frozen under semantic versioning like the rest, and a
+[snapshot test](https://github.com/frenck/probatio/blob/main/tests/test_public_surface.py)
+covers the whole of it, so a change can only be deliberate.
+
+**The error model** gets its own line, because it is the largest thing probatio
+adds over voluptuous. The error classes (`Invalid` and its subclasses) and the
+structured data they carry, the `path` to the offending value, the
+machine-readable `code`, and the `context`, are API: catch them by type, read
+those fields, and rely on them. The human-readable message text is not frozen; it
+can be reworded to read better, the same latitude voluptuous takes with its own
+messages. The `translation_key` behind each message is finer-grained than `code`
+and tracks the message catalog, which is still settling, so treat it as a
+rendering detail rather than a frozen contract: key your own logic and any
+localization on `code`, which is stable.
+
+**The internals are not promised.** Before 1.0 they may change while the project
+gathers production feedback and the implementation settles. If you reach past the
+public API into private modules (anything with a leading underscore), that is on
+you.
 
 :::caution[Pre-1.0]
-Some internals may still change before 1.0. The public API is the contract; the
-internals are not.
+The probatio-only surface may still shift before 1.0 as production feedback comes
+in. The voluptuous-compatible surface is already the contract; the internals never
+are.
 :::
 
 ## Versioning


### PR DESCRIPTION
## Breaking change

None. Documentation only.

## Proposed change

The stability page ("Stability and roadmap") split the world in two, the voluptuous-tracking public API and the internals, and said nothing about the large probatio-only surface that has grown alongside it (`DataclassSchema`, `TypedDictSchema`, the extra validators and markers, the codecs, the build and compile policies) or the error model. That is the biggest 1.0 commitment, and it was undocumented.

This reframes "What stable means here" into three tiers:

- **The voluptuous-compatible surface** is the contract and tracks voluptuous.
- **The probatio-only surface** is public too: anything importable from `probatio` and in `__all__`. It may still shift pre-1.0, and at 1.0 it is frozen under semantic versioning, guarded by the public-surface snapshot test (#180) so a change can only be deliberate.
- **The internals** are not promised.

The error model gets its own paragraph, since it is the largest thing probatio adds over voluptuous: the error classes and their structured fields (`path`, `code`, `context`) are API; the human-readable message text is not frozen; and `translation_key` is finer-grained than `code` and tracks the still-settling message catalog, so it is a rendering detail rather than a frozen contract. Consumers, including any localization, key on the stable `code`. (`code` is coarse and per-concept, `translation_key` is per-message; committing to `code` keeps probatio free to refine error messages, which is one of its selling points, while giving consumers a stable programmatic identifier. voluptuous has neither, so the drop-in promise does not depend on frozen keys.)

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: 1.0 readiness (stating what the probatio-only surface and error model commit to)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.