### PR TITLE
Lay out a compiled mapping result in the input's key order

### DIFF
--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -588,6 +588,8 @@ def _emit_seed(
     # ALLOW_EXTRA keeps an unknown key with its input value, which is exactly what
     # the seed leaves behind untouched. PREVENT_EXTRA bails on one (below), so there
     # every seeded key is a schema key that the field lines overwrite.
+    # The seed reads them up front, where the engine reads each as it walks the input.
+    # Only a validator that rewrites its own input can tell, which is undefined here.
     return ["    out = dict(data)"]
 
 

--- a/src/probatio/_codegen.py
+++ b/src/probatio/_codegen.py
@@ -563,24 +563,48 @@ def _emit_field(
     return lines
 
 
+def _emit_seed(
+    extra: int, allowed: frozenset[Any], namespace: dict[str, Any]
+) -> list[str]:
+    """Emit the lines creating ``out``, seeded so its key order is the input's.
+
+    The engine writes keys in the order the *input* has them and appends a defaulted
+    key after all of those, while the generated field lines run in schema declaration
+    order. Seeding ``out`` from the input closes that gap: overwriting a key leaves
+    its position alone, so every present key keeps the slot the input gave it, and a
+    defaulted key (absent from the input, so never seeded) lands after them all. What
+    the seed puts in a slot to begin with is per-policy; either way the field lines
+    below overwrite every key the schema knows about with its validated value.
+    """
+    if extra == REMOVE_EXTRA:
+        # Unknown keys are dropped, so they are never seeded in the first place, and
+        # the input's values are not worth copying: a seeded key is by construction a
+        # schema key that is present, so the field lines below always overwrite it (or
+        # bail, and then this dict is thrown away). Placeholders reserve the slot for
+        # a third of what carrying the real value over costs.
+        namespace["_allowed"] = allowed
+        return ["    out = {_k: None for _k in data if _k in _allowed}"]
+
+    # ALLOW_EXTRA keeps an unknown key with its input value, which is exactly what
+    # the seed leaves behind untouched. PREVENT_EXTRA bails on one (below), so there
+    # every seeded key is a schema key that the field lines overwrite.
+    return ["    out = dict(data)"]
+
+
 def _emit_extra(
     extra: int, allowed: frozenset[Any], namespace: dict[str, Any]
 ) -> list[str]:
-    """Emit the extra-key handling for the given policy, binding what it needs."""
+    """Emit the extra-key check for the given policy, binding what it needs.
+
+    Only PREVENT_EXTRA needs a check of its own; the other two policies are already
+    served by how ``_emit_seed`` builds ``out``.
+    """
     if extra == PREVENT_EXTRA:
         # The keys view superset-checks against the allowed set in C; the prebound
         # method skips a rich-comparison dispatch per call. An unexpected key bails
         # so the interpreted path reports it (with its suggestion).
         namespace["_issuperset"] = allowed.issuperset
         return ["    if not _issuperset(data.keys()):", "        raise _Bail"]
-    if extra == ALLOW_EXTRA:
-        namespace["_allowed"] = allowed
-        return [
-            "    for _k in data:",
-            "        if _k not in _allowed:",
-            "            out[_k] = data[_k]",
-        ]
-    # REMOVE_EXTRA drops unknown keys, which is what simply not copying them does.
     return []
 
 
@@ -618,19 +642,16 @@ def compile_mapping(
     }
     allowed = frozenset(candidate.key_schema for candidate in candidates)
     if construct is None:
-        # One ``type()`` read serves both the foreign-type guard and the out-dict
-        # setup, so the exact-dict case (nearly every call) pays one identity test.
-        # A plain dict stays plain; a dict subclass is preserved (the engine does
-        # so); a foreign Mapping or wrong type keeps the interpreted path, which
-        # accepts the Mapping superset and raises the right type error.
+        # Only an exact dict, the case nearly every call is, takes the generated
+        # path, for one identity test. A dict subclass defers to the engine, which
+        # rebuilds the result as that subclass through its ``__setitem__``, and so
+        # does a foreign Mapping or a wrong type (the engine accepts the Mapping
+        # superset and raises the right type error). Neither is something the seeded
+        # copy below reproduces, and neither is a hot path worth generating for.
         prologue = [
-            "    _dt = type(data)",
-            "    if _dt is dict:",
-            "        out = {}",
-            "    elif isinstance(data, dict):",
-            "        out = _dt()",
-            "    else:",
+            "    if type(data) is not dict:",
             "        return _interpreted(data)",
+            *_emit_seed(validator._extra, allowed, namespace),  # noqa: SLF001
         ]
     else:
         # The fused constructor path builds no out dict; just guard the type.

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -51,6 +51,21 @@ def _is_compiled(schema: Schema) -> bool:
     return getattr(schema._compiled, "__name__", "") == "_validate"
 
 
+def _key_order(value: object) -> object:
+    """Capture the key order of a result, recursively, as something comparable.
+
+    Two dicts holding the same pairs in a different order compare equal, so an
+    order-only divergence between the two paths slips straight through ``==``
+    (that is how issue #307 survived the differential tests and the compiled CI
+    lane). This makes the layout part of what is compared.
+    """
+    if isinstance(value, dict):
+        return tuple((key, _key_order(item)) for key, item in value.items())
+    if isinstance(value, list):
+        return [_key_order(item) for item in value]
+    return None
+
+
 def _outcome(schema: Schema, data: object) -> object:
     """Reduce a validation to a comparable result or a structured error."""
     try:
@@ -62,7 +77,7 @@ def _outcome(schema: Schema, data: object) -> object:
             tuple(tuple(e.path) for e in err.errors),
             tuple(e.code for e in err.errors),
         )
-    return ("ok", result, type(result).__name__)
+    return ("ok", result, type(result).__name__, _key_order(result))
 
 
 # Schema builders, each exercised interpreted and compiled. Keep them varied:
@@ -213,6 +228,14 @@ _INPUTS: list[object] = [
     {"x": "abc"},
     {"x": "abcdef"},
     {"x": ""},
+    # Inputs whose key order is not the schema's declaration order: the result must
+    # be laid out the way the input is, not the way the schema is written (issue
+    # #307). Reversed against "types", against "defaults" (leaving the defaulted key
+    # to be appended), an extra key ahead of a known one, and a reversed nested value.
+    {"f": 1.5, "ok": True, "p": 1, "n": "x"},
+    {"p": 1, "n": "x"},
+    {"b": 2, "a": 1},
+    {"srv": {"port": 2, "host": "h"}},
 ]
 
 
@@ -568,6 +591,28 @@ def test_auto_compiles_a_schema_once_it_is_hot() -> None:
         assert schema({"a": 0}) == {"a": 0}  # crosses the threshold
         assert _is_compiled(schema)
         assert schema({"a": 7}) == {"a": 7}  # now via the compiled validator
+    finally:
+        set_compile_policy(CompilePolicy.OFF)
+
+
+def test_auto_keeps_the_key_order_stable_across_the_threshold() -> None:
+    """Going hot under AUTO does not relayout the result dict (issue #307).
+
+    The engine lays a result out the way the input is laid out and appends the
+    defaulted keys; the generated code writes fields in declaration order. When the
+    two disagreed, a schema silently started returning a differently ordered dict on
+    its 50th call, which anything serializing a validated config can see.
+    """
+    set_compile_policy(CompilePolicy.AUTO)
+    try:
+        schema = Schema({Optional("step", default=1): int, Optional("mode"): str})
+        cold = list(schema({"mode": "box"}))
+        for _ in range(_AUTO_COMPILE_THRESHOLD):
+            hot = list(schema({"mode": "box"}))
+
+        assert _is_compiled(schema)
+        assert cold == ["mode", "step"]
+        assert hot == cold
     finally:
         set_compile_policy(CompilePolicy.OFF)
 


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. The compiled path now returns what the interpreted path already returned, which is what ADR-011 promises it returns.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

The generated mapping validator wrote its fields into a fresh `{}` in schema declaration order. The engine writes keys in the order the *input* has them and appends defaulted keys after. So the same schema and the same input returned a differently ordered dict depending on whether the schema had gone hot, which under `AUTO` flips silently at call 50.

The report found it through a defaulted key, but the divergence was wider: any input whose key order is not the schema's declaration order diverged, defaults or no defaults.

```
all keys present, input reversed    interpreted ['b','a']       compiled ['a','b']
the reported default case           interpreted ['mode','step'] compiled ['step','mode']
ALLOW_EXTRA, extra in the middle    interpreted ['a','x','b']   compiled ['a','b','x']
```

A randomized differential over 4000 random schema and input pairs across all three extra policies found 1299 mismatches before this change and none after.

The fix seeds `out` from the input instead of starting empty. Overwriting a key leaves its position alone, so a present key keeps the slot the input gave it, and a defaulted key (absent from the input, so never seeded) lands after them all. Per policy:

- `PREVENT_EXTRA` and `ALLOW_EXTRA` seed `dict(data)`. For `ALLOW_EXTRA` that copy *is* the extra-key handling, so the emitted Python-level extras loop is gone.
- `REMOVE_EXTRA` seeds `{_k: None for _k in data if _k in _allowed}`. Placeholders, because a seeded key is by construction a present schema key that the field lines overwrite (or bail, and then the dict is thrown away).

The prologue also narrows to an exact `dict`. A dict subclass or a foreign Mapping now defers to the engine, which is the reference path, so both produce exactly what they produced before.

Why nothing caught this: `_outcome` in the differential harness compared results with `==`, and two dicts holding the same pairs in a different order compare equal. That blindness is why both the curated differential tests and the whole-suite `--compiled` CI lane sailed straight past it. Key order is now part of what those tests compare, recursively, plus four inputs whose key order is not the declaration order and a regression test for the threshold flip itself. Reverting the generator change while keeping the tests fails five builders and the new test.

The cost, best of three runs on the compiled mapping path:

| scenario | before | after | delta |
| --- | --- | --- | --- |
| flat types | 0.540µs | 0.565µs | +4.6% |
| config | 0.869µs | 0.910µs | +4.7% |
| one key | 0.330µs | 0.360µs | +9.1% |
| allow extra | 0.422µs | 0.283µs | -32.9% |
| remove extra | 0.244µs | 0.368µs | +50.8% |

`dict(data)` at 82ns is the cheapest seed available; `dict.fromkeys` is 167ns because it misses the dict-to-dict copy path. `REMOVE_EXTRA` is the one that loses: it used to get key filtering for free by simply not copying, and now pays a pass over the input to learn the order. A superset-guarded variant that skips the filter when there are no extras measured worse for the case `REMOVE_EXTRA` exists for, so it is not here. Correctness over the last 100ns, and CodSpeed will show the instrumented numbers.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #307

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
