### PR TITLE
Propagate the extra-key policy into nested dataclass and TypedDict schemas

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -282,6 +282,69 @@ is_dataclass(User)  # True
 create_dataclass_schema(User)({"name": "ada"})  # User(name='ada')
 ```
 
+## Extra keys, all the way down
+
+`extra` propagates. Set `extra=REMOVE_EXTRA` (or `ALLOW_EXTRA`) and the policy
+applies at every level: nested dataclasses, nested TypedDicts, and dataclasses
+inside a `list`, `dict`, `tuple`, or union all follow it. This is the case for
+parsing a third-party API response into a tree of dataclasses while dropping the
+fields you do not model, one flag, not a wrapper per level.
+
+```python
+from dataclasses import dataclass, field
+
+from probatio import DataclassSchema, REMOVE_EXTRA
+
+
+@dataclass
+class Server:
+    host: str = ""
+
+
+@dataclass
+class Config:
+    server: Server = field(default_factory=Server)
+
+
+data = {"server": {"host": "nas", "unmodeled": 9}, "toplevel_junk": 1}
+DataclassSchema(Config, extra=REMOVE_EXTRA)(data)  # Config(server=Server(host='nas'))
+```
+
+To pin a different policy for one field's subtree, put `Key(extra=...)` in its
+`Annotated` metadata. It overrides the inherited policy for that field only, so
+you can keep one noisy sub-object loose while the rest stays strict, or the
+reverse:
+
+```python
+from dataclasses import dataclass, field
+from typing import Annotated
+
+from probatio import DataclassSchema, Key, PREVENT_EXTRA
+
+
+@dataclass
+class Strict:
+    id: int = 0
+
+
+@dataclass
+class Doc:
+    meta: Annotated[Strict, Key(extra=PREVENT_EXTRA)] = field(default_factory=Strict)
+```
+
+The schema is loose, but `meta` stays strict and rejects the unknown key:
+
+<!-- verify: raises MultipleInvalid -->
+
+```python
+DataclassSchema(Doc, extra=REMOVE_EXTRA)({"meta": {"id": 1, "typo": 2}})
+# MultipleInvalid: not a valid option at 'meta.typo'
+```
+
+The default (`PREVENT_EXTRA`) is unchanged: an unknown key, at any level, is
+rejected. `Key(extra=...)` on a plain (leaf) field has nothing to apply to and is
+ignored.
+
 ## Coercing a field's type
 
 A field annotated with `datetime` validates by `isinstance`, so a string from

--- a/docs/src/content/docs/guides/typeddict.md
+++ b/docs/src/content/docs/guides/typeddict.md
@@ -198,6 +198,9 @@ guide](/guides/dataclasses/) covers the rest, and it all behaves the same with a
 - [Key facets on fields](/guides/dataclasses/#key-facets-on-fields): `Key(...)` in
   the `Annotated` metadata to redact, alias, group, forbid, or override the presence
   of a field.
+- [Extra keys propagating into nested schemas](/guides/dataclasses/#extra-keys-all-the-way-down):
+  `extra` applies at every level, including a nested `TypedDict`, and `Key(extra=...)`
+  pins a different policy for one field's subtree.
 
 The one difference is the result: a dataclass schema constructs an instance, a
 TypedDict schema returns the validated dict. Because nothing is constructed, a

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -165,6 +165,7 @@ def _base_asserts_the_result(base_schema: TypingAny) -> bool:
 def _annotation_to_schema(  # noqa: PLR0911, PLR0912
     annotation: TypingAny,
     self_refs: dict[type, _RecursiveSchemaRef],
+    extra: int,
 ) -> TypingAny:
     """Map a single type annotation to a probatio schema fragment.
 
@@ -172,6 +173,11 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
     deferred reference. A field whose type is one of them (a self-referential or
     mutually recursive dataclass) becomes that reference instead of recursing
     forever, and the reference resolves once its schema is built.
+
+    ``extra`` is the enclosing schema's extra-key policy, threaded into every
+    nested dataclass, TypedDict, and container so the policy applies all the way
+    down. A ``Key(extra=...)`` in a field's ``Annotated`` metadata overrides it for
+    that field's subtree.
     """
     if annotation is TypingAny:
         return object
@@ -180,13 +186,16 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
 
     if hasattr(annotation, "__supertype__"):
         # A ``NewType`` is a thin alias; validate against the type it wraps.
-        return _annotation_to_schema(annotation.__supertype__, self_refs)
+        return _annotation_to_schema(annotation.__supertype__, self_refs, extra)
 
     if get_origin(annotation) is Annotated:
         # Callable Annotated metadata are extra validators; other metadata is for
-        # other tools and is ignored here.
+        # other tools and is ignored here. A ``Key(extra=...)`` pins the extra-key
+        # policy for this field's subtree, overriding the inherited one.
         base, *meta = get_args(annotation)
-        base_schema = _annotation_to_schema(base, self_refs)
+        key = next((item for item in meta if isinstance(item, Key)), None)
+        field_extra = key.extra if key is not None and key.extra is not None else extra
+        base_schema = _annotation_to_schema(base, self_refs, field_extra)
         extras = [item for item in meta if callable(item)]
         if not extras:
             return base_schema
@@ -206,14 +215,14 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
     if _is_dataclass_type(annotation):
         if annotation in self_refs:
             return self_refs[annotation]
-        return create_dataclass_schema(annotation, _self_refs=self_refs)
+        return create_dataclass_schema(annotation, extra=extra, _self_refs=self_refs)
 
     if is_typeddict(annotation):
         # A nested TypedDict validates as its own mapping schema (it cannot be an
         # ``isinstance`` check, since a TypedDict has no runtime type).
         if annotation in self_refs:
             return self_refs[annotation]
-        return create_typeddict_schema(annotation, _self_refs=self_refs)
+        return create_typeddict_schema(annotation, extra=extra, _self_refs=self_refs)
 
     origin = get_origin(annotation)
     if origin is None:
@@ -223,7 +232,7 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
 
     args = get_args(annotation)
     if origin in (TypingUnion, types.UnionType):
-        return _union_to_schema(args, self_refs)
+        return _union_to_schema(args, self_refs, extra)
     if origin is Literal:
         return In(list(args))
     if not args:
@@ -231,30 +240,31 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
         # to descend into, so validate the container type itself.
         return origin
     if origin is list:
-        return [_annotation_to_schema(args[0], self_refs)]
+        return [_annotation_to_schema(args[0], self_refs, extra)]
     if origin is set:
-        return {_annotation_to_schema(args[0], self_refs)}
+        return {_annotation_to_schema(args[0], self_refs, extra)}
     if origin is frozenset:
-        return frozenset([_annotation_to_schema(args[0], self_refs)])
+        return frozenset([_annotation_to_schema(args[0], self_refs, extra)])
     if origin is dict:
         return {
-            _annotation_to_schema(args[0], self_refs): _annotation_to_schema(
+            _annotation_to_schema(args[0], self_refs, extra): _annotation_to_schema(
                 args[1],
                 self_refs,
+                extra,
             ),
         }
     if origin is tuple:
-        return _tuple_to_schema(args, self_refs)
+        return _tuple_to_schema(args, self_refs, extra)
     if origin in (Sequence, MutableSequence):
         # An abstract sequence validates element-wise like a list; config data
         # arrives as a list, and a str (also a Sequence) is correctly not one.
-        return [_annotation_to_schema(args[0], self_refs)]
+        return [_annotation_to_schema(args[0], self_refs, extra)]
     if origin in (AbstractSet, MutableSet):
-        return {_annotation_to_schema(args[0], self_refs)}
+        return {_annotation_to_schema(args[0], self_refs, extra)}
     if origin in (Mapping, MutableMapping):
         return {
-            _annotation_to_schema(args[0], self_refs): _annotation_to_schema(
-                args[1], self_refs
+            _annotation_to_schema(args[0], self_refs, extra): _annotation_to_schema(
+                args[1], self_refs, extra
             ),
         }
     # For other generics, validate the container type instead of accepting
@@ -263,7 +273,9 @@ def _annotation_to_schema(  # noqa: PLR0911, PLR0912
 
 
 def _union_to_schema(
-    args: tuple[TypingAny, ...], self_refs: dict[type, _RecursiveSchemaRef]
+    args: tuple[TypingAny, ...],
+    self_refs: dict[type, _RecursiveSchemaRef],
+    extra: int,
 ) -> TypingAny:
     """Map a union: ``X | None`` becomes ``Maybe(X)``, a wider union becomes ``Any``.
 
@@ -274,7 +286,7 @@ def _union_to_schema(
     """
     has_none = type(None) in args
     member_types = [a for a in args if a is not type(None)]
-    members = [_annotation_to_schema(a, self_refs) for a in member_types]
+    members = [_annotation_to_schema(a, self_refs, extra) for a in member_types]
 
     if len(members) == 1:
         inner: TypingAny = members[0]
@@ -354,7 +366,9 @@ def _make_discriminant(
 
 
 def _tuple_to_schema(
-    args: tuple[TypingAny, ...], self_refs: dict[type, _RecursiveSchemaRef]
+    args: tuple[TypingAny, ...],
+    self_refs: dict[type, _RecursiveSchemaRef],
+    extra: int,
 ) -> TypingAny:
     """Map a tuple: ``tuple[X, ...]`` is homogeneous, ``tuple[X, Y]`` is positional.
 
@@ -362,9 +376,9 @@ def _tuple_to_schema(
     and preserve whichever was given (the value is not coerced between them).
     """
     if len(args) == 2 and args[1] is Ellipsis:
-        element = _annotation_to_schema(args[0], self_refs)
+        element = _annotation_to_schema(args[0], self_refs, extra)
         return Any([element], (element,))
-    return ExactSequence([_annotation_to_schema(a, self_refs) for a in args])
+    return ExactSequence([_annotation_to_schema(a, self_refs, extra) for a in args])
 
 
 def _constant(value: TypingAny) -> TypingAny:
@@ -561,6 +575,7 @@ def _field_mapping(
     dataclass_type: type,
     constraints: dict[str, TypingAny],
     self_refs: dict[type, _RecursiveSchemaRef],
+    extra: int,
 ) -> dict[TypingAny, TypingAny]:
     """Build the mapping schema for a dataclass's constructor fields."""
     try:
@@ -574,7 +589,7 @@ def _field_mapping(
     mapping: dict[TypingAny, TypingAny] = {}
     for field in _iter_init_fields(dataclass_type):
         annotation = _field_annotation(hints.get(field.name, TypingAny))
-        value_schema = _annotation_to_schema(annotation, self_refs)
+        value_schema = _annotation_to_schema(annotation, self_refs, extra)
         if field.name in constraints:
             value_schema = All(value_schema, constraints[field.name])
 
@@ -680,7 +695,9 @@ def create_dataclass_schema(
     self_refs = dict(_self_refs or {})
     ref = _RecursiveSchemaRef()
     self_refs[dataclass_type] = ref
-    mapping = _field_mapping(dataclass_type, additional_constraints or {}, self_refs)
+    mapping = _field_mapping(
+        dataclass_type, additional_constraints or {}, self_refs, extra
+    )
 
     # DataclassSchema compiles mapping validation and construction together, so it
     # needs an interpreted inner mapping to read from.
@@ -1123,6 +1140,7 @@ def _typeddict_mapping(
     typeddict_type: TypingAny,
     constraints: dict[str, TypingAny],
     self_refs: dict[type, _RecursiveSchemaRef],
+    extra: int,
 ) -> dict[TypingAny, TypingAny]:
     """Build the mapping schema for a TypedDict's fields."""
     try:
@@ -1146,7 +1164,7 @@ def _typeddict_mapping(
         required, field_type = _typeddict_presence(
             annotation, default_required=name in required_keys
         )
-        value_schema = _annotation_to_schema(field_type, self_refs)
+        value_schema = _annotation_to_schema(field_type, self_refs, extra)
         if name in constraints:
             value_schema = All(value_schema, constraints[name])
 
@@ -1195,7 +1213,7 @@ def create_typeddict_schema(
     ref = _RecursiveSchemaRef()
     self_refs[typeddict_type] = ref
     mapping = _typeddict_mapping(
-        typeddict_type, additional_constraints or {}, self_refs
+        typeddict_type, additional_constraints or {}, self_refs, extra
     )
 
     inner = Schema(mapping, extra=extra)

--- a/src/probatio/decorator.py
+++ b/src/probatio/decorator.py
@@ -16,7 +16,7 @@ from functools import wraps
 
 from probatio.dataclass_schema import _annotation_to_schema
 from probatio.error import SchemaError
-from probatio.schema import ALLOW_EXTRA, Schema
+from probatio.schema import ALLOW_EXTRA, PREVENT_EXTRA, Schema
 from probatio.validators import All
 
 # ``probatio`` preserves the decorated callable's signature for callers: the
@@ -148,7 +148,7 @@ def _parameter_schema(
         if parameter.kind not in _VALIDATED_KINDS:
             continue
         if name in hints:
-            inferred = _annotation_to_schema(hints[name], {})
+            inferred = _annotation_to_schema(hints[name], {}, PREVENT_EXTRA)
             _reject_validator_annotation(
                 func, f"parameter {name!r}", hints[name], inferred
             )
@@ -182,7 +182,7 @@ def _return_schema(
                 f"probatio: returns=True needs a return annotation on {_name(func)!r}"
             )
             raise SchemaError(message)
-        inferred = _annotation_to_schema(hints[_RETURN], {})
+        inferred = _annotation_to_schema(hints[_RETURN], {}, PREVENT_EXTRA)
         _reject_validator_annotation(func, "the return", hints[_RETURN], inferred)
         return Schema(inferred)
     return Schema(returns)

--- a/src/probatio/fields.py
+++ b/src/probatio/fields.py
@@ -33,9 +33,16 @@ class Key:
     ``required`` overrides the presence a dataclass default (or a TypedDict's
     ``total``) would imply. ``description`` and ``msg`` pass through to the marker.
 
+    ``extra`` pins the extra-key policy for this field's own subtree, overriding
+    the one the enclosing schema propagates. Set it (to ``PREVENT_EXTRA``,
+    ``ALLOW_EXTRA``, or ``REMOVE_EXTRA``) on a field whose type is a nested
+    dataclass, TypedDict, or a container of them, to keep that subtree strict while
+    the rest of the schema is loose, or the reverse. On a leaf field (a plain type)
+    it has nothing to apply to and is ignored.
+
     The facets that define the key's role (``alias``, ``forbidden``, ``remove``,
     ``inclusive``, ``exclusive``) are mutually exclusive; ``secret`` layers on top
-    of any of them.
+    of any of them, and ``extra`` is orthogonal to all of them.
     """
 
     secret: bool = False
@@ -48,3 +55,4 @@ class Key:
     required: bool | None = None
     description: Any = None
     msg: str | None = None
+    extra: int | None = None

--- a/tests/__snapshots__/test_public_surface.ambr
+++ b/tests/__snapshots__/test_public_surface.ambr
@@ -867,6 +867,7 @@
         'required POSITIONAL_OR_KEYWORD None',
         'description POSITIONAL_OR_KEYWORD None',
         'msg POSITIONAL_OR_KEYWORD None',
+        'extra POSITIONAL_OR_KEYWORD None',
       ]),
     }),
     'Latitude': dict({

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -1453,68 +1453,92 @@ def test_self_constraint_keeps_the_tower_and_still_validates() -> None:
     assert error.path == ["child", "name"]
 
 
-# --- extra propagates into nested schemas (handoff: nested extra recursion) ---
+# --- the extra-key policy propagates into nested schemas ----------------------
 
 
 @dataclass
 class _XInner:
+    """A nested dataclass, to prove the policy reaches one level down."""
+
     a: int = 0
 
 
 @dataclass
 class _XOuter:
+    """A dataclass holding a nested dataclass and a scalar."""
+
     inner: _XInner = field(default_factory=_XInner)
     x: int = 0
 
 
 @dataclass
 class _XItem:
+    """An element type for a list of dataclasses."""
+
     id: int = 0
 
 
 @dataclass
 class _XColl:
+    """A dataclass holding a list of dataclasses."""
+
     items: list[_XItem] = field(default_factory=list)
 
 
 @dataclass
 class _XEco:
+    """A dataclass nested inside an optional field."""
+
     enabled: bool = False
 
 
 @dataclass
 class _XCtrl:
+    """A dataclass with an ``X | None`` nested dataclass."""
+
     eco: _XEco | None = None
 
 
 @dataclass
 class _XL3:
+    """The deepest level of a three-deep nesting."""
+
     v: int = 0
 
 
 @dataclass
 class _XL2:
+    """The middle level of a three-deep nesting."""
+
     three: _XL3 = field(default_factory=_XL3)
 
 
 @dataclass
 class _XL1:
+    """The top level of a three-deep nesting."""
+
     two: _XL2 = field(default_factory=_XL2)
 
 
 @dataclass
 class _XNode:
+    """A self-referential dataclass, for the policy on a recursive edge."""
+
     name: str = ""
     child: _XNode | None = None
 
 
 @dataclass
 class _XStrict:
+    """A dataclass pinned strict by a Key(extra=...) on its field."""
+
     b: int = 0
 
 
 @dataclass
 class _XMixed:
+    """A loose schema with one field pinned strict via Key(extra=PREVENT_EXTRA)."""
+
     loose: _XInner = field(default_factory=_XInner)
     strict: Annotated[_XStrict, Key(extra=PREVENT_EXTRA)] = field(
         default_factory=_XStrict
@@ -1523,6 +1547,8 @@ class _XMixed:
 
 @dataclass
 class _XLoosenedOuter:
+    """A strict schema with one field pinned loose via Key(extra=REMOVE_EXTRA)."""
+
     loose: Annotated[_XInner, Key(extra=REMOVE_EXTRA)] = field(default_factory=_XInner)
 
 

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -23,6 +23,8 @@ import pytest
 
 from probatio import (
     ALLOW_EXTRA,
+    PREVENT_EXTRA,
+    REMOVE_EXTRA,
     AsDatetime,
     Coerce,
     DataclassSchema,
@@ -1449,3 +1451,141 @@ def test_self_constraint_keeps_the_tower_and_still_validates() -> None:
         schema({"name": "a", "child": {"name": 1, "child": None}})
     (error,) = caught.value.errors
     assert error.path == ["child", "name"]
+
+
+# --- extra propagates into nested schemas (handoff: nested extra recursion) ---
+
+
+@dataclass
+class _XInner:
+    a: int = 0
+
+
+@dataclass
+class _XOuter:
+    inner: _XInner = field(default_factory=_XInner)
+    x: int = 0
+
+
+@dataclass
+class _XItem:
+    id: int = 0
+
+
+@dataclass
+class _XColl:
+    items: list[_XItem] = field(default_factory=list)
+
+
+@dataclass
+class _XEco:
+    enabled: bool = False
+
+
+@dataclass
+class _XCtrl:
+    eco: _XEco | None = None
+
+
+@dataclass
+class _XL3:
+    v: int = 0
+
+
+@dataclass
+class _XL2:
+    three: _XL3 = field(default_factory=_XL3)
+
+
+@dataclass
+class _XL1:
+    two: _XL2 = field(default_factory=_XL2)
+
+
+@dataclass
+class _XNode:
+    name: str = ""
+    child: _XNode | None = None
+
+
+@dataclass
+class _XStrict:
+    b: int = 0
+
+
+@dataclass
+class _XMixed:
+    loose: _XInner = field(default_factory=_XInner)
+    strict: Annotated[_XStrict, Key(extra=PREVENT_EXTRA)] = field(
+        default_factory=_XStrict
+    )
+
+
+@dataclass
+class _XLoosenedOuter:
+    loose: Annotated[_XInner, Key(extra=REMOVE_EXTRA)] = field(default_factory=_XInner)
+
+
+@pytest.mark.parametrize("extra", [REMOVE_EXTRA, ALLOW_EXTRA])
+def test_extra_recurses_into_a_nested_dataclass(extra: int) -> None:
+    """REMOVE_EXTRA and ALLOW_EXTRA drop an unknown key one level down too."""
+    data = {"x": 1, "junk": 9, "inner": {"a": 2, "innerjunk": 3}}
+    assert DataclassSchema(_XOuter, extra=extra)(data) == _XOuter(_XInner(a=2), x=1)
+
+
+def test_nested_extra_default_still_rejects() -> None:
+    """The default (PREVENT_EXTRA) still raises on a nested unknown key."""
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(_XOuter)({"inner": {"a": 2, "innerjunk": 3}})
+    (error,) = caught.value.errors
+    assert error.path == ["inner", "innerjunk"]
+
+
+def test_extra_recurses_under_compilation() -> None:
+    """The compiled engine inherits the propagated nested policy (issue parity)."""
+    data = {"x": 1, "junk": 9, "inner": {"a": 2, "innerjunk": 3}}
+    interpreted = DataclassSchema(_XOuter, extra=REMOVE_EXTRA)
+    compiled = DataclassSchema(_XOuter, extra=REMOVE_EXTRA, compile=True).compile()
+    assert interpreted(dict(data)) == compiled(dict(data)) == _XOuter(_XInner(2), 1)
+
+
+def test_extra_recurses_into_a_list_of_dataclasses() -> None:
+    """A junk key inside a list element is dropped under REMOVE_EXTRA."""
+    result = DataclassSchema(_XColl, extra=REMOVE_EXTRA)({"items": [{"id": 1, "j": 2}]})
+    assert result == _XColl(items=[_XItem(id=1)])
+
+
+def test_extra_recurses_into_an_optional_nested_dataclass() -> None:
+    """A junk key inside an ``X | None`` nested dataclass is dropped."""
+    result = DataclassSchema(_XCtrl, extra=REMOVE_EXTRA)(
+        {"eco": {"enabled": True, "j": 1}}
+    )
+    assert result == _XCtrl(eco=_XEco(enabled=True))
+
+
+def test_extra_recurses_all_the_way_down() -> None:
+    """The policy holds three levels deep."""
+    data = {"two": {"three": {"v": 1, "junk": 2}}}
+    assert DataclassSchema(_XL1, extra=REMOVE_EXTRA)(data) == _XL1(_XL2(_XL3(1)))
+
+
+def test_extra_recurses_across_a_recursive_edge() -> None:
+    """A self-referential tree keeps the policy at depth two and beyond."""
+    data = {"name": "a", "junk": 1, "child": {"name": "b", "junk": 2, "child": None}}
+    result = DataclassSchema(_XNode, extra=REMOVE_EXTRA)(data)
+    assert result == _XNode(name="a", child=_XNode(name="b", child=None))
+
+
+def test_key_extra_pins_a_strict_subtree_inside_a_loose_schema() -> None:
+    """Key(extra=PREVENT_EXTRA) keeps one field strict while the rest is loose."""
+    data = {"loose": {"a": 1, "j": 2}, "strict": {"b": 1, "j": 3}}
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(_XMixed, extra=REMOVE_EXTRA)(data)
+    (error,) = caught.value.errors
+    assert error.path == ["strict", "j"]
+
+
+def test_key_extra_pins_a_loose_subtree_inside_a_strict_schema() -> None:
+    """Key(extra=REMOVE_EXTRA) loosens one field while the schema stays strict."""
+    result = DataclassSchema(_XLoosenedOuter)({"loose": {"a": 5, "junk": 9}})
+    assert result == _XLoosenedOuter(loose=_XInner(a=5))

--- a/tests/test_typeddict_schema.py
+++ b/tests/test_typeddict_schema.py
@@ -14,6 +14,8 @@ import pytest
 
 from probatio import (
     ALLOW_EXTRA,
+    PREVENT_EXTRA,
+    REMOVE_EXTRA,
     Key,
     Range,
     TypedDictSchema,
@@ -312,3 +314,46 @@ def test_required_qualifier_inside_annotated_is_honored() -> None:
     with pytest.raises(MultipleInvalid):
         req({})  # Required honored inside Annotated, in a total=False TypedDict
     assert req({"x": 5}) == {"x": 5}
+
+
+# --- extra propagates into nested schemas (handoff: nested extra recursion) ---
+
+
+class _XTDInner(TypedDict):
+    a: int
+
+
+class _XTDOuter(TypedDict):
+    inner: _XTDInner
+
+
+class _XTDStrictInner(TypedDict):
+    b: int
+
+
+class _XTDMixed(TypedDict):
+    loose: _XTDInner
+    strict: Annotated[_XTDStrictInner, Key(extra=PREVENT_EXTRA)]
+
+
+def test_extra_recurses_into_a_nested_typeddict() -> None:
+    """REMOVE_EXTRA drops an unknown key inside a nested TypedDict."""
+    result = TypedDictSchema(_XTDOuter, extra=REMOVE_EXTRA)({"inner": {"a": 1, "j": 2}})
+    assert result == {"inner": {"a": 1}}
+
+
+def test_nested_typeddict_extra_default_still_rejects() -> None:
+    """The default (PREVENT_EXTRA) still raises on a nested unknown key."""
+    with pytest.raises(MultipleInvalid) as caught:
+        TypedDictSchema(_XTDOuter)({"inner": {"a": 1, "j": 2}})
+    (error,) = caught.value.errors
+    assert error.path == ["inner", "j"]
+
+
+def test_key_extra_pins_a_strict_nested_typeddict() -> None:
+    """Key(extra=PREVENT_EXTRA) keeps one nested TypedDict strict under a loose parent."""
+    data = {"loose": {"a": 1, "j": 2}, "strict": {"b": 1, "j": 3}}
+    with pytest.raises(MultipleInvalid) as caught:
+        TypedDictSchema(_XTDMixed, extra=REMOVE_EXTRA)(data)
+    (error,) = caught.value.errors
+    assert error.path == ["strict", "j"]

--- a/tests/test_typeddict_schema.py
+++ b/tests/test_typeddict_schema.py
@@ -316,22 +316,30 @@ def test_required_qualifier_inside_annotated_is_honored() -> None:
     assert req({"x": 5}) == {"x": 5}
 
 
-# --- extra propagates into nested schemas (handoff: nested extra recursion) ---
+# --- the extra-key policy propagates into nested schemas ----------------------
 
 
 class _XTDInner(TypedDict):
+    """A nested TypedDict, to prove the policy reaches one level down."""
+
     a: int
 
 
 class _XTDOuter(TypedDict):
+    """A TypedDict holding a nested TypedDict."""
+
     inner: _XTDInner
 
 
 class _XTDStrictInner(TypedDict):
+    """A TypedDict pinned strict by a Key(extra=...) on its field."""
+
     b: int
 
 
 class _XTDMixed(TypedDict):
+    """A loose schema with one field pinned strict via Key(extra=PREVENT_EXTRA)."""
+
     loose: _XTDInner
     strict: Annotated[_XTDStrictInner, Key(extra=PREVENT_EXTRA)]
 


### PR DESCRIPTION
## Breaking change

Behavior change (not a hard API break). `extra` now propagates into nested schemas. Before, `DataclassSchema(T, extra=REMOVE_EXTRA)` / `ALLOW_EXTRA` relaxed the policy only for the top-level mapping; every nested level stayed `PREVENT_EXTRA`. Now the policy applies all the way down.

The default (`PREVENT_EXTRA`) is unchanged: a schema that did not set `extra` still rejects unknown keys at every level. Only a schema that opted into `REMOVE_EXTRA` or `ALLOW_EXTRA` sees the deeper effect. Anyone (probably nobody) who relied on "loose at the top, strict one level down" is affected and can pin the old behavior per field with `Key(extra=PREVENT_EXTRA)`.

## Proposed change

Surfaced while migrating [`python-fumis`](https://github.com/frenck/python-fumis) off mashumaro onto Probatio. `DataclassSchema` and `TypedDictSchema` only relaxed the extra-key policy for the top-level mapping; a nested dataclass, TypedDict, or dataclass inside a `list`/`dict`/`tuple`/union was rebuilt with the hardcoded `PREVENT_EXTRA` default, so an unknown key one level down still raised. The headline case, parsing an external API response into a tree of dataclasses while dropping unmodeled fields, could not be expressed without an `Any`-typed wrapper per level.

- Thread `extra` through `_annotation_to_schema` and every recursion site (nested dataclass, TypedDict, `list`/`set`/`dict`/`tuple`, unions), plus `_field_mapping`/`_typeddict_mapping` and both `create_*` entry points, so the policy applies all the way down.
- Add `Key(extra=...)`: an `Annotated`-metadata override that pins a different policy for one field's subtree (keep one noisy sub-object loose while the rest is strict, or the reverse).

Interactions, all verified:

- **Compiled engine**: inherits the propagated policy for free, since the nested schema carries its own `extra` at build time. The full compiled parity lane is green, and there is an explicit `compile=True` test.
- **Codecs**: `to_json_schema` / `to_openapi` already read per-schema `extra`, so a nested `ALLOW_EXTRA` emits `additionalProperties: true` on the nested object.
- **`@probatio` decorator**: passes `PREVENT_EXTRA` explicitly, so its behavior is unchanged.
- **`additional_constraints`** stays top-level only, as before (the asymmetry is intentional for now).

Tests cover nested dataclass (`REMOVE`/`ALLOW`/default), list/optional/deep/recursive, the `Key(extra=...)` override in both directions, TypedDict parity, and the compiled path. Docs get an "Extra keys, all the way down" section with the `Key(extra=...)` escape hatch, and a TypedDict parity note. The public-surface snapshot picks up `Key.extra`.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: migrating python-fumis onto Probatio (nested external-API payloads)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.