### PR TITLE
Honor the PEP 484 numeric tower for a bare float

### DIFF
--- a/adr/017-numeric-tower-for-float.md
+++ b/adr/017-numeric-tower-for-float.md
@@ -1,0 +1,80 @@
+# ADR-017: Honor the numeric tower for a bare `float`
+
+**Date**: 2026-07-07
+**Status**: Accepted
+
+**Context**: A bare `float` schema validated by `isinstance`, so `Schema(float)(5)`
+raised "expected float" and only a `float` was accepted. That matches voluptuous,
+which is the behavior probatio deliberately mirrors (ADR-001). It is also wrong on
+its own terms.
+
+`5` is not dirty data in a `float` field: it genuinely is a valid float value. PEP
+484 states that when an argument is annotated `float`, an argument of type `int` is
+acceptable, and PEP 3141 grounds this at runtime (an `int` is a `numbers.Real`).
+Rejecting it rejects correct input on a representational technicality, and the only
+workaround was a `Coerce(float)` that normalizes nothing meaningful. In the
+python-fumis migration that was five fields wearing `Coerce(float)` plus three more
+`Maybe(Coerce(float))` for the optional ones, annotation noise standing in for a
+rule the type system already implies.
+
+The old rule was also inconsistent with the rest of probatio:
+
+- `to_json_schema(Schema(float))` already emits `{"type": "number"}`, and in JSON
+  Schema `number` accepts integers. So the schema probatio _published_ said `5` is
+  valid while the validator probatio _ran_ rejected it.
+- The `isinstance` rule already leaks the numeric tower in the worse direction:
+  `Schema(int)(True)` returns `True`, because `bool` is a subclass of `int`. So
+  probatio was never principled about the numeric hierarchy; it accepted
+  `bool`-as-`int` (the footgun) while rejecting `int`-as-`float` (the harmless one).
+
+This is a different case from a `str` in an `int` field. That one is dirty: reject
+it, or coerce it deliberately. The tower is exactly the place where strictness buys
+nothing.
+
+**Decision**: A bare `float` honors the numeric tower on every path a bare type
+reaches (`Schema(float)`, a mapping value, a sequence element, a dataclass or
+TypedDict field, a union or `Maybe` base):
+
+- a `float` passes through unchanged (a `float` subclass included),
+- an `int` is accepted and returned as `float(value)`,
+- `bool` is excluded (an `int` subclass, but not a number a `float` field should
+  hold),
+- everything else (a `str`, `None`, a `complex`) is rejected as before.
+
+It accepts _and coerces_ rather than passing the `int` through, so a `float` field
+never ends up holding an `int` and the "the type is true" invariant holds. The rule
+lives in one place (`_FloatCheck`) and applies to the bare `Schema(float)` validator
+as well as the annotation path, so there is no seam between the two.
+
+This is a deliberate, documented deviation from voluptuous (ADR-001), the first on
+the scalar type path. It only ever turns a rejection into an acceptance, so it
+cannot change the result of a validation that passes today.
+
+Bounded on purpose:
+
+- **`complex`.** The tower also makes a `float` (and `int`) acceptable where
+  `complex` is annotated. Rare, and deferred: `Schema(complex)(5.0)` still rejects.
+  Recorded here so the omission is a decision, not a gap.
+- **`bool`-as-`int`.** A bare `int` still accepts `True` today. Tightening that
+  (rejecting `bool` for `int`) is a separate, _stricter_ change with real
+  backward-compatibility weight, so it stays out of this decision.
+
+**Consequences**:
+
+- `Schema(float)` now coerces: `Schema(float)(5)` returns `5.0`. A validator that
+  used to only ever return its input now normalizes an `int`. This is the intended
+  divergence, not a regression.
+- The runtime agrees with the JSON Schema probatio emits: an integer that
+  `{"type": "number"}` accepts now validates.
+- A `float` used as a matcher matches integers too, because an `int` is now a valid
+  `float`. `Remove(float)` in a list drops ints as well, and a `{float: ...}` type
+  key matches an int key. This follows from the rule and is not special-cased.
+- Migrating off voluptuous, a schema that relied on an `int` being _rejected_ for a
+  `float` field as a strictness signal now accepts it. That reliance is exactly the
+  behavior this ADR argues is wrong, and it is safe by construction otherwise: no
+  passing validation changes its result.
+- `float` loses the inlined `isinstance` fast path the other builtin types keep:
+  `_FloatCheck` exposes no `checked_type`, so the mapping and sequence engines call
+  it instead of inlining, paying one call per float value to get the coercion. The
+  compiled engine inlines the same tower rule in `_codegen`, bailing a `float`
+  subclass or a `bool` to the interpreted `_FloatCheck`, so the two engines agree.

--- a/adr/README.md
+++ b/adr/README.md
@@ -19,3 +19,4 @@ Each record captures what was chosen, the alternatives considered, and why.
 | [ADR-014](014-annotation-driven-argument-decorator.md)      | An annotation-driven argument-validation decorator             |
 | [ADR-015](015-structured-errors-and-localization.md)        | Structured errors, human-first messages, and localization      |
 | [ADR-016](016-remove-serde-loaders-and-dumpers.md)          | Remove the serde loaders and dumpers                           |
+| [ADR-017](017-numeric-tower-for-float.md)                   | Honor the numeric tower for a bare `float`                     |

--- a/docs/src/content/docs/guides/dataclasses.md
+++ b/docs/src/content/docs/guides/dataclasses.md
@@ -88,22 +88,28 @@ schema({"name": "ada", "tags": ["x"], "home": {"street": "Main", "number": 5}})
 
 The full set of mappings:
 
-| Annotation                 | Schema                               |
-| -------------------------- | ------------------------------------ |
-| `int`, `str`, a plain type | the type (an `isinstance` check)     |
-| `list[T]`                  | `[T]` (element type validated)       |
-| `set[T]`, `frozenset[T]`   | `{T}` / `frozenset([T])`             |
-| `dict[K, V]`               | `{K: V}` (key and value validated)   |
-| `tuple[X, Y]`              | `ExactSequence([X, Y])` (positional) |
-| `tuple[X, ...]`            | a homogeneous sequence of `X`        |
-| `X \| None`                | `Maybe(X)`                           |
-| `X \| Y`                   | `Any(X, Y)`                          |
-| `Literal["a", "b"]`        | `In(["a", "b"])`                     |
-| a nested dataclass         | its own generated schema             |
-| `Any`                      | accepts any value                    |
+| Annotation                 | Schema                                    |
+| -------------------------- | ----------------------------------------- |
+| `int`, `str`, a plain type | the type (an `isinstance` check)          |
+| `float`                    | the numeric tower (`int` in, `float` out) |
+| `list[T]`                  | `[T]` (element type validated)            |
+| `set[T]`, `frozenset[T]`   | `{T}` / `frozenset([T])`                  |
+| `dict[K, V]`               | `{K: V}` (key and value validated)        |
+| `tuple[X, Y]`              | `ExactSequence([X, Y])` (positional)      |
+| `tuple[X, ...]`            | a homogeneous sequence of `X`             |
+| `X \| None`                | `Maybe(X)`                                |
+| `X \| Y`                   | `Any(X, Y)`                               |
+| `Literal["a", "b"]`        | `In(["a", "b"])`                          |
+| a nested dataclass         | its own generated schema                  |
+| `Any`                      | accepts any value                         |
 
 A tuple field accepts a list or a tuple, since a sequence arrives as a list from
 JSON, and keeps whichever you gave it.
+
+A `float` field is the one plain type that is not a bare `isinstance`. It honors
+the PEP 484 numeric tower: an `int` is a valid `float` value, so `5` is accepted
+and normalized to `5.0`, while `bool`, a string, and `None` are still rejected. See
+[ADR-017](https://github.com/frenck/probatio/blob/main/adr/017-numeric-tower-for-float.md).
 
 ## Layering extra rules
 

--- a/docs/src/content/docs/guides/validation-model.md
+++ b/docs/src/content/docs/guides/validation-model.md
@@ -35,6 +35,11 @@ Each kind of object means something:
 Because a schema is just data, schemas compose: a dict can hold lists of nested
 dicts, and any value position can be a validator like `All` or `Coerce`.
 
+One type is not a bare `isinstance`: `float` honors the PEP 484 numeric tower, so
+`Schema(float)(5)` accepts the `int` and returns `5.0` (`bool` excluded). This is a
+deliberate deviation from voluptuous, which rejects it. See
+[ADR-017](https://github.com/frenck/probatio/blob/main/adr/017-numeric-tower-for-float.md).
+
 ## Compile once, validate many
 
 `Schema(...)` does its analysis up front. Building the schema is the expensive

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -258,6 +258,15 @@ improvement over a sharp edge, not a regression.
 Each entry reads the same way: the behavior, then what voluptuous does, then what
 Probatio does.
 
+- **An `int` in a `float` schema (`Schema(float)(5)`, ADR-017).** voluptuous
+  validates `float` by `isinstance`, so an `int` is rejected. Probatio honors the
+  PEP 484 numeric tower: an `int` is a valid `float` value, so it is accepted and
+  normalized to `float` (`5` becomes `5.0`), while `bool`, a string, and `None` are
+  still rejected. This aligns the validator with the `{"type": "number"}` that
+  `to_json_schema` already emits. A strict widening: only a value voluptuous would
+  have rejected is affected, and a `float` matcher now matches an `int` too (so
+  `Remove(float)` in a list drops ints, and a `{float: ...}` type key matches an int
+  key).
 - **The rendered error string, `str(error)` (ADR-015).** voluptuous renders
   `expected int for dictionary value @ data['server']['port']`. Probatio renders
   the same error as `expected int at 'server.port'`: the path is a dotted trail

--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -286,7 +286,22 @@ def _inline_in(schema: Any, namespace: dict[str, Any], tag: str) -> list[str] | 
 
 
 def _inline_type(schema: type, namespace: dict[str, Any], tag: str) -> list[str] | None:
-    """Inline an isinstance check for a plain (non-Enum) type; ``_v`` is unchanged."""
+    """Inline an isinstance check for a plain (non-Enum) type; ``_v`` is unchanged.
+
+    ``float`` is the exception: it honors the numeric tower (ADR-017), so an ``int``
+    is coerced to ``float`` rather than rejected. A ``float`` subclass or a ``bool``
+    bails to the interpreted ``_FloatCheck``, which decides them, so compiled and
+    interpreted agree.
+    """
+    if schema is float:
+        return [
+            "        if type(_v) is float:",
+            "            pass",
+            "        elif type(_v) is int:",
+            "            _v = float(_v)",
+            "        else:",
+            "            raise _Bail",
+        ]
     if issubclass(schema, Enum):
         return None
     namespace[f"_ty{tag}"] = schema

--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -298,7 +298,10 @@ def _inline_type(schema: type, namespace: dict[str, Any], tag: str) -> list[str]
             "        if type(_v) is float:",
             "            pass",
             "        elif type(_v) is int:",
-            "            _v = float(_v)",
+            "            try:",
+            "                _v = float(_v)",
+            "            except OverflowError:",
+            "                raise _Bail",
             "        else:",
             "            raise _Bail",
         ]

--- a/src/probatio/_compile.py
+++ b/src/probatio/_compile.py
@@ -224,12 +224,23 @@ class _FloatCheck:
 
     __slots__ = ()
 
+    # Read by the ``Any``/``Union`` fast path to recognize the float tower without a
+    # circular import: its accept set is a ``float`` or an ``int`` (never a ``bool``).
+    is_float_tower = True
+
     def __call__(self, data: Any) -> Any:
         """Return a ``float`` unchanged, an ``int`` as ``float``, else raise."""
         if isinstance(data, float):
             return data
         if isinstance(data, int) and not isinstance(data, bool):
-            return float(data)
+            try:
+                return float(data)
+            except OverflowError:
+                # An integer too large to represent as a float (``10**400``, which
+                # JSON can decode from untrusted input) is rejected cleanly rather
+                # than leaking the ``OverflowError`` a leaf validator must never
+                # raise, like ``Coerce`` guards the same conversion.
+                pass
         raise TypeInvalid(
             context={"expected": "float"},
             translation_key="expected_type",

--- a/src/probatio/_compile.py
+++ b/src/probatio/_compile.py
@@ -205,16 +205,54 @@ class _TypeCheck:
         return data
 
 
+class _FloatCheck:
+    """Validate ``float`` honoring the PEP 484 numeric tower: an ``int`` is accepted.
+
+    A bare ``float`` accepts a ``float`` unchanged and an ``int`` normalized to
+    ``float``, and rejects everything else (a ``str``, ``None``, and ``bool``, which
+    is an ``int`` subclass but not a number a ``float`` field should hold). This is a
+    deliberate deviation from voluptuous, whose ``isinstance`` rejects an ``int``
+    here (ADR-017): ``5`` genuinely is a valid ``float`` value, and probatio's own
+    ``to_json_schema`` already emits ``{"type": "number"}``, which accepts integers.
+
+    It accepts *and coerces* rather than passing the ``int`` through, so a ``float``
+    field never ends up holding an ``int`` and the "the type is true" invariant
+    holds. Unlike ``_TypeCheck`` it exposes no ``checked_type``, so the mapping and
+    sequence engines never inline it as a bare ``isinstance`` (which cannot coerce)
+    and always call it, keeping the normalized value.
+    """
+
+    __slots__ = ()
+
+    def __call__(self, data: Any) -> Any:
+        """Return a ``float`` unchanged, an ``int`` as ``float``, else raise."""
+        if isinstance(data, float):
+            return data
+        if isinstance(data, int) and not isinstance(data, bool):
+            return float(data)
+        raise TypeInvalid(
+            context={"expected": "float"},
+            translation_key="expected_type",
+            placeholders={"expected": "float"},
+        )
+
+
+# One shared, immutable ``_FloatCheck``: like the ``_TypeCheck`` instances below it
+# carries no per-schema state, so every ``float`` schema holds the same one.
+_FLOAT_CHECK = _FloatCheck()
+
+
 # One shared ``_TypeCheck`` per builtin type: these are by far the most common
 # type schemas, they cannot grow a ``__probatio_validate__`` (builtins reject
 # setattr), and a ``_TypeCheck`` is immutable (slots, never written after init),
 # so every schema can hold the same instance instead of allocating its own.
+# ``float`` is intentionally absent: it maps to ``_FLOAT_CHECK`` (the numeric
+# tower, ADR-017), not a bare ``isinstance``.
 _BUILTIN_TYPE_CHECKS: dict[type, _TypeCheck] = {
     builtin: _TypeCheck(builtin)
     for builtin in (
         str,
         int,
-        float,
         bool,
         bytes,
         bytearray,
@@ -561,6 +599,10 @@ def _compile_type(schema: type) -> CompiledSchema:
     read to inline the ``isinstance`` into their loops and skip a call per
     value. Called directly (when not inlined) it behaves like the closure.
     """
+    # ``float`` honors the numeric tower (an ``int`` is accepted and normalized),
+    # a deliberate deviation from voluptuous's bare ``isinstance`` (ADR-017).
+    if schema is float:
+        return _FLOAT_CHECK
     # ``type(schema) is type`` excludes metaclass instances, whose custom
     # ``__eq__``/``__hash__`` could otherwise spoof a builtin in the lookup.
     if (

--- a/src/probatio/validators/combinators.py
+++ b/src/probatio/validators/combinators.py
@@ -267,6 +267,45 @@ def _type_tuple(
     return tuple(types), allow_none
 
 
+def _float_superset(
+    validators: list[typing.Any], compiled: list[typing.Any]
+) -> tuple[tuple[type, ...], bool] | None:
+    """Return ``(accept_types, allow_none)`` for an ``Any`` of types plus a float tower.
+
+    Only for a branch set that is otherwise all bare types or ``None`` but for the
+    float tower (ADR-017), which coerces an ``int`` and so has no ``checked_type`` to
+    inline. The tower cannot fold into the single ``isinstance`` ``_type_tuple`` uses
+    (a match may coerce, and branch order decides the result), so this gives the
+    weaker but cheap signal ``__call__`` needs: the *superset* of types any branch
+    could accept, ``float`` and ``int`` standing in for the tower. A value outside it
+    cannot match any branch, so a miss is rejected with one ``isinstance``; a value
+    inside it defers to the ordered, coercing ``_run_any``. ``None`` if a branch is
+    neither a type, ``None``, nor the float tower, or if no float tower is present.
+    """
+    types: list[type] = []
+    allow_none = False
+    has_float_tower = False
+    for raw, branch in zip(validators, compiled, strict=True):
+        if raw is None:
+            allow_none = True
+            continue
+        if getattr(branch, "is_float_tower", False):
+            has_float_tower = True
+            # The tower accepts a float or an int (coerced); a bool is excluded by
+            # the tower itself, so let it into the ordered path to be rejected there.
+            types.append(float)
+            types.append(int)
+            continue
+        checked_type = getattr(branch, "checked_type", None)
+        if checked_type is None:
+            return None
+        types.append(checked_type)
+
+    if not has_float_tower:
+        return None
+    return tuple(types), allow_none
+
+
 def _run_typed_any(
     types: tuple[type, ...],
     allow_none: bool,
@@ -293,6 +332,36 @@ def _run_typed_any(
         )
     # The typed path always labels (every branch is a type), so this fallback
     # is unreachable; it keeps the type checker honest without a cast.
+    raise AnyInvalid(translation_key="no_valid_value")  # pragma: no cover
+
+
+def _run_float_superset_any(
+    superset: tuple[tuple[type, ...], bool],
+    candidates: list[typing.Any],
+    value: typing.Any,
+    msg: str | None,
+    miss_label: str | None,
+) -> typing.Any:
+    """Resolve a types-plus-float-tower ``Any``, rejecting a miss with one isinstance.
+
+    A value outside the accept superset cannot match any branch, so it is rejected
+    without running one (the common error path). A value inside it might match, and a
+    float branch may coerce, so it defers to the ordered ``_run_any`` which decides
+    correctly. The tower keeps its fast rejection without giving up branch order or
+    coercion on a hit.
+    """
+    accept_types, allow_none = superset
+    if (allow_none and value is None) or isinstance(value, accept_types):
+        return _run_any(candidates, value, msg, miss_label)
+    if msg is not None:
+        raise AnyInvalid(msg)
+    if miss_label is not None:
+        raise AnyInvalid(
+            translation_key="expected_type",
+            placeholders={"expected": miss_label},
+        )
+    # A float tower always labels (float and every other branch is a type), so this
+    # fallback is unreachable; kept to satisfy the type checker without a cast.
     raise AnyInvalid(translation_key="no_valid_value")  # pragma: no cover
 
 
@@ -330,6 +399,13 @@ class Any(_Combinator):
             for validator in self.validators
         ]
         self._types = _type_tuple(self.validators, self._compiled)
+        # When a float tower blocks the single-isinstance path, keep a cheap miss
+        # rejection via the accept superset (ADR-017). Only computed when needed.
+        self._float_superset = (
+            _float_superset(self.validators, self._compiled)
+            if self._types is None
+            else None
+        )
         # Prebuilt so a miss does not re-derive a label that only depends on the
         # branch labels, which are fixed here; the sentence itself renders lazily
         # from the "expected_type" catalog template.
@@ -340,6 +416,10 @@ class Any(_Combinator):
         # All-type (or None) branches resolve by one isinstance, on match and miss.
         if self._types is not None:
             return _run_typed_any(*self._types, value, self.msg, self._expected)
+        if self._float_superset is not None:
+            return _run_float_superset_any(
+                self._float_superset, self._compiled, value, self.msg, self._expected
+            )
         return _run_any(self._compiled, value, self.msg, self._expected)
 
     def __repr__(self) -> str:

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -77,7 +77,9 @@ def mixed_key(lib: Any) -> Any:
 
 def two_type_keys(lib: Any) -> Any:
     """Two type keys, so a key failing both reports the first key validator."""
-    return lib.Schema({int: str, float: str})
+    # Both must stay bare ``isinstance`` keys: ``float`` honors the numeric tower
+    # (ADR-017), which would coerce an int key instead of inlining the check.
+    return lib.Schema({int: str, bytes: str})
 
 
 def callable_key(lib: Any) -> Any:

--- a/tests/test_numeric_tower.py
+++ b/tests/test_numeric_tower.py
@@ -13,8 +13,10 @@ from dataclasses import dataclass
 import pytest
 
 from probatio import (
+    Any,
     DataclassSchema,
     MultipleInvalid,
+    Remove,
     Schema,
     to_json_schema,
 )
@@ -98,6 +100,43 @@ def test_runtime_agrees_with_the_emitted_json_schema() -> None:
     """to_json_schema emits {'type': 'number'}, which accepts an int, and now so does the validator."""
     assert to_json_schema(Schema(float)) == {"type": "number"}
     assert Schema(float)(5) == 5.0
+
+
+def test_an_integer_too_large_for_a_float_is_rejected_cleanly() -> None:
+    """A huge int (10**400 overflows float()) raises Invalid, not a raw OverflowError."""
+    with pytest.raises(MultipleInvalid):
+        Schema(float)(10**400)
+    with pytest.raises(MultipleInvalid):
+        Schema([float])([10**400])
+
+
+def test_a_float_matcher_drops_matching_ints() -> None:
+    """Remove(float) in a list drops ints too, since an int is now a valid float match."""
+    assert Schema([Remove(float), str])([1, 2.0, "keep"]) == ["keep"]
+
+
+def test_an_any_of_types_and_float_keeps_branch_order() -> None:
+    """In an Any, the first matching branch wins, so int-before-float keeps the int."""
+    assert Schema(Any(float, int))(5) == 5.0  # float first: coerced
+    assert type(Schema(Any(float, int))(5)) is float
+    assert Schema(Any(int, float))(5) == 5  # int first: unchanged
+    assert type(Schema(Any(int, float))(5)) is int
+
+
+def test_an_any_of_types_and_float_coerces_or_misses() -> None:
+    """A float branch in an Any coerces an int, excludes bool, and misses cleanly."""
+    assert Schema(Any(float, str))(5) == 5.0
+    with pytest.raises(MultipleInvalid):
+        Schema(Any(float, str))(True)
+    with pytest.raises(MultipleInvalid):
+        Schema(Any(int, float, str))(None)
+
+
+def test_a_custom_msg_is_used_on_a_float_any_miss() -> None:
+    """A custom msg on an Any with a float branch is raised on the fast miss path."""
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema(Any(int, float, str, msg="nope"))(None)
+    assert caught.value.errors[0].error_message == "nope"
 
 
 def test_complex_does_not_yet_honor_the_tower() -> None:

--- a/tests/test_numeric_tower.py
+++ b/tests/test_numeric_tower.py
@@ -1,0 +1,106 @@
+"""The PEP 484 numeric tower for a bare float: an int is accepted and normalized.
+
+A ``float`` schema accepts an ``int`` and returns it as a ``float``, on every path
+a bare type reaches (a scalar ``Schema``, a mapping value, a sequence element, a
+dataclass field, a union base). ``bool`` is excluded and everything else is rejected
+as before. This is a deliberate deviation from voluptuous (ADR-017).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from probatio import (
+    DataclassSchema,
+    MultipleInvalid,
+    Schema,
+    to_json_schema,
+)
+
+
+def test_schema_float_accepts_an_int_and_normalizes_it() -> None:
+    """Schema(float) takes an int and returns a float, not the int."""
+    result = Schema(float)(5)
+    assert result == 5.0
+    assert type(result) is float
+
+
+def test_schema_float_passes_a_float_through() -> None:
+    """A float is returned unchanged."""
+    assert Schema(float)(5.0) == 5.0
+
+
+def test_schema_float_accepts_a_float_subclass_unchanged() -> None:
+    """A float subclass is a float, so it passes through as-is (not re-boxed)."""
+
+    class Weight(float):
+        """A float subclass standing in for a numpy-style scalar."""
+
+    value = Weight(2.5)
+    assert Schema(float)(value) is value
+
+
+@pytest.mark.parametrize("value", [True, False, "5", None, 5j])
+def test_schema_float_rejects_non_numbers_and_bool(value: object) -> None:
+    """bool, a string, None, and a complex are not floats and are rejected."""
+    with pytest.raises(MultipleInvalid):
+        Schema(float)(value)
+
+
+def test_tower_applies_to_a_mapping_value() -> None:
+    """{str: float} coerces an int value to a float."""
+    assert Schema({str: float})({"a": 1}) == {"a": 1.0}
+
+
+def test_tower_applies_to_a_sequence_element() -> None:
+    """[float] coerces each int element to a float, order kept."""
+    assert Schema([float])([1, 2.0, 3]) == [1.0, 2.0, 3.0]
+
+
+def test_tower_applies_to_a_mapping_type_key() -> None:
+    """A {float: ...} type key matches an int key and normalizes it to a float."""
+    assert Schema({float: str})({5: "x"}) == {5.0: "x"}
+    with pytest.raises(MultipleInvalid):
+        Schema({float: str})({"k": "x"})
+
+
+@dataclass
+class Reading:
+    """A dataclass with a bare float field and an optional float field."""
+
+    value: float
+    trim: float | None = None
+
+
+def test_tower_applies_to_a_dataclass_field() -> None:
+    """A float field accepts an int and stores a float."""
+    result = DataclassSchema(Reading)({"value": 5})
+    assert result == Reading(value=5.0)
+    assert type(result.value) is float
+
+
+def test_tower_applies_under_a_union_base() -> None:
+    """A float | None field coerces an int and still accepts None."""
+    assert DataclassSchema(Reading)({"value": 1, "trim": 2}) == Reading(1.0, 2.0)
+    assert DataclassSchema(Reading)({"value": 1, "trim": None}) == Reading(1.0, None)
+
+
+def test_a_dataclass_float_field_still_rejects_a_string() -> None:
+    """The tower only reaches int; a string in a float field is still rejected."""
+    with pytest.raises(MultipleInvalid) as caught:
+        DataclassSchema(Reading)({"value": "5"})
+    assert caught.value.errors[0].path == ["value"]
+
+
+def test_runtime_agrees_with_the_emitted_json_schema() -> None:
+    """to_json_schema emits {'type': 'number'}, which accepts an int, and now so does the validator."""
+    assert to_json_schema(Schema(float)) == {"type": "number"}
+    assert Schema(float)(5) == 5.0
+
+
+def test_complex_does_not_yet_honor_the_tower() -> None:
+    """complex is a deferred tower step (ADR-017): a float is still rejected there."""
+    with pytest.raises(MultipleInvalid):
+        Schema(complex)(5.0)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -57,7 +57,7 @@ def test_remove_drops_matching_list_items_by_value() -> None:
 
 def test_remove_drops_matching_list_items_by_type() -> None:
     """A Remove element matching by type drops those items, order respected."""
-    assert Schema([1.0, Remove(float), int])([1, 2, 1.0, 2.0, 3.0, 4]) == [1, 2, 1.0, 4]
+    assert Schema([Remove(str), int])([1, "a", 2, "b", 3]) == [1, 2, 3]
 
 
 def test_namedtuple_data_round_trips_through_a_tuple_schema() -> None:


### PR DESCRIPTION
## Breaking change

None in the strict sense: this only ever turns a rejection into an acceptance, so no validation that passes today changes its result. The one behavioral shift to be aware of is that `Schema(float)(5)` now returns `5.0` where it used to raise, and a `float` used as a matcher now matches an `int` (so `Remove(float)` in a list drops ints, and a `{float: ...}` type key matches an int key and normalizes it). Documented as an intentional deviation from voluptuous in ADR-017.

## Proposed change

A bare `float` validated by `isinstance`, so an `int` was rejected where a `float` was expected. That is wrong on its own terms: PEP 484 makes an `int` acceptable for a `float`, PEP 3141 grounds it (an `int` is a `numbers.Real`), and probatio's own `to_json_schema` already emits `{"type": "number"}`, which accepts integers, so the validator disagreed with the schema it published. In the python-fumis migration this was five fields wearing a `Coerce(float)` (plus three `Maybe(Coerce(float))`) whose only job was to placate the `isinstance` check.

A `float` now honors the numeric tower on every path a bare type reaches (`Schema(float)`, a mapping value or type key, a sequence element, a dataclass or TypedDict field, a union base): an `int` is accepted and normalized to `float`, `bool` is excluded, and a `str`, `None`, or `complex` is rejected as before. It accepts *and coerces* rather than passing the `int` through, so a `float` field never ends up holding an `int`.

The rule lives in one `_FloatCheck` (it exposes no `checked_type`, so the mapping and sequence engines call it instead of inlining a bare `isinstance` that cannot coerce), with a matching branch in the codegen so the compiled engine inlines the same rule and the two engines agree. `complex` (the next tower step) is deferred, and `bool`-as-`int` is deliberately left alone; both are recorded in the ADR.

See [ADR-017](https://github.com/frenck/probatio/blob/main/adr/017-numeric-tower-for-float.md) for the full reasoning.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.