### PR TITLE
Surface AsTimedelta and Maybe(Coerce(...)) as coerce-or-passthrough idioms

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -424,6 +424,37 @@ coerces a raw string and `Annotated[datetime | None, Coerce(FromEpoch())]` turns
 timestamp into a `datetime`, keeping the field's real `int | None` /
 `datetime | None` type instead of falling back to `Any`.
 
+Reach for a built-in coercer before writing a lambda. `AsTimedelta` reads a
+count of seconds, a `H:MM:SS` string, or an ISO 8601 duration into a `timedelta`,
+and `Maybe(Coerce(float))` coerces a value while letting `None` through. Both
+compose straight onto a field, so a "seconds or a `timedelta`" field is
+`Annotated[timedelta, AsTimedelta()]` and an "optional, coerce if present" field
+is `Annotated[float | None, Maybe(Coerce(float))]`, with no coercer of your own to
+write or test:
+
+```python
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Annotated
+
+from probatio import AsTimedelta, Coerce, DataclassSchema, Maybe
+
+
+@dataclass
+class Job:
+    timeout: Annotated[timedelta, AsTimedelta()] = timedelta()
+    ratio: Annotated[float | None, Maybe(Coerce(float))] = None
+
+
+DataclassSchema(Job)({"timeout": 90, "ratio": "0.5"})
+# Job(timeout=datetime.timedelta(seconds=90), ratio=0.5)
+```
+
+The `As*` coercers return their native type unchanged (`AsTimedelta` on a
+`timedelta`, `AsDatetime` on a `datetime`), so they are idempotent in the sense
+above: one sits on a defaulted field without re-converting the default when it
+flows back through the schema.
+
 ## Recursive dataclasses
 
 A dataclass whose field refers back to itself (a tree node, a linked list) is

--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -135,6 +135,17 @@ Schema(Maybe(int))(5)                     # 5
 Schema(EnsureList())("one")               # ['one']
 ```
 
+`Maybe` composes with a coercer for the "optional, coerce if present" field:
+`Maybe(Coerce(float))` leaves `None` alone and coerces anything else, so there is
+no null check to hand-write:
+
+```python
+from probatio import Schema, Maybe, Coerce
+
+Schema(Maybe(Coerce(float)))(None)    # None
+Schema(Maybe(Coerce(float)))("0.5")   # 0.5
+```
+
 `Sorted` requires a collection to already be in order (it does not reorder):
 
 ```python


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

People reinvent a "seconds to a `timedelta`" or an "optional, coerce if present" coercer when a built-in already composes for it. This adds documentation pointing at `AsTimedelta` for a duration field and `Maybe(Coerce(float))` for a nullable coerced field:

- In the dataclasses guide, under "Coercing a field's type": a note with a runnable `Job` example, plus a line tying the `As*` native passthrough to the defaulted-field idempotency the guide already documents.
- In the validators guide, next to the `Maybe` examples: a short `Maybe(Coerce(float))` composition so the pattern is discoverable there too.

Surfaced while porting python-fumis, which had hand-rolled helpers that these built-ins cover. No API change; both examples are executed by `docs/verify_examples.py`. `FromEpoch` idempotency is intentionally left out of the prose here, since that behavior lands in a separate change; every claim in this PR holds on `main` today.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.