### PR TITLE
Warn that global build/compile policies are for applications, not libraries

### DIFF
--- a/docs/src/content/docs/guides/compiled-schemas.md
+++ b/docs/src/content/docs/guides/compiled-schemas.md
@@ -100,6 +100,17 @@ A per-schema `compile` flag always wins over the policy, in either direction. Th
 order of precedence is: `schema.compile()`, then the `compile=True`/`compile=False`
 flag, then the process policy.
 
+:::caution[Applications set this, not libraries]
+`set_compile_policy` is a single process-wide switch, so only an application (the
+process that owns the run) should call it. A library that sets it changes compilation
+for every schema in the process, the application's own and those of unrelated
+dependencies included, which is not a library's call to make. A library that wants a
+particular schema compiled (or kept interpreted) sets the per-schema flag instead,
+`Schema(..., compile=True)` or `compile=False`, and even then sparingly: whether
+compilation pays depends on how the application drives the schema, so the `AUTO`
+default is usually the right answer.
+:::
+
 ## What compiles, and what does not
 
 The generator handles the common shapes: dict (mapping) schemas, dataclasses, and

--- a/docs/src/content/docs/guides/lazy-building.md
+++ b/docs/src/content/docs/guides/lazy-building.md
@@ -45,6 +45,15 @@ set_build_policy(BuildPolicy.LAZY)   # defer every eligible schema to first use
 set_build_policy(BuildPolicy.EAGER)  # the default: compile at construction
 ```
 
+:::caution[Applications set this, not libraries]
+`set_build_policy` is a single process-wide switch, so only an application (the
+process that owns the run) should call it. A library that sets it changes how every
+schema in the process builds, the application's own and those of unrelated
+dependencies included, which is not a library's call to make. And unlike the compile
+policy, the build policy has no per-schema form, so a library cannot scope it to its
+own schemas either. Leave it to the application and rely on the `EAGER` default.
+:::
+
 After `set_build_policy(BuildPolicy.LAZY)`, a schema you build does not compile
 until its first validation. A schema you build and never call never compiles at
 all, and never allocates its validator tree.

--- a/src/probatio/_build_policy.py
+++ b/src/probatio/_build_policy.py
@@ -41,10 +41,15 @@ _policy = _DEFAULT_POLICY
 def set_build_policy(policy: BuildPolicy) -> None:
     """Set the process-wide build policy.
 
-    Call it once, early, from deliberate startup code, before the schemas you want
-    deferred are constructed. Raises ``TypeError`` for anything that is not a
-    ``BuildPolicy``, so a stray string fails loudly rather than silently disabling
-    lazy building.
+    This is a single process-wide switch, so only an application (the process owner)
+    should call it, once, early, from deliberate startup code, before the schemas it
+    wants deferred are constructed. A library must not: it would change how every
+    schema in the process builds, the application's own and those of unrelated
+    dependencies included. The build policy has no per-schema override, so a library
+    has nothing to set here and should leave the choice to the application.
+
+    Raises ``TypeError`` for anything that is not a ``BuildPolicy``, so a stray string
+    fails loudly rather than silently disabling lazy building.
     """
     if not isinstance(policy, BuildPolicy):
         message = f"build policy must be a BuildPolicy, got {type(policy).__name__}"

--- a/src/probatio/_compile_policy.py
+++ b/src/probatio/_compile_policy.py
@@ -45,10 +45,19 @@ _policy = _DEFAULT_POLICY
 def set_compile_policy(policy: CompilePolicy) -> None:
     """Set the process-wide compile policy.
 
-    Call it once, early, from deliberate startup code. A per-schema ``compile``
-    flag still overrides it in either direction. Raises ``TypeError`` for anything
-    that is not a ``CompilePolicy``, so a stray string like ``"off"`` fails loudly
-    rather than being stored and silently breaking every later compile decision.
+    This is a single process-wide switch for an application (the process owner) to
+    set, once, early, from deliberate startup code. A library must not call it: it
+    would change compilation for every schema in the process, the application's own
+    and those of unrelated dependencies included. A library that wants a specific
+    schema compiled (or not) sets the per-schema ``compile`` flag instead
+    (``Schema(..., compile=True)`` / ``compile=False``), and sparingly, since whether
+    compilation pays depends on how the application uses the schema, so the ``AUTO``
+    default is usually the right call.
+
+    A per-schema ``compile`` flag still overrides this in either direction. Raises
+    ``TypeError`` for anything that is not a ``CompilePolicy``, so a stray string like
+    ``"off"`` fails loudly rather than being stored and silently breaking every later
+    compile decision.
     """
     if not isinstance(policy, CompilePolicy):
         message = f"compile policy must be a CompilePolicy, got {type(policy).__name__}"


### PR DESCRIPTION
## Breaking change

None. Documentation and docstrings only.

## Proposed change

`set_build_policy` and `set_compile_policy` are single process-wide switches, so a library that calls one changes behavior for every schema in the process, the application's own and those of unrelated dependencies included. That is the same class of footgun ADR-008 removed the type registry over. This adds the warning where someone would read it:

- `set_build_policy` / `set_compile_policy` docstrings now state that only the application (the process owner) should call them, and a library must not.
- The lazy-building and compiled-schemas guides each get a `:::caution[Applications set this, not libraries]` aside.

It keeps the two accurate to their asymmetry: a library that wants a specific schema compiled uses the per-schema `compile` flag (`Schema(..., compile=True/False)`, sparingly, since `AUTO` is usually right); the build policy has no per-schema form, so a library should leave it to the application entirely.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.