### PR TITLE
Add SchemaMixin: a dataclass gets a cached from_dict by inheriting it

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -288,6 +288,44 @@ is_dataclass(User)  # True
 create_dataclass_schema(User)({"name": "ada"})  # User(name='ada')
 ```
 
+## A `from_dict` mixin
+
+Parsing an API payload into a dataclass tree is the common shape: a
+`DataclassSchema` built once, then called, usually behind a `from_dict`
+classmethod. `SchemaMixin` bundles that into the class. Inherit it, pass the
+extra-key policy as a class argument, and the dataclass gets a cached, validating
+`from_dict`, with no separate module-level schema and no hand-written classmethod.
+
+```python
+from dataclasses import dataclass
+
+from probatio import REMOVE_EXTRA, SchemaMixin
+
+
+@dataclass
+class Server(SchemaMixin, extra=REMOVE_EXTRA):
+    host: str = ""
+    port: int = 80
+
+
+Server.from_dict({"host": "nas", "port": 8080, "unmodeled": 1})
+# Server(host='nas', port=8080)
+```
+
+`from_dict` returns an instance of the class, typed as such, so your editor and
+type-checker know the result. The `DataclassSchema` is built on the first call and
+reused after, and `extra` is inherited: a subclass that sets none keeps the parent's
+policy. The class stays an ordinary dataclass; the mixin adds `from_dict` and records
+`extra`, and leaves the fields alone. A `TypedDict` cannot carry methods, so it keeps
+using `TypedDictSchema` directly.
+
+:::note
+Because a default flows back through the schema when its key is absent, a `Coerce`
+on a defaulted field must be idempotent: it has to take its own already-final default
+(a `datetime`, a `None`) and return it unchanged, rather than convert it a second
+time.
+:::
+
 ## Extra keys, all the way down
 
 `extra` propagates. Set `extra=REMOVE_EXTRA` (or `ALLOW_EXTRA`) and the policy

--- a/src/probatio/__init__.py
+++ b/src/probatio/__init__.py
@@ -110,6 +110,7 @@ from probatio.markers import (
     default_factory,
     extra,
 )
+from probatio.model import SchemaMixin
 from probatio.schema import (
     ALLOW_EXTRA,
     PREVENT_EXTRA,
@@ -451,6 +452,7 @@ __all__ = [
     "ScalarInvalid",
     "Schema",
     "SchemaError",
+    "SchemaMixin",
     "Schemable",
     "Secret",
     "Self",

--- a/src/probatio/model.py
+++ b/src/probatio/model.py
@@ -12,18 +12,17 @@ keeps using ``TypedDictSchema`` directly.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, cast
-from weakref import WeakKeyDictionary
 
 from probatio.dataclass_schema import DataclassSchema
-from probatio.schema import PREVENT_EXTRA
+
+# ``Schema`` is imported at runtime, not under ``TYPE_CHECKING``: the
+# ``_probatio_schema`` annotation below rides in the class, so ``get_type_hints``
+# on a subclass (which the dataclass builder calls) must resolve it without a
+# ``NameError``.
+from probatio.schema import PREVENT_EXTRA, Schema
 
 if TYPE_CHECKING:
     from typing import Self
-
-    from probatio.schema import Schema
-
-# One built schema per subclass, keyed weakly so a throwaway class does not leak.
-_SCHEMAS: WeakKeyDictionary[type, Schema] = WeakKeyDictionary()
 
 
 class SchemaMixin:
@@ -38,13 +37,15 @@ class SchemaMixin:
 
         Config.from_dict({"name": "app", "unknown": 1})  # Config(name='app')
 
-    The ``DataclassSchema`` is built on the first ``from_dict`` and reused after.
-    ``extra`` is inherited: a subclass that does not set its own keeps the parent's
-    policy. The class is a plain dataclass otherwise; the mixin adds ``from_dict``
-    and records ``extra``, and does not touch the fields.
+    The ``DataclassSchema`` is built on the first ``from_dict`` and cached on the
+    class, so it is collected when the class is. ``extra`` is inherited: a subclass
+    that does not set its own keeps the parent's policy. The class is a plain
+    dataclass otherwise; the mixin adds ``from_dict`` and records ``extra``, and
+    does not touch the fields.
     """
 
     _probatio_extra: ClassVar[int] = PREVENT_EXTRA
+    _probatio_schema: ClassVar[Schema | None] = None
 
     def __init_subclass__(cls, *, extra: int | None = None, **kwargs: Any) -> None:
         """Record the subclass's extra-key policy, or inherit the parent's.
@@ -60,10 +61,13 @@ class SchemaMixin:
     @classmethod
     def from_dict(cls, data: Any) -> Self:
         """Validate ``data`` against this dataclass and return the built instance."""
-        schema = _SCHEMAS.get(cls)
+        # Read this class's own cache, not an inherited one: a subclass has different
+        # fields and needs its own schema. Store it on the class so it is collected
+        # with the class rather than pinned alive by a module-level table.
+        schema = cls.__dict__.get("_probatio_schema")
         if schema is None:
             schema = DataclassSchema(cls, extra=cls._probatio_extra)
-            _SCHEMAS[cls] = schema
+            cls._probatio_schema = schema
         # ``Schema.__call__`` is typed ``Any``; the mapping came from ``cls``, so the
         # result is a ``cls`` instance.
         return cast("Self", schema(data))

--- a/src/probatio/model.py
+++ b/src/probatio/model.py
@@ -1,0 +1,69 @@
+"""A mixin that gives a dataclass a validating ``from_dict`` classmethod.
+
+Parsing an external payload into a dataclass tree is the common shape: a
+``DataclassSchema(T, extra=...)`` built once, then called. ``SchemaMixin`` bundles
+that, so a dataclass gets a cached, validating ``from_dict`` by inheriting it,
+without a separate module-level schema or a hand-written classmethod. The class
+stays an ordinary dataclass; the mixin adds one classmethod and records the
+extra-key policy, nothing else. A TypedDict cannot carry methods (PEP 589), so it
+keeps using ``TypedDictSchema`` directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+from weakref import WeakKeyDictionary
+
+from probatio.dataclass_schema import DataclassSchema
+from probatio.schema import PREVENT_EXTRA
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from probatio.schema import Schema
+
+# One built schema per subclass, keyed weakly so a throwaway class does not leak.
+_SCHEMAS: WeakKeyDictionary[type, Schema] = WeakKeyDictionary()
+
+
+class SchemaMixin:
+    """Add a cached, validating ``from_dict`` to a dataclass.
+
+    Inherit it and pass ``extra`` (the schema's extra-key policy) as a class
+    argument::
+
+        @dataclass
+        class Config(SchemaMixin, extra=REMOVE_EXTRA):
+            name: str
+
+        Config.from_dict({"name": "app", "unknown": 1})  # Config(name='app')
+
+    The ``DataclassSchema`` is built on the first ``from_dict`` and reused after.
+    ``extra`` is inherited: a subclass that does not set its own keeps the parent's
+    policy. The class is a plain dataclass otherwise; the mixin adds ``from_dict``
+    and records ``extra``, and does not touch the fields.
+    """
+
+    _probatio_extra: ClassVar[int] = PREVENT_EXTRA
+
+    def __init_subclass__(cls, *, extra: int | None = None, **kwargs: Any) -> None:
+        """Record the subclass's extra-key policy, or inherit the parent's.
+
+        ``extra`` defaults to ``None`` (not passed), which leaves ``_probatio_extra``
+        resolving to the enclosing class's value through the MRO, so a subclass
+        inherits it. A value passed here pins it on this class.
+        """
+        super().__init_subclass__(**kwargs)
+        if extra is not None:
+            cls._probatio_extra = extra
+
+    @classmethod
+    def from_dict(cls, data: Any) -> Self:
+        """Validate ``data`` against this dataclass and return the built instance."""
+        schema = _SCHEMAS.get(cls)
+        if schema is None:
+            schema = DataclassSchema(cls, extra=cls._probatio_extra)
+            _SCHEMAS[cls] = schema
+        # ``Schema.__call__`` is typed ``Any``; the mapping came from ``cls``, so the
+        # result is a ``cls`` instance.
+        return cast("Self", schema(data))

--- a/tests/__snapshots__/test_public_surface.ambr
+++ b/tests/__snapshots__/test_public_surface.ambr
@@ -1298,6 +1298,11 @@
     'SchemaError': dict({
       'kind': 'class',
     }),
+    'SchemaMixin': dict({
+      'kind': 'class',
+      'signature': list([
+      ]),
+    }),
     'Schemable': dict({
       'kind': 'value',
     }),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import gc
+import weakref
+from dataclasses import dataclass, field, make_dataclass
 from typing import Annotated
 
 import pytest
@@ -108,7 +110,9 @@ def test_schema_is_built_once_and_reused() -> None:
 
 def test_the_nested_fixes_flow_through_from_dict() -> None:
     """Nested extra, an instance default, and a union coercer all apply via from_dict."""
-    result = Outer.from_dict({"inner": {"a": 9, "innerjunk": 1}, "label": "5", "top": 2})
+    result = Outer.from_dict(
+        {"inner": {"a": 9, "innerjunk": 1}, "label": "5", "top": 2}
+    )
     assert result == Outer(inner=Inner(a=9), label=5)
     assert Outer.from_dict({}) == Outer(inner=Inner(a=0), label=None)
 
@@ -121,3 +125,13 @@ def test_a_non_dataclass_subclass_raises() -> None:
 
     with pytest.raises(SchemaError):
         NotADataclass.from_dict({})
+
+
+def test_the_cached_schema_does_not_pin_a_throwaway_class() -> None:
+    """A dynamically created model is collectible after use; the cache dies with it."""
+    tmp = make_dataclass("Tmp", [("v", int)], bases=(SchemaMixin,))
+    tmp.from_dict({"v": 5})  # builds and caches the schema on the class
+    ref = weakref.ref(tmp)
+    del tmp
+    gc.collect()
+    assert ref() is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,123 @@
+"""The SchemaMixin: a dataclass gets a cached, validating from_dict by inheriting it."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Annotated
+
+import pytest
+
+from probatio import (
+    ALLOW_EXTRA,
+    REMOVE_EXTRA,
+    Coerce,
+    MultipleInvalid,
+    SchemaError,
+    SchemaMixin,
+)
+
+
+@dataclass
+class Point(SchemaMixin):
+    """A closed model (the default PREVENT_EXTRA)."""
+
+    x: int
+    y: int = 0
+
+
+@dataclass
+class Loose(SchemaMixin, extra=REMOVE_EXTRA):
+    """A model that drops unknown keys."""
+
+    name: str = ""
+
+
+@dataclass
+class LooseChild(Loose):
+    """A subclass that sets no policy of its own, so it inherits Loose's."""
+
+    extra_field: int = 0
+
+
+@dataclass(frozen=True)
+class Inner(SchemaMixin, extra=REMOVE_EXTRA):
+    """A nested frozen model with an all-defaulted field."""
+
+    a: int = 0
+
+
+@dataclass(frozen=True)
+class Outer(SchemaMixin, extra=REMOVE_EXTRA):
+    """A frozen model exercising the nested fixes through from_dict."""
+
+    inner: Inner = field(default_factory=Inner)
+    label: Annotated[
+        int | None, Coerce(lambda v: None if v in (None, "-1") else int(v))
+    ] = None
+
+
+def test_from_dict_validates_and_constructs() -> None:
+    """from_dict validates the mapping and returns a built instance."""
+    result = Point.from_dict({"x": 1, "y": 2})
+    assert result == Point(x=1, y=2)
+    assert isinstance(result, Point)
+
+
+def test_from_dict_reports_a_validation_error() -> None:
+    """A bad field is reported like any DataclassSchema call."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Point.from_dict({"x": "no"})
+    assert caught.value.errors[0].path == ["x"]
+
+
+def test_default_policy_is_prevent_extra() -> None:
+    """Without an extra argument, an unknown key is rejected."""
+    with pytest.raises(MultipleInvalid):
+        Point.from_dict({"x": 1, "junk": 2})
+
+
+def test_extra_policy_is_applied() -> None:
+    """extra=REMOVE_EXTRA on the class drops an unknown key."""
+    assert Loose.from_dict({"name": "app", "junk": 1}) == Loose(name="app")
+
+
+def test_extra_is_inherited_by_a_subclass() -> None:
+    """A subclass that sets no policy keeps the parent's extra."""
+    assert LooseChild._probatio_extra == REMOVE_EXTRA
+    result = LooseChild.from_dict({"name": "app", "extra_field": 3, "junk": 9})
+    assert result == LooseChild(name="app", extra_field=3)
+
+
+def test_a_subclass_can_override_the_policy() -> None:
+    """A subclass may pin its own extra, not the parent's."""
+
+    @dataclass
+    class Strict(Loose, extra=ALLOW_EXTRA):
+        pass
+
+    assert Strict._probatio_extra == ALLOW_EXTRA
+
+
+def test_schema_is_built_once_and_reused() -> None:
+    """Two from_dict calls succeed; the schema is built on the first and cached."""
+    first = Point.from_dict({"x": 1})
+    second = Point.from_dict({"x": 2})
+    assert first == Point(x=1)
+    assert second == Point(x=2)
+
+
+def test_the_nested_fixes_flow_through_from_dict() -> None:
+    """Nested extra, an instance default, and a union coercer all apply via from_dict."""
+    result = Outer.from_dict({"inner": {"a": 9, "innerjunk": 1}, "label": "5", "top": 2})
+    assert result == Outer(inner=Inner(a=9), label=5)
+    assert Outer.from_dict({}) == Outer(inner=Inner(a=0), label=None)
+
+
+def test_a_non_dataclass_subclass_raises() -> None:
+    """Using the mixin on a non-dataclass fails clearly when from_dict is called."""
+
+    class NotADataclass(SchemaMixin):
+        pass
+
+    with pytest.raises(SchemaError):
+        NotADataclass.from_dict({})


### PR DESCRIPTION
## Breaking change

None. New optional public name.

## Proposed change

Parsing an external payload into a dataclass tree is the most common way to use `DataclassSchema`, and it means the same boilerplate every time: a module-level schema built after the class, plus a `from_dict` classmethod that forward-references it.

```python
@dataclass
class FumisInfo:
    ...
    @classmethod
    def from_dict(cls, data: dict) -> FumisInfo:
        return FUMIS_INFO_SCHEMA(data)

FUMIS_INFO_SCHEMA = DataclassSchema(FumisInfo, extra=REMOVE_EXTRA)
```

`SchemaMixin` bundles that into the class:

```python
@dataclass
class FumisInfo(SchemaMixin, extra=REMOVE_EXTRA):
    ...

FumisInfo.from_dict(data)   # same call site, now typed -> FumisInfo
```

- The `DataclassSchema` is built on the first `from_dict` and reused after, keyed weakly so a throwaway class does not leak.
- `extra` is a class keyword (`class X(SchemaMixin, extra=REMOVE_EXTRA)`) and is inherited: a subclass that sets none keeps the parent's policy.
- `from_dict` is typed to return the class (`-> Self`), so an editor and type-checker know the result. mypy confirms `X.from_dict(data)` is `X`.
- The class stays an ordinary dataclass. The mixin adds one classmethod and records `extra`, and leaves the fields alone. Everything else (nested `extra` recursion, instance defaults, union coercers) flows through it.

Dataclass only, on purpose: a `TypedDict` cannot carry methods or inherit a non-TypedDict base (PEP 589), and returns a validated dict with no instance to construct, so it keeps using `TypedDictSchema` directly. `extra` is the only class keyword for now; `required=` is a one-line addition if it is wanted.

Validated on a real integration: the [`python-fumis`](https://github.com/frenck/python-fumis) models migrated to `SchemaMixin` pass their full suite (120 tests) across the whole nested, frozen, aliased, coerced tree.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: developer experience for the dataclass parse-from-dict pattern
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.