### PR TITLE
Add a dynamic-key validation recipe to the cookbook

### DIFF
--- a/docs/src/content/docs/recipes/cookbook.md
+++ b/docs/src/content/docs/recipes/cookbook.md
@@ -173,6 +173,50 @@ schema({"name": "app", "debug": True, "retries": 3})
 
 Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
 
+## Validating dynamic keys
+
+When the keys themselves are data (device slugs, entity ids, translation keys, a
+status code), put a validator in the key position. It runs on every key: a format
+check rejects a bad key pointing at the key, and a coercer or normalizer rewrites the
+key into the result. This is the same idea as a type key, with any validator.
+
+```python
+from probatio import Schema, Slug, Match, Coerce, In
+
+# Keys must be slugs (area or device maps keyed by name).
+Schema({Slug(): int})({"living-room": 1, "kitchen": 2})
+# {'living-room': 1, 'kitchen': 2}
+
+# Keys must match a pattern (an entity id, a translation key: [a-z0-9_-]).
+Schema({Match(r"^[a-z0-9_-]+$"): str})({"already_running": "In progress"})
+# {'already_running': 'In progress'}
+
+# Coerce the key: JSON object keys are always strings, take integer ids back.
+Schema({Coerce(int): str})({"1": "on", "2": "off"})
+# {1: 'on', 2: 'off'}
+
+# Restrict the key to a known set.
+Schema({In(["celsius", "fahrenheit"]): float})({"celsius": 21.5})
+# {'celsius': 21.5}
+```
+
+A bad key is reported at that key, not swallowed as an unexpected extra:
+
+<!-- verify: raises MultipleInvalid -->
+
+```python
+from probatio import Schema, Slug
+
+Schema({Slug(): int})({"Not A Slug": 1})  # expected a slug at 'Not A Slug'
+```
+
+Coming from Home Assistant, this is the direct form of `cv.schema_with_slug_keys`:
+`{Slug(): value_schema}` (or your own key validator, `{key_validator: value_schema}`)
+validates each key and then the values, no wrapper needed. Normalizing keys works the
+same way, `{Lower: value_schema}` folds the case of every key.
+
+Deep dive: [Dict schemas and markers](/guides/dict-schemas-and-markers/).
+
 ## Nested optional sections with defaults
 
 A whole config section can be optional, holding a nested schema with its own


### PR DESCRIPTION
## Breaking change

None. Docs only.

## Proposed change

A "Validating dynamic keys" recipe in the cookbook, showing that any validator works in the mapping key position, the pattern for keys that are themselves data (device slugs, entity ids, translation keys, status codes):

- `{Slug(): value_schema}` and `{Match(r"^[a-z0-9_-]+$"): value_schema}` format-check every key
- `{Coerce(int): str}` and `{Lower: value_schema}` rewrite the key into the result
- `{In([...]): value_schema}` restricts the key set
- a bad key is reported at the key, not swallowed as an unexpected extra

It also points out, for readers coming from Home Assistant, that this is the direct form of `cv.schema_with_slug_keys`: `{Slug(): value_schema}` validates each key then the values, with no wrapper. I checked hassfest's translation schema (which leans on `schema_with_slug_keys`, `{str: validator}` maps, `vol.All`/markers/`has_at_least_one_key`); all of it is standard voluptuous that probatio already carries, so this is a discoverability recipe, not new capability. Five examples run under `docs/verify_examples.py`.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #206
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.