### PR TITLE
Fix documentation staleness and completeness gaps

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -220,13 +220,14 @@ first-seen order, the transformer siblings of `Sorted` and `Unique`. `First` and
 the holes.
 
 ```python
-from probatio import Schema, Split, Join, Sort, Dedupe, First, Without
+from probatio import Schema, Split, Join, Sort, Dedupe, First, Last, Without
 
 Schema(Split(","))("a, b ,c")        # ['a', 'b', 'c']
 Schema(Join(","))([1, 2, 3])         # '1,2,3'
 Schema(Sort())([3, 1, 2])            # [1, 2, 3]
 Schema(Dedupe())([1, 2, 1, 3])       # [1, 2, 3]
 Schema(First())([1, 2, 3])           # 1
+Schema(Last())([1, 2, 3])            # 3
 Schema(Without(None, 0))([1, None, 0, 2])  # [1, 2]
 ```
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -58,7 +58,7 @@ change before 1.0 while the project gathers production feedback.
   </Card>
   <Card title="Typed and modern" icon="setting">
     Ships `py.typed`, checked under mypy and ty, pure Python with no native
-    build. Loads JSON, YAML, and TOML, and exports JSON Schema and OpenAPI.
+    build. Exports JSON Schema and OpenAPI from a schema, and reads them back in.
   </Card>
 </CardGrid>
 
@@ -102,8 +102,8 @@ except Invalid as err:
 
 ## Why trust it
 
-It is a config-loading library, so the bar is whether you would hand it untrusted
-input. The evidence, not the adjectives:
+It validates untrusted input, config, an API body, a device response, so the bar
+is whether you would hand it exactly that. The evidence, not the adjectives:
 
 - **voluptuous 0.16.0 test suite:** runs against Probatio, with every divergence
   a deliberate, documented deviation. voluptuous's own authors' notion of the

--- a/docs/src/content/docs/project/roadmap.md
+++ b/docs/src/content/docs/project/roadmap.md
@@ -4,9 +4,8 @@ description: Where Probatio stands today, and what stable means before 1.0.
 ---
 
 Probatio is pre-1.0. Honest status: it works, it is tested, and it is young.
-The current release line is 0.5, with v0.5.4 the latest at the time of writing;
-the [release notes on GitHub](https://github.com/frenck/probatio/releases)
-track what each release changed.
+It is on the 0.x line; the [release notes on GitHub](https://github.com/frenck/probatio/releases)
+track the latest release and what each one changed.
 
 ## The goal
 

--- a/docs/src/content/docs/reference/builtins-by-role.md
+++ b/docs/src/content/docs/reference/builtins-by-role.md
@@ -54,17 +54,18 @@ key, so a marker stands in for the bare key.
 
 Compose or wrap other validators.
 
-| Name     | Note                                                |
-| -------- | --------------------------------------------------- |
-| `All`    | Run each in turn; the output of one feeds the next. |
-| `Any`    | The first that accepts wins.                        |
-| `And`    | Alias of `All`.                                     |
-| `Or`     | Alias of `Any`.                                     |
-| `Union`  | `Any` with an optional discriminant.                |
-| `Switch` | Alias of `Union`.                                   |
-| `SomeOf` | Between `min_valid` and `max_valid` must pass.      |
-| `Maybe`  | Accept `None`, otherwise the wrapped validator.     |
-| `Msg`    | Override a validator's error message.               |
+| Name          | Note                                                |
+| ------------- | --------------------------------------------------- |
+| `All`         | Run each in turn; the output of one feeds the next. |
+| `Any`         | The first that accepts wins.                        |
+| `And`         | Alias of `All`.                                     |
+| `Or`          | Alias of `Any`.                                     |
+| `Union`       | `Any` with an optional discriminant.                |
+| `Switch`      | Alias of `Union`.                                   |
+| `TaggedUnion` | Route on one key's value to the matching schema.    |
+| `SomeOf`      | Between `min_valid` and `max_valid` must pass.      |
+| `Maybe`       | Accept `None`, otherwise the wrapped validator.     |
+| `Msg`         | Override a validator's error message.               |
 
 ## Validators
 


### PR DESCRIPTION
## Breaking change

None

## Proposed change

A general documentation pass for staleness and completeness, following up on the serde removal cleanup. The docs still carried claims that no longer match the code.

- Homepage: dropped the "Loads JSON, YAML, and TOML" claim (that layer went away with the serde removal, ADR-016) and reframed the trust section around validating untrusted input rather than being a config-loading library.
- Roadmap: un-pinned the release version ("0.5 / v0.5.4 the latest at the time of writing") so it tracks the 0.x line and cannot re-stale.
- Validators guide: the collection-shaper example named `Last` in prose but never imported or showed it. Added it to the import and a `Schema(Last())([1, 2, 3])` line.
- Builtins-by-role reference: the combinators table was missing `TaggedUnion`. Added the row.

Deterministic checks (dashes, "e.g."/"i.e.", "click"/"Home Assistant", undocumented `__all__` names) are clean, and `docs/verify_examples.py` (270 blocks), prettier, and spellcheck all pass.

## Type of change

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [x] Documentation only

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to:
- Link to a separate documentation pull request:

## Checklist

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.
