### PR TITLE
Run an Annotated coercer before a nullable or union base

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -374,6 +374,12 @@ table](#annotations-drive-the-validators)). This works the same way in a nested
 dataclass field, and `additional_constraints` still layers on top. The
 hand-written `Schema(datetime)` path is never affected.
 
+It holds for a nullable or union field too: the coercer runs before the
+`X | None` (or `X | Y`) base confirms the result, so `Annotated[int | None, Coerce(...)]`
+coerces a raw string and `Annotated[datetime | None, Coerce(FromEpoch())]` turns a
+timestamp into a `datetime`, keeping the field's real `int | None` /
+`datetime | None` type instead of falling back to `Any`.
+
 ## Recursive dataclasses
 
 A dataclass whose field refers back to itself (a tree node, a linked list) is

--- a/src/probatio/dataclass_schema.py
+++ b/src/probatio/dataclass_schema.py
@@ -154,12 +154,26 @@ def _base_asserts_the_result(base_schema: TypingAny) -> bool:
     ``__probatio_validate__`` protocol (ADR-007) are bare types too, but they *coerce* a
     raw value into the validated form when compiled, so they are producers and run first
     (like a registry coercer, a nested schema, or a container).
+
+    A ``Maybe`` (from ``X | None``) or a union (from ``X | Y``) asserts when every
+    branch does: it only checks that the raw value is ``None`` or one of the member
+    types. So a coercer in the metadata runs first and the ``Maybe``/union confirms
+    the result, extending the ADR-008 rule from a bare type to a nullable or union
+    base (``Annotated[int | None, Coerce(...)]``). A ``Maybe``/union that wraps a
+    producer (a nested dataclass, a container) is itself a producer and keeps
+    running first.
     """
-    return (
-        isinstance(base_schema, type)
-        and not issubclass(base_schema, enum.Enum)
-        and not callable(getattr(base_schema, "__probatio_validate__", None))
-    )
+    if isinstance(base_schema, type):
+        return not issubclass(base_schema, enum.Enum) and not callable(
+            getattr(base_schema, "__probatio_validate__", None)
+        )
+    if isinstance(base_schema, Maybe):
+        return _base_asserts_the_result(base_schema.validator)
+    if isinstance(base_schema, (Any, Union)):
+        return all(
+            _base_asserts_the_result(member) for member in base_schema.validators
+        )
+    return False
 
 
 def _annotation_to_schema(  # noqa: PLR0911, PLR0912

--- a/tests/test_dataclass_schema.py
+++ b/tests/test_dataclass_schema.py
@@ -28,6 +28,7 @@ from probatio import (
     AsDatetime,
     Coerce,
     DataclassSchema,
+    FromEpoch,
     In,
     Invalid,
     Key,
@@ -38,6 +39,7 @@ from probatio import (
     Self,
     create_dataclass_schema,
     is_dataclass,
+    to_json_schema,
 )
 from probatio import Any as AnyOf
 from probatio.dataclass_schema import _build_discriminant, _literal_tags
@@ -1615,3 +1617,103 @@ def test_key_extra_pins_a_loose_subtree_inside_a_strict_schema() -> None:
     """Key(extra=REMOVE_EXTRA) loosens one field while the schema stays strict."""
     result = DataclassSchema(_XLoosenedOuter)({"loose": {"a": 5, "junk": 9}})
     assert result == _XLoosenedOuter(loose=_XInner(a=5))
+
+
+# --- a coercer runs before a nullable/union base (ADR-008 for unions) ----------
+
+
+def _opt_int(value: object) -> int | None:
+    """Coerce to int, mapping the -1 sentinel to None."""
+    number = int(value)  # type: ignore[arg-type]
+    return None if number == -1 else number
+
+
+@dataclass
+class _UCInt:
+    """A nullable int field that coerces its raw input first."""
+
+    v: Annotated[int | None, Coerce(_opt_int)] = None
+
+
+@dataclass
+class _UCDatetime:
+    """A nullable datetime field coerced from a Unix timestamp."""
+
+    ts: Annotated[datetime.datetime | None, Coerce(FromEpoch())] = None
+
+
+@dataclass
+class _UCWide:
+    """A wider union coerced first (str-or-int narrowed to int)."""
+
+    v: Annotated[int | str, Coerce(_opt_int)] = 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(7, 7), (-1, None), ("5", 5), ("-1", None)],
+)
+def test_coerce_runs_before_a_nullable_int_base(
+    raw: object, expected: int | None
+) -> None:
+    """Annotated[int | None, Coerce(...)] coerces the raw value, then the base confirms."""
+    assert DataclassSchema(_UCInt)({"v": raw}).v == expected
+
+
+def test_coerce_from_epoch_into_a_nullable_datetime() -> None:
+    """A raw timestamp coerces into datetime | None instead of being rejected first."""
+    result = DataclassSchema(_UCDatetime)({"ts": 1719571800}).ts
+    assert result == datetime.datetime(2024, 6, 28, 10, 50, tzinfo=datetime.UTC)
+
+
+def test_coerce_into_a_nullable_base_under_compilation() -> None:
+    """The compiled engine orders the coercer ahead of the base the same way."""
+    interpreted = DataclassSchema(_UCInt)
+    compiled = DataclassSchema(_UCInt, compile=True).compile()
+    assert interpreted({"v": "5"}).v == compiled({"v": "5"}).v == 5
+
+
+def test_coerce_runs_before_a_wider_union_base() -> None:
+    """A coercer runs before an X | Y base too, not only a nullable one."""
+    assert DataclassSchema(_UCWide)({"v": "8"}).v == 8
+
+
+def test_non_union_coerce_is_unchanged() -> None:
+    """A bare-type base still coerces first, then confirms (ADR-008, no regression)."""
+
+    @dataclass
+    class Plain:
+        ts: Annotated[datetime.datetime, FromEpoch()] = None  # type: ignore[assignment]
+
+    result = DataclassSchema(Plain)({"ts": 1719571800}).ts
+    assert result == datetime.datetime(2024, 6, 28, 10, 50, tzinfo=datetime.UTC)
+
+
+def test_codec_of_a_coerced_nullable_field_renders() -> None:
+    """to_json_schema of a coerced nullable field renders without error."""
+    assert "properties" in to_json_schema(DataclassSchema(_UCInt))
+
+
+def _nonempty_street(addr: Address) -> Address:
+    """Reject a constructed Address whose street is empty."""
+    if not addr.street:
+        message = "street must not be empty"
+        raise Invalid(message)
+    return addr
+
+
+@dataclass
+class _AnnProducerBase:
+    """A field whose Annotated base produces (a nested dataclass), with an extra check."""
+
+    addr: Annotated[Address, _nonempty_street]
+
+
+def test_annotated_producer_base_runs_before_the_extra() -> None:
+    """A nested-dataclass base validates and constructs first, then the extra runs on it."""
+    result = DataclassSchema(_AnnProducerBase)(
+        {"addr": {"street": "Main", "number": 5}}
+    )
+    assert result.addr == Address(street="Main", number=5)
+    with pytest.raises(MultipleInvalid):
+        DataclassSchema(_AnnProducerBase)({"addr": {"street": "", "number": 5}})


### PR DESCRIPTION
## Breaking change

Ordering change for one composition: `Annotated[<union or X | None>, <coercer>]` now runs the coercer before the union/nullable base instead of after. A field that previously errored (a raw value that needs coercing) now validates. No API break, and non-union `Annotated` and plain unions without a coercer are unaffected.

## Proposed change

Second of the two frictions from the [`python-fumis`](https://github.com/frenck/python-fumis) migration (the first, instance-valued defaults, is a separate PR).

ADR-008 orders a coercing hint ahead of a bare-type base: the coercer produces the value and the type confirms the result, so `Annotated[datetime, FromEpoch()]` coerces the timestamp first and the `datetime` confirms it. That rule stopped at a union. For a nullable or union field the base was checked *before* the coercer:

```python
@dataclass
class A:
    v: Annotated[int | None, Coerce(opt_int)] = None

DataclassSchema(A)({"v": "5"})   # before: MultipleInvalid: expected int at 'v'
```

The `Maybe(int)` ran on the raw string and rejected it before the `Coerce` could produce an int. `Annotated[datetime | None, Coerce(from_epoch)]` failed on *every* input (a raw int is never a `datetime`). The only robust spelling was `Annotated[Any, Coerce(fn)]`, which throws away the field's real type in the API and the codecs.

The fix extends the ordering rule in `_base_asserts_the_result`: a `Maybe` or union whose branches all assert is itself an asserter, so a coercer in the metadata runs first and the `Maybe`/union confirms the coerced result. A `Maybe`/union that wraps a *producer* (a nested dataclass, a container) stays a producer and keeps running first, so nothing else reorders. The ordering is decided at schema-build time, so the compiled engine and the codecs follow for free.

Result: `Annotated[int | None, Coerce(fn)]` and `Annotated[datetime | None, Coerce(FromEpoch())]` work and keep their real `int | None` / `datetime | None` types.

Tests cover the nullable-int coercer (raw str, int, sentinel), the nullable-datetime timestamp coercer, a wider `X | Y` base, the compiled path, the non-union regression, a producer base (nested dataclass) still running first, and the codec rendering. Docs get a note in the coercion section.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: migrating python-fumis onto Probatio (nullable fields that coerce)
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.