### PR TITLE
Pass a built dataclass instance through instead of re-validating it as a mapping

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -251,6 +251,12 @@ One boundary to know, on which defaults pass through the schema:
   field, an unselected `exclusive` member) takes the dataclass's own default
   exactly as declared: no validation, no coercion.
 
+A nested dataclass field can default to a built instance, the idiomatic
+"always-present, defensive empty object": `inner: Inner = field(default_factory=Inner)`.
+When the key is absent, the `Inner()` fills in as-is; it is not re-validated as a
+mapping. A caller may also hand in an already-built instance for such a field, and
+it passes through untouched; only a mapping is validated and constructed.
+
 The schema validates input, and that second group's values are not input, so
 write an already-typed default for such a field; a wrong-typed one is a type
 error your type-checker flags. See

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -729,6 +729,12 @@ def _fuse_validate_and_construct(
 ) -> CompiledSchema:
     """Return one closure that validates the mapping and constructs the instance.
 
+    An input that is already an instance of the dataclass passes straight through,
+    untouched. That makes an instance-valued default idiomatic (a field typed
+    ``T`` with ``default_factory=T`` fills in a ``T()`` when the key is absent, and
+    the default is not re-validated as a mapping), and it lets a caller hand in a
+    built instance. Only a mapping is validated and constructed.
+
     The public schema shape stays ``Schema(All(inner, _Constructor))``; this is
     only a faster interpreted engine for it. Called generically, that ``All``
     tower is five frames of pure delegation per validation (the callable guard,
@@ -764,6 +770,8 @@ def _fuse_validate_and_construct(
 
         def validate(data: TypingAny) -> TypingAny:
             """Validate the mapping, then construct through the filter."""
+            if isinstance(data, dataclass_type):
+                return data
             validated = validate_mapping(data)
             try:
                 return construct(validated)
@@ -779,6 +787,8 @@ def _fuse_validate_and_construct(
 
     def validate_splat(data: TypingAny) -> TypingAny:
         """Validate the mapping, then splat it straight into the constructor."""
+        if isinstance(data, dataclass_type):
+            return data
         validated = validate_mapping(data)
         try:
             return dataclass_type(**validated)

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -1615,3 +1615,80 @@ def test_key_extra_pins_a_loose_subtree_inside_a_strict_schema() -> None:
     """Key(extra=REMOVE_EXTRA) loosens one field while the schema stays strict."""
     result = DataclassSchema(_XLoosenedOuter)({"loose": {"a": 5, "junk": 9}})
     assert result == _XLoosenedOuter(loose=_XInner(a=5))
+
+
+# --- an instance-valued default is not re-validated as a mapping --------------
+
+
+@dataclass(frozen=True)
+class _IDInner:
+    """A nested dataclass with an all-defaulted field (frozen, so it can be a default)."""
+
+    a: int = 0
+
+
+@dataclass
+class _IDOuter:
+    """A dataclass whose nested field defaults to a constructed instance."""
+
+    inner: _IDInner = field(default_factory=_IDInner)
+    x: int = 0
+
+
+@dataclass
+class _IDLiteral:
+    """A dataclass whose nested field default is a literal instance."""
+
+    inner: _IDInner = _IDInner(a=3)
+
+
+@dataclass
+class _IDMid:
+    """The middle level of a two-deep instance-default nesting."""
+
+    inner: _IDInner = field(default_factory=_IDInner)
+
+
+@dataclass
+class _IDTop:
+    """The top level of a two-deep instance-default nesting."""
+
+    mid: _IDMid = field(default_factory=_IDMid)
+
+
+@pytest.mark.parametrize("extra", [PREVENT_EXTRA, REMOVE_EXTRA, ALLOW_EXTRA])
+def test_instance_default_factory_fills_in_when_absent(extra: int) -> None:
+    """An absent field with default_factory=T constructs the default, not an error."""
+    result = DataclassSchema(_IDOuter, extra=extra)({"x": 5})
+    assert result == _IDOuter(inner=_IDInner(a=0), x=5)
+
+
+def test_literal_instance_default_fills_in_when_absent() -> None:
+    """An absent field with a literal instance default takes that instance."""
+    assert DataclassSchema(_IDLiteral)({}) == _IDLiteral(inner=_IDInner(a=3))
+
+
+def test_instance_default_under_compilation() -> None:
+    """The compiled engine fills an instance default the same as interpreted."""
+    interpreted = DataclassSchema(_IDOuter)
+    compiled = DataclassSchema(_IDOuter, compile=True).compile()
+    assert interpreted({"x": 5}) == compiled({"x": 5}) == _IDOuter(_IDInner(0), 5)
+
+
+def test_a_built_instance_passes_through_as_input() -> None:
+    """A caller may hand in an already-built nested instance; it is not re-validated."""
+    result = DataclassSchema(_IDOuter)({"x": 5, "inner": _IDInner(a=7)})
+    assert result == _IDOuter(inner=_IDInner(a=7), x=5)
+
+
+def test_instance_defaults_fill_in_two_levels_deep() -> None:
+    """Instance defaults fill in at each absent level of a nesting."""
+    assert DataclassSchema(_IDTop)({}) == _IDTop(mid=_IDMid(inner=_IDInner(a=0)))
+
+
+def test_a_present_mapping_still_validates_and_constructs() -> None:
+    """Supplying the key still validates the mapping and constructs (no passthrough)."""
+    result = DataclassSchema(_IDOuter)({"x": 5, "inner": {"a": 9}})
+    assert result == _IDOuter(inner=_IDInner(a=9), x=5)
+    with pytest.raises(MultipleInvalid):
+        DataclassSchema(_IDOuter)({"x": 5, "inner": {"a": "bad"}})


### PR DESCRIPTION
## Breaking change

Behavior change (a previously-erroring input now succeeds, and a nested dataclass field now also accepts a built instance). No API break.

## Proposed change

Surfaced while completing the [`python-fumis`](https://github.com/frenck/python-fumis) migration. A nested dataclass field with an instance-valued default, the idiomatic "always-present, defensive empty object":

```python
@dataclass
class Outer:
    inner: Inner = field(default_factory=Inner)
```

raised when the key was absent. The engine validates a default through the field's value schema (voluptuous's "a default is coerced like input" behavior, which is what makes `default="1"` through `Coerce(int)` yield `1`). For a nested dataclass that schema expects a *mapping*, so the constructed `Inner()` default was rejected with `expected a mapping`. The only workarounds were typing the field `Inner | None = None` (changing its public contract, every consumer grows a `None` check) or `default_factory=dict` (lying about the type).

The fix accepts an already-built instance: the fused validate-and-construct closure returns the value untouched when it is already an instance of the dataclass, otherwise it validates and constructs from a mapping. That is one insertion point every dataclass schema runs through (top-level and nested), and the compiled path routes a non-mapping to the same closure, so both engines agree.

Effects:
- An instance-valued default (`default_factory=T` or a literal `T(...)`) fills in when the key is absent, not re-validated.
- A caller may hand in a built instance for a nested field; it passes through untouched (matching mashumaro / pydantic).
- Container and scalar defaults (`default=dict`, `default=list`, a number) still flow through and coerce as before.
- A present mapping still validates and constructs; a bad nested value still errors.

Tests cover `default_factory` under `PREVENT`/`REMOVE`/`ALLOW`, a literal instance default, the compiled path, two-level nesting, instance-as-input, and the present-mapping/error regressions. Docs get a note in the dataclasses guide.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: migrating python-fumis onto Probatio (defensive nested-object defaults)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.