### PR TITLE
Frame from_dict as the validation boundary in the mixin guide

### DIFF
--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -319,6 +319,14 @@ policy. The class stays an ordinary dataclass; the mixin adds `from_dict` and re
 `extra`, and leaves the fields alone. A `TypedDict` cannot carry methods, so it keeps
 using `TypedDictSchema` directly.
 
+`from_dict` is the validation boundary, not the class. Coming from pydantic, this
+is the one thing to know: `SchemaMixin` does not make the dataclass validate itself.
+Constructing one directly (`Server(host="nas", port="no")`) runs no validation, the
+same as any plain dataclass, and a type-checker already flags the wrong type there.
+Validate untrusted input at the edge with `from_dict`, and treat an instance you
+already hold as trusted. The schema stays separate from the data, so the same
+dataclass keeps working with probatio nowhere in sight.
+
 :::note
 Because a default flows back through the schema when its key is absent, a `Coerce`
 on a defaulted field must be idempotent: it has to take its own already-final default


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

`SchemaMixin` makes a dataclass read as a self-validating model, so a reader coming from pydantic can reasonably expect direct construction to validate. It does not: the class stays a plain dataclass and `from_dict` is the validation boundary. This adds one paragraph to the mixin section of the dataclasses guide that says so plainly, names the pydantic expectation directly, and points at the type-checker already flagging the obvious mistake (`Server(port="no")`). It turns the boundary-validation design into a choice on the page rather than a surprise. Docs only, no API change.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.