### PR TITLE
Return a datetime through FromEpoch unchanged so it is idempotent

### DIFF
--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -579,10 +579,11 @@ class FromEpoch(_SafeValidator):
     so the same input would validate to different moments on different machines. A
     ``bool``, a string, or an out-of-range or NaN value is rejected.
 
-    A ``datetime`` already is returned unchanged (like ``AsTimedelta`` with a
-    ``timedelta`` and the ``As*`` validators with their native types), so the
-    validator is idempotent: it sits on a field whose default is a ``datetime``
-    without re-converting that default when it flows back through the schema.
+    An aware UTC ``datetime`` (what this validator itself produces) is returned
+    unchanged, so the validator is idempotent: it sits on a field whose default is
+    such a ``datetime`` without re-converting it when the default flows back through
+    the schema. A naive or non-UTC ``datetime`` is rejected, not silently passed on,
+    so the always-aware-and-UTC guarantee holds for every result.
     """
 
     def __init__(self, unit: str = "seconds", msg: str | None = None) -> None:
@@ -601,7 +602,14 @@ class FromEpoch(_SafeValidator):
     def __call__(self, value: typing.Any) -> datetime.datetime:
         """Return the timestamp as an aware UTC datetime, else raise EpochInvalid."""
         if isinstance(value, datetime.datetime):
-            return value
+            # Pass through only a value this validator could have produced: an aware
+            # UTC datetime. A naive or non-UTC one would break the always-UTC
+            # guarantee and reintroduce host-timezone dependence, so reject it like
+            # any other bad value. A zero UTC offset is the UTC test; it is ``None``
+            # for a naive datetime, which never equals the zero timedelta.
+            if value.utcoffset() == datetime.timedelta(0):
+                return value
+            raise EpochInvalid(self.msg, translation_key="expected_unix_timestamp")
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise EpochInvalid(self.msg, translation_key="expected_unix_timestamp")
 

--- a/src/probatio/validators/temporal.py
+++ b/src/probatio/validators/temporal.py
@@ -578,6 +578,11 @@ class FromEpoch(_SafeValidator):
     aware and in UTC: a naive, local result would depend on the host's time zone,
     so the same input would validate to different moments on different machines. A
     ``bool``, a string, or an out-of-range or NaN value is rejected.
+
+    A ``datetime`` already is returned unchanged (like ``AsTimedelta`` with a
+    ``timedelta`` and the ``As*`` validators with their native types), so the
+    validator is idempotent: it sits on a field whose default is a ``datetime``
+    without re-converting that default when it flows back through the schema.
     """
 
     def __init__(self, unit: str = "seconds", msg: str | None = None) -> None:
@@ -595,6 +600,8 @@ class FromEpoch(_SafeValidator):
 
     def __call__(self, value: typing.Any) -> datetime.datetime:
         """Return the timestamp as an aware UTC datetime, else raise EpochInvalid."""
+        if isinstance(value, datetime.datetime):
+            return value
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise EpochInvalid(self.msg, translation_key="expected_unix_timestamp")
 

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -435,11 +435,27 @@ def test_epoch_accepts_a_float() -> None:
     assert result.microsecond == 500000
 
 
-def test_epoch_passes_a_datetime_through_unchanged() -> None:
-    """A datetime is returned as-is, so FromEpoch is idempotent on its own output."""
+def test_epoch_passes_an_aware_utc_datetime_through_unchanged() -> None:
+    """An aware UTC datetime is returned as-is, so FromEpoch is idempotent on its output."""
     once = Schema(FromEpoch())(1719571800)
     twice = Schema(FromEpoch())(once)
     assert twice is once
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.datetime(2024, 6, 28, 10, 50),  # naive
+        datetime.datetime(
+            2024, 6, 28, 10, 50, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
+        ),  # aware, non-UTC
+    ],
+)
+def test_epoch_rejects_a_naive_or_non_utc_datetime(value: datetime.datetime) -> None:
+    """A naive or non-UTC datetime is rejected, keeping the always-aware-UTC guarantee."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(FromEpoch())(value)
+    assert isinstance(caught.value.errors[0], EpochInvalid)
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/test_temporal.py
+++ b/tests/validators/test_temporal.py
@@ -435,6 +435,13 @@ def test_epoch_accepts_a_float() -> None:
     assert result.microsecond == 500000
 
 
+def test_epoch_passes_a_datetime_through_unchanged() -> None:
+    """A datetime is returned as-is, so FromEpoch is idempotent on its own output."""
+    once = Schema(FromEpoch())(1719571800)
+    twice = Schema(FromEpoch())(once)
+    assert twice is once
+
+
 @pytest.mark.parametrize(
     "value", [True, "1719571800", float("nan"), float("inf"), 10**30]
 )


### PR DESCRIPTION
## Breaking change

None. A `datetime` was rejected before and is now returned unchanged; nothing that used to validate changes result.

## Proposed change

`FromEpoch` parses an `int` or `float` epoch count into a timezone-aware UTC `datetime`. Passed a `datetime`, it raised "expected a Unix timestamp". That made the validator non-idempotent: a dataclass field whose default is a `datetime` could not flow back through the schema without a hand-rolled coercer to pass the already-converted value through.

This returns a `datetime` as-is before the numeric check, so `FromEpoch` is idempotent on its own output. It matches `AsTimedelta` returning a `timedelta` unchanged and the `As*` validators returning their native types. The `bool` and string rejections are untouched: neither is a `datetime`, so the new branch never shadows them.

Surfaced while porting python-fumis, where a `_to_epoch` helper existed only to work around this.

## Type of change

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.