### PR TITLE
Decode the JSON Schema propertyNames keyword

### DIFF
--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -104,19 +104,21 @@ to_json_schema(Schema({"token": str.strip}), custom_serializer=as_password)
 `from_json_schema` understands the keywords below. A purely descriptive keyword
 it does not read (`title`, `examples`) is ignored, so a partial schema still
 yields a usable validator. A _restrictive_ keyword it cannot honor
-(`if`/`then`/`else`, `propertyNames`, `patternProperties`, `dependentSchemas`,
-`dependencies`, `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`,
-`$recursiveRef`) is refused with a `SchemaError` rather than silently dropped, so
-an untrusted schema is never quietly widened to accept what its author meant to
-forbid. `dependentRequired` is honored only in the symmetric all-or-none form
-that maps to an `Inclusive` group (see below); its asymmetric form is refused the
-same way. The object and array keywords apply even on a node without a `type`
-(scoped to instances of their type, as the spec says). `to_json_schema` emits the
-same constructs in the other direction.
+(`if`/`then`/`else`, `patternProperties`, `dependentSchemas`, `dependencies`,
+`unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`, `$recursiveRef`) is
+refused with a `SchemaError` rather than silently dropped, so an untrusted schema
+is never quietly widened to accept what its author meant to forbid.
+`dependentRequired` is honored only in the symmetric all-or-none form that maps
+to an `Inclusive` group (see below); its asymmetric form is refused the same way.
+`propertyNames` is honored: a mapping key is itself validated by a schema, so it
+becomes the key validator of the mapping (see below). The object and array
+keywords apply even on a node without a `type` (scoped to instances of their
+type, as the spec says). `to_json_schema` emits the same constructs in the other
+direction.
 
 | Area    | Keywords                                                                                                                                                                           |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Objects | `properties`, `required`, `additionalProperties`, `minProperties`, `maxProperties`, `dependentRequired` (symmetric all-or-none only)                                               |
+| Objects | `properties`, `required`, `additionalProperties`, `propertyNames`, `minProperties`, `maxProperties`, `dependentRequired` (symmetric all-or-none only)                              |
 | Arrays  | `items`, `minItems`, `maxItems`, `prefixItems`, `uniqueItems`, `contains`, `minContains`, `maxContains`                                                                            |
 | Strings | `minLength`, `maxLength`, `pattern`, `format` (`date`, `date-time`, `time`, `email`, `uri`, `ipv4`, `ipv6`, `uuid`, `hostname`, `byte`), `writeOnly`, `contentEncoding` (`Base64`) |
 | Numbers | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`                                                                                                         |
@@ -145,6 +147,7 @@ round-trip:
 | `Secret` key                  | its property with `writeOnly: true`                                                                                               |
 | `Base64`                      | `contentEncoding: base64`                                                                                                         |
 | `Inclusive` group             | `dependentRequired` (all-or-none); the symmetric map decodes back to an `Inclusive` group                                         |
+| Variable key validator        | `propertyNames`, for a mapping that declares no properties (a plain `str` key emits nothing: it accepts every JSON key)           |
 
 Combinators and a few more constructs also render, though most have no inverse
 so they do not round-trip:
@@ -174,6 +177,22 @@ emits the symmetric all-or-none map (every member requires every other), and
 set of mutually dependent properties. The general `dependentRequired` is broader:
 an asymmetric dependency (`a` requires `b` but not the reverse) has no `Inclusive`
 equivalent, so it is refused rather than silently widened.
+
+`propertyNames` maps onto the key side of a mapping, where probatio already
+validates keys with a schema. `{"propertyNames": {"enum": ["a", "b"]}}` decodes
+to `{In(["a", "b"]): ...}`, so a key outside the set is rejected instead of
+quietly accepted, and `to_json_schema` emits the keyword back for a restrictive
+key validator. A key schema that accepts anything constrains nothing (every JSON
+object key is a string), so it is dropped in both directions rather than adding
+noise. The encoder emits it only for a mapping that declares no properties: JSON
+Schema applies `propertyNames` to declared names too, while a probatio literal
+key is matched ahead of the variable keys and never sees them, so emitting it
+beside a declared property would reject input the schema accepts. Dropping it
+widens instead, the direction the encoder is allowed to be wrong in.
+
+This matters in practice: Zod emits `propertyNames` for every `z.record(...)` and
+Pydantic emits it for a `dict` keyed by a `Literal`, which makes the keyword
+common in machine-generated schemas such as MCP tool definitions.
 
 `oneOf` decodes with its exact semantics (a value must match exactly one branch,
 so one matching two or more is rejected), unlike the looser `anyOf`.

--- a/docs/src/content/docs/guides/json-schema.md
+++ b/docs/src/content/docs/guides/json-schema.md
@@ -182,9 +182,14 @@ equivalent, so it is refused rather than silently widened.
 validates keys with a schema. `{"propertyNames": {"enum": ["a", "b"]}}` decodes
 to `{In(["a", "b"]): ...}`, so a key outside the set is rejected instead of
 quietly accepted, and `to_json_schema` emits the keyword back for a restrictive
-key validator. A key schema that accepts anything constrains nothing (every JSON
-object key is a string), so it is dropped in both directions rather than adding
-noise. The encoder emits it only for a mapping that declares no properties: JSON
+key validator. The two directions treat a permissive key schema differently, on
+purpose. Decoding keeps `{"type": "string"}` as the mapping's `str` key, because
+a decoded schema also runs against Python mappings, where a non-string key is
+reachable and should be rejected; only `{}` and `true`, which accept anything at
+all, are dropped. Encoding drops a plain `str` key, since every JSON property
+name is a string and emitting it would add noise to every record schema.
+
+The encoder emits the keyword only for a mapping that declares no properties: JSON
 Schema applies `propertyNames` to declared names too, while a probatio literal
 key is matched ahead of the variable keys and never sees them, so emitting it
 beside a declared property would reject input the schema accepts. Dropping it

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -2129,6 +2129,11 @@ def _key_filter(key_validator: Any) -> Callable[[str], bool]:
     The key schema is compiled once here rather than per name, and a name it
     rejects is reported as not allowed. Only ``Invalid`` counts as a rejection;
     any other failure is a malformed schema and belongs to ``_decode``.
+
+    A key schema that refers to the schema still being built (``{"$ref": "#"}``)
+    is the one case this cannot answer: running it would re-enter a reference
+    whose target does not exist yet. Guessing would either forbid a property the
+    document allows or accept one it forbids, so the document is refused instead.
     """
     if key_validator is _NO_KEY_SCHEMA:
         return lambda _name: True
@@ -2140,6 +2145,13 @@ def _key_filter(key_validator: Any) -> Callable[[str], bool]:
             compiled(name)
         except Invalid:
             return False
+        except RuntimeError as exc:
+            message = (
+                "JSON Schema 'propertyNames' refers to the schema being built, so "
+                "it cannot be resolved against a declared property name; refusing "
+                "rather than guessing at the constraint"
+            )
+            raise SchemaError(message) from exc
         return True
 
     return allowed

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -406,9 +406,13 @@ def _convert_mapping(
     # ``propertyNames`` constrains *every* property name, declared ones included,
     # but a probatio literal key is matched ahead of the variable keys and never
     # sees them. Emitting it beside a declared property would therefore narrow the
-    # document, so it is only emitted for a mapping that declares none. Dropping it
-    # widens instead, which is the encoder's documented fallback.
-    property_names = _property_names(variable_keys) if not properties else None
+    # document, so it is only emitted for a mapping that declares none.
+    property_names = _property_names(variable_keys)
+    if property_names is not None and properties:
+        # Dropping it widens, so strict mode refuses: ``_open`` raises there. Its
+        # open-schema return is not wanted here, only that refusal.
+        _open("a key validator on a mapping that also declares properties")
+        property_names = None
     if property_names is not None:
         result["propertyNames"] = property_names
     if required:
@@ -509,6 +513,9 @@ def _property_names(variable_keys: list[dict[str, Any]]) -> dict[str, Any] | Non
     if not variable_keys or any(key in _ANY_KEY for key in variable_keys):
         return None
     if not all(map(_matches_a_property_name, variable_keys)):
+        # A real key constraint with no JSON Schema form here, so it is dropped.
+        # That widens, which is what strict mode exists to refuse.
+        _open("a key validator that cannot match a property name")
         return None
     if len(variable_keys) == 1:
         return variable_keys[0]

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -2105,6 +2105,14 @@ def _from_property_names(node: dict[str, Any], ctx: _Decode) -> Any:
         )
         raise SchemaError(message) from None
 
+    # A key schema that decodes to a plain value (``{"const": "a"}`` or
+    # ``{"type": "null"}``) would go in as a *literal* key, and a marker compares
+    # equal to its own name (``Optional("a") == "a"``, same hash), so it would
+    # silently replace a declared property rather than constrain the key. Wrapping
+    # it keeps it a key *validator*, which the engine matches separately.
+    if not callable(key_validator):
+        return Equal(key_validator)
+
     return key_validator
 
 

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -19,7 +19,10 @@ import datetime
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from probatio._compile import recursion_guard
 from probatio.codecs._regex_safety import is_catastrophic
@@ -324,6 +327,9 @@ def _convert_mapping(
     # Multiple variable keys ({str: int, int: str}) merge into one
     # ``additionalProperties`` schema; ``allow_extra`` seeds the default.
     variable_values: list[dict[str, Any]] = []
+    # ...and their *key* validators, which become ``propertyNames``: the mirror of
+    # the constraint ``from_json_schema`` reads back out of that keyword.
+    variable_keys: list[dict[str, Any]] = []
     # A ``Forbidden`` over a type/callable key (``Forbidden(str)`` forbids every
     # string key, so every JSON key) closes the object regardless of the extra
     # policy.
@@ -354,6 +360,7 @@ def _convert_mapping(
             # present value before dropping it, so its value schema still applies
             # to the keys it matches, the same as a plain variable key.
             variable_values.append(value_schema)
+            variable_keys.append(_child(name))
             continue
 
         if not isinstance(name, str):
@@ -396,6 +403,14 @@ def _convert_mapping(
         "properties": properties,
         "additionalProperties": additional,
     }
+    # ``propertyNames`` constrains *every* property name, declared ones included,
+    # but a probatio literal key is matched ahead of the variable keys and never
+    # sees them. Emitting it beside a declared property would therefore narrow the
+    # document, so it is only emitted for a mapping that declares none. Dropping it
+    # widens instead, which is the encoder's documented fallback.
+    property_names = _property_names(variable_keys) if not properties else None
+    if property_names is not None:
+        result["propertyNames"] = property_names
     if required:
         result["required"] = required
     dependent = groups.dependent_required()
@@ -470,6 +485,26 @@ def _additional_properties(
     if len(variable_values) == 1:
         return variable_values[0]
     return {"anyOf": variable_values}
+
+
+# Key schemas that constrain nothing. Every JSON object key is a string, so
+# ``{"type": "string"}`` accepts them all, exactly like the empty schema.
+_ANY_KEY: tuple[dict[str, Any], ...] = ({}, {"type": "string"})
+
+
+def _property_names(variable_keys: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Combine the variable-key validators into one ``propertyNames``, or None.
+
+    None means "no constraint to emit": either the mapping has no variable key,
+    or one of them accepts every key, which makes the union accept every key too.
+    Several restrictive keys ({In([...]): str, Match(...): int}) become an
+    ``anyOf``, since the engine accepts a key that matches any one of them.
+    """
+    if not variable_keys or any(key in _ANY_KEY for key in variable_keys):
+        return None
+    if len(variable_keys) == 1:
+        return variable_keys[0]
+    return {"anyOf": variable_keys}
 
 
 def _decorate_property(
@@ -1168,7 +1203,8 @@ def from_json_schema(schema: dict[str, Any]) -> Schema:
     """Build a ``Schema`` from a JSON Schema dictionary.
 
     This is the inverse of ``to_json_schema`` for the constructs that map cleanly:
-    objects (with ``properties``, ``required``, ``additionalProperties``), arrays
+    objects (with ``properties``, ``required``, ``additionalProperties``, and
+    ``propertyNames``, which becomes the mapping's key validator), arrays
     (``items``, ``minItems``/``maxItems``), the primitive types, ``enum``,
     ``const``, ``anyOf``, ``allOf``, ``oneOf`` (with its exact "one branch only"
     semantics), a ``type`` array like ``["string", "null"]``, and the string and
@@ -1314,8 +1350,11 @@ def _typed_facet(node: dict[str, Any], ctx: _Decode) -> Any:
 _UNSUPPORTED_KEYWORDS = frozenset(
     {
         "if",
-        "propertyNames",
         "patternProperties",
+        # ``propertyNames`` is not refused: a mapping key is itself validated by a
+        # schema, so it decodes to the key side of the mapping (see
+        # ``_from_property_names``).
+        #
         # ``dependentRequired`` is not blanket-refused: its symmetric all-or-none
         # form decodes to an ``Inclusive`` group (see ``_from_object``). The
         # asymmetric form it cannot honor is refused there instead.
@@ -1705,6 +1744,7 @@ _OBJECT_KEYWORDS = frozenset(
         "properties",
         "required",
         "additionalProperties",
+        "propertyNames",
         "minProperties",
         "maxProperties",
         "dependentRequired",
@@ -1930,10 +1970,24 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
         message = "JSON Schema 'required' must contain only property names (strings)"
         raise SchemaError(message)
 
+    key_validator = _from_property_names(node, ctx)
+    allowed = _key_filter(key_validator)
+
     required: set[Any] = set(required_raw)
+
+    # A required name the key schema rejects has to be present and may never be
+    # present, so nothing satisfies the object. Rendering the individual key as
+    # forbidden would still accept every object that simply omits it, which is
+    # wider than the document allows; refuse the lot instead.
+    if not all(map(allowed, required)):
+        return In([])
+
     mapping: dict[Any, Any] = {}
     for name, subschema in properties.items():
-        if subschema is False:
+        # ``propertyNames`` covers declared names too, so a property its key
+        # schema rejects can never legally appear. That is what ``Forbidden``
+        # says, and it is already how a ``properties`` entry of ``false`` renders.
+        if subschema is False or not allowed(name):
             mapping[Forbidden(name)] = object
             continue
         key = _from_key(name, subschema, required=name in required)
@@ -1953,13 +2007,25 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
             additional_schema if additional_schema is not None else object
         )
 
+    # An undeclared key is validated by the mapping's variable key. Without
+    # ``propertyNames`` that is plain ``str`` (every JSON key); with it, the
+    # decoded key schema, so the constraint reaches the keys it was written for.
     if additional_schema is not None:
-        mapping[str] = additional_schema
+        mapping[key_validator if key_validator is not None else str] = additional_schema
+    elif key_validator is not None and additional is not False:
+        # Names constrained, values not: undeclared keys stay allowed, but each
+        # one still has to satisfy the key schema.
+        mapping[key_validator] = object
 
     if "dependentRequired" in node:
         _apply_inclusive_groups(node["dependentRequired"], mapping)
 
-    base = _object_base(mapping, additional, declared="properties" in node)
+    base = _object_base(
+        mapping,
+        additional,
+        declared="properties" in node,
+        constrained_keys=key_validator is not None,
+    )
     min_props = _item_count(node, "minProperties")
     max_props = _item_count(node, "maxProperties")
     if min_props is not None or max_props is not None:
@@ -1968,7 +2034,70 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     return base
 
 
-def _object_base(mapping: dict[Any, Any], additional: Any, *, declared: bool) -> Any:
+def _from_property_names(node: dict[str, Any], ctx: _Decode) -> Any:
+    """Decode ``propertyNames`` into a key validator for the mapping, or None.
+
+    A mapping key is itself validated by a schema, so ``propertyNames`` maps onto
+    the key side of the mapping directly. A key schema that accepts anything
+    (``{}`` or ``true``) constrains nothing, so it decodes to None and the object
+    keeps whatever shape ``additionalProperties`` alone would have given it.
+
+    Plain ``{"type": "string"}`` is *not* folded away, even though every JSON key
+    is a string: the decoded schema also runs against Python mappings, where a
+    non-string key is reachable. It costs nothing anyway, since ``str`` is the key
+    the mapping would use regardless.
+    """
+    if "propertyNames" not in node:
+        return None
+
+    key_validator = _from_node(node["propertyNames"], ctx)
+    if key_validator is object:
+        return None
+
+    # The key validator goes in as a dict key, so an unhashable decode (a nested
+    # mapping schema) cannot be installed at all. Refuse it rather than let the
+    # dict write raise, and rather than drop the constraint.
+    try:
+        hash(key_validator)
+    except TypeError:
+        message = (
+            "JSON Schema 'propertyNames' does not decode to a usable key "
+            "validator; refusing to silently ignore the constraint"
+        )
+        raise SchemaError(message) from None
+
+    return key_validator
+
+
+def _key_filter(key_validator: Any) -> Callable[[str], bool]:
+    """Build the "may this property name appear" test for a decoded key schema.
+
+    The key schema is compiled once here rather than per name, and a name it
+    rejects is reported as not allowed. Only ``Invalid`` counts as a rejection;
+    any other failure is a malformed schema and belongs to ``_decode``.
+    """
+    if key_validator is None:
+        return lambda _name: True
+
+    compiled = Schema(key_validator)
+
+    def allowed(name: str) -> bool:
+        try:
+            compiled(name)
+        except Invalid:
+            return False
+        return True
+
+    return allowed
+
+
+def _object_base(
+    mapping: dict[Any, Any],
+    additional: Any,
+    *,
+    declared: bool,
+    constrained_keys: bool,
+) -> Any:
     """Pick the base object schema from the property map and additionalProperties.
 
     A declared property set is a closed contract (probatio's deliberate strict
@@ -1977,7 +2106,14 @@ def _object_base(mapping: dict[Any, Any], additional: Any, *, declared: bool) ->
     explicit ``additionalProperties: false`` keeps an empty object closed. And a
     ``required`` list without a ``properties`` set constrains presence only, so
     undeclared extra keys stay allowed.
+
+    A ``propertyNames`` key schema is the exception to all of that: it constrains
+    every key, so the object can never render open. ``ALLOW_EXTRA`` would wave
+    through precisely the keys the key schema exists to reject.
     """
+    if constrained_keys:
+        return mapping
+
     if additional is True:
         return Schema(mapping, extra=ALLOW_EXTRA)
 

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -495,16 +495,40 @@ _ANY_KEY: tuple[dict[str, Any], ...] = ({}, {"type": "string"})
 def _property_names(variable_keys: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Combine the variable-key validators into one ``propertyNames``, or None.
 
-    None means "no constraint to emit": either the mapping has no variable key,
-    or one of them accepts every key, which makes the union accept every key too.
+    None means "no constraint to emit". That covers a mapping with no variable
+    key, one whose key accepts everything (so the union does too), and one whose
+    key does not match strings, since a JSON property name always is one: a
+    coercing key like ``Coerce(int)`` renders as ``{"type": "integer"}``, which
+    no property name can satisfy, so emitting it would reject every object the
+    schema accepts. The union has to cover every key, so one unrepresentable
+    branch drops the whole keyword rather than over-constraining the rest.
+
     Several restrictive keys ({In([...]): str, Match(...): int}) become an
     ``anyOf``, since the engine accepts a key that matches any one of them.
     """
     if not variable_keys or any(key in _ANY_KEY for key in variable_keys):
         return None
+    if not all(map(_matches_a_property_name, variable_keys)):
+        return None
     if len(variable_keys) == 1:
         return variable_keys[0]
     return {"anyOf": variable_keys}
+
+
+def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
+    """Whether a rendered key schema can match a string, the only kind of key.
+
+    Deliberately conservative: a shape this cannot read as string-matching (an
+    ``allOf`` of merged constraints, say) reports False and drops the keyword,
+    which widens. Widening is the direction the encoder is allowed to be wrong in.
+    """
+    if key_schema.get("type") == "string":
+        return True
+    if "enum" in key_schema:
+        return all(isinstance(member, str) for member in key_schema["enum"])
+    if "const" in key_schema:
+        return isinstance(key_schema["const"], str)
+    return False
 
 
 def _decorate_property(
@@ -1998,6 +2022,13 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
         _from_node(additional, ctx) if isinstance(additional, dict) else None
     )
 
+    # An undeclared name is an additional property, so ``additionalProperties:
+    # false`` forbids it while ``required`` demands it: nothing satisfies the
+    # object. Treating the name as declared would accept the very objects the
+    # document rules out.
+    if additional is False and required - properties.keys():
+        return In([])
+
     # A ``required`` name with no ``properties`` entry is still a presence
     # constraint; dropping it would widen an untrusted schema. Its value schema
     # is whatever ``additionalProperties`` says (an undeclared property), or
@@ -2011,8 +2042,10 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     # ``propertyNames`` that is plain ``str`` (every JSON key); with it, the
     # decoded key schema, so the constraint reaches the keys it was written for.
     if additional_schema is not None:
-        mapping[key_validator if key_validator is not None else str] = additional_schema
-    elif key_validator is not None and additional is not False:
+        mapping[str if key_validator is _NO_KEY_SCHEMA else key_validator] = (
+            additional_schema
+        )
+    elif key_validator is not _NO_KEY_SCHEMA and additional is not False:
         # Names constrained, values not: undeclared keys stay allowed, but each
         # one still has to satisfy the key schema.
         mapping[key_validator] = object
@@ -2024,7 +2057,7 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
         mapping,
         additional,
         declared="properties" in node,
-        constrained_keys=key_validator is not None,
+        constrained_keys=key_validator is not _NO_KEY_SCHEMA,
     )
     min_props = _item_count(node, "minProperties")
     max_props = _item_count(node, "maxProperties")
@@ -2034,13 +2067,19 @@ def _from_object(node: dict[str, Any], ctx: _Decode) -> Any:
     return base
 
 
+# "This node carries no key constraint", distinct from every value a key schema
+# can decode to. ``None`` cannot serve: ``{"const": null}`` decodes to it and is a
+# real constraint (no JSON key is null), so sharing the sentinel would drop it.
+_NO_KEY_SCHEMA = object()
+
+
 def _from_property_names(node: dict[str, Any], ctx: _Decode) -> Any:
-    """Decode ``propertyNames`` into a key validator for the mapping, or None.
+    """Decode ``propertyNames`` into a key validator, or ``_NO_KEY_SCHEMA``.
 
     A mapping key is itself validated by a schema, so ``propertyNames`` maps onto
     the key side of the mapping directly. A key schema that accepts anything
-    (``{}`` or ``true``) constrains nothing, so it decodes to None and the object
-    keeps whatever shape ``additionalProperties`` alone would have given it.
+    (``{}`` or ``true``) constrains nothing, so it reports ``_NO_KEY_SCHEMA`` and
+    the object keeps whatever shape ``additionalProperties`` alone would give it.
 
     Plain ``{"type": "string"}`` is *not* folded away, even though every JSON key
     is a string: the decoded schema also runs against Python mappings, where a
@@ -2048,11 +2087,11 @@ def _from_property_names(node: dict[str, Any], ctx: _Decode) -> Any:
     the mapping would use regardless.
     """
     if "propertyNames" not in node:
-        return None
+        return _NO_KEY_SCHEMA
 
     key_validator = _from_node(node["propertyNames"], ctx)
     if key_validator is object:
-        return None
+        return _NO_KEY_SCHEMA
 
     # The key validator goes in as a dict key, so an unhashable decode (a nested
     # mapping schema) cannot be installed at all. Refuse it rather than let the
@@ -2076,7 +2115,7 @@ def _key_filter(key_validator: Any) -> Callable[[str], bool]:
     rejects is reported as not allowed. Only ``Invalid`` counts as a rejection;
     any other failure is a malformed schema and belongs to ``_decode``.
     """
-    if key_validator is None:
+    if key_validator is _NO_KEY_SCHEMA:
         return lambda _name: True
 
     compiled = Schema(key_validator)

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -153,8 +153,14 @@ def test_property_names_roundtrip_reaches_a_behavioral_fixpoint(
     value path just as much as here.
     """
     once = from_json_schema(document)
-    twice = from_json_schema(to_json_schema(once))
-    thrice = from_json_schema(to_json_schema(twice))
+    emitted = to_json_schema(once)
+    # The fixpoint is behavioral, but a document that no validator would accept
+    # makes the comparison meaningless, so each trip has to stay a valid schema.
+    _VALIDATOR.check_schema(emitted)
+    twice = from_json_schema(emitted)
+    re_emitted = to_json_schema(twice)
+    _VALIDATOR.check_schema(re_emitted)
+    thrice = from_json_schema(re_emitted)
 
     for value in _VALUES:
         assert _accepts(twice, value) == _accepts(thrice, value), (

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -12,6 +12,14 @@ failure mode that matters, because it silently lets an untrusted document throug
 Probatio being stricter is expected and allowed: a declared property set is a
 closed contract here (its deliberate strict default), where JSON Schema leaves the
 object open unless ``additionalProperties`` says otherwise.
+
+The matrix deliberately carries no negated ``pattern``. JSON Schema ``pattern`` is
+an unanchored search while ``Match`` is an anchored ``re.match``, so ``{"not":
+{"pattern": "x"}}`` accepts the key ``"ax"`` where the reference rejects it. That
+is a real widening, but it belongs to every decoded ``pattern`` rather than to
+key schemas (``_convert_match`` already compensates in the encode direction and
+the decoder has no counterpart), so it is tracked separately rather than papered
+over with a key-schema-shaped exclusion here.
 """
 
 from __future__ import annotations
@@ -71,22 +79,11 @@ _VALUES: list[dict[str, Any]] = [
 
 
 def _documents() -> list[dict[str, Any]]:
-    """Every propertyNames-bearing object document the matrix describes.
-
-    One combination is left out: ``additionalProperties: false`` alongside a
-    ``required`` name that ``properties`` does not declare. That document is
-    unsatisfiable (the name must be present, and is an additional property, which
-    is forbidden), and probatio accepts objects carrying the name. The divergence
-    has nothing to do with ``propertyNames``: it reproduces on a document with no
-    key schema at all, so it is out of scope here rather than silently tolerated.
-    """
+    """Every propertyNames-bearing object document the matrix describes."""
     documents = []
     for key, additional, properties, required in itertools.product(
         _KEY_SCHEMAS, _ADDITIONAL, _PROPERTIES, _REQUIRED
     ):
-        if additional is False and set(required or []) - set(properties or {}):
-            continue
-
         document: dict[str, Any] = {"type": "object", "propertyNames": key}
         if additional is not None:
             document["additionalProperties"] = additional

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -1,0 +1,153 @@
+"""Behavioral oracle for the ``propertyNames`` decode against the reference.
+
+The encoder already has an oracle (``test_encoder_differential``); the decoder had
+none, so a newly implemented keyword had nothing but hand-written examples holding
+it in place. These tests close that for ``propertyNames`` by running the decoded
+validator and ``jsonschema``'s reference implementation over the same documents
+and inputs.
+
+The property is one-directional, the same shape the encoder oracles use: the
+decoded validator must never *accept* what the reference rejects. Widening is the
+failure mode that matters, because it silently lets an untrusted document through.
+Probatio being stricter is expected and allowed: a declared property set is a
+closed contract here (its deliberate strict default), where JSON Schema leaves the
+object open unless ``additionalProperties`` says otherwise.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import jsonschema
+import pytest
+
+from probatio import Invalid, from_json_schema, to_json_schema
+
+_VALIDATOR = jsonschema.Draft202012Validator
+
+# Key schemas: vacuous (two spellings), a closed set, a length bound, a pattern,
+# and a negation, so the decode is exercised on more than the enum it was written
+# for.
+_KEY_SCHEMAS: list[Any] = [
+    {"type": "string"},
+    {"enum": ["a", "b"]},
+    {"type": "string", "maxLength": 2},
+    {"type": "string", "pattern": "^x"},
+    {},
+    True,
+    {"not": {"enum": ["bad"]}},
+]
+_ADDITIONAL: list[Any] = [None, True, False, {"type": "string"}, {"type": "integer"}, {}]
+_PROPERTIES: list[Any] = [None, {}, {"a": {"type": "string"}}, {"xy": {"type": "string"}}]
+_REQUIRED: list[Any] = [None, [], ["a"], ["zz"]]
+
+_VALUES: list[dict[str, Any]] = [
+    {},
+    {"a": "s"},
+    {"a": 1},
+    {"b": "s"},
+    {"xy": "s"},
+    {"x1": "s"},
+    {"zz": "s"},
+    {"bad": "s"},
+    {"a": "s", "b": "s"},
+    {"": "s"},
+    {"toolongkey": "s"},
+    {"xy": "s", "a": "s"},
+]
+
+
+def _documents() -> list[dict[str, Any]]:
+    """Every propertyNames-bearing object document the matrix describes.
+
+    One combination is left out: ``additionalProperties: false`` alongside a
+    ``required`` name that ``properties`` does not declare. That document is
+    unsatisfiable (the name must be present, and is an additional property, which
+    is forbidden), and probatio accepts objects carrying the name. The divergence
+    has nothing to do with ``propertyNames``: it reproduces on a document with no
+    key schema at all, so it is out of scope here rather than silently tolerated.
+    """
+    documents = []
+    for key, additional, properties, required in itertools.product(
+        _KEY_SCHEMAS, _ADDITIONAL, _PROPERTIES, _REQUIRED
+    ):
+        if additional is False and set(required or []) - set(properties or {}):
+            continue
+
+        document: dict[str, Any] = {"type": "object", "propertyNames": key}
+        if additional is not None:
+            document["additionalProperties"] = additional
+        if properties is not None:
+            document["properties"] = properties
+        if required is not None:
+            document["required"] = required
+        documents.append(document)
+
+    return documents
+
+
+def _accepts(schema: Any, value: Any) -> bool:
+    """Whether the decoded schema accepts the value."""
+    try:
+        schema(value)
+    except Invalid:
+        return False
+    return True
+
+
+@pytest.mark.parametrize("document", _documents(), ids=str)
+def test_decoded_property_names_never_widens(document: dict[str, Any]) -> None:
+    """A decoded propertyNames document never accepts what the reference rejects."""
+    _VALIDATOR.check_schema(document)
+    reference = _VALIDATOR(document)
+    schema = from_json_schema(document)
+
+    for value in _VALUES:
+        if _accepts(schema, value):
+            assert reference.is_valid(value), (
+                f"decoded schema widens: probatio accepts {value!r} but the "
+                f"reference rejects it for {document!r}"
+            )
+
+
+def test_unsatisfiable_required_name_accepts_nothing() -> None:
+    """A required name the key schema forbids makes the whole object unsatisfiable.
+
+    Forbidding just that key would still accept every object omitting it, which is
+    wider than the document allows and is what the oracle caught.
+    """
+    document = {
+        "type": "object",
+        "required": ["zz"],
+        "propertyNames": {"enum": ["a", "b"]},
+    }
+    reference = _VALIDATOR(document)
+    schema = from_json_schema(document)
+
+    for value in [{}, {"a": "s"}, {"zz": "s"}, {"a": "s", "b": "s"}]:
+        assert not reference.is_valid(value)
+        with pytest.raises(Invalid):
+            schema(value)
+
+
+@pytest.mark.parametrize("document", _documents(), ids=str)
+def test_property_names_roundtrip_reaches_a_behavioral_fixpoint(
+    document: dict[str, Any],
+) -> None:
+    """Re-encoding a decoded propertyNames document stops changing what it accepts.
+
+    The property the codec promises (see ``test_fuzz_roundtrip``): the *first*
+    trip may be lossy, but from the second schema onward the accept set is fixed.
+    The emitted document itself is not asserted stable; a pre-existing ``allOf``
+    accretion in the ``All`` encode/decode pair grows it on every trip, on the
+    value path just as much as here.
+    """
+    once = from_json_schema(document)
+    twice = from_json_schema(to_json_schema(once))
+    thrice = from_json_schema(to_json_schema(twice))
+
+    for value in _VALUES:
+        assert _accepts(twice, value) == _accepts(thrice, value), (
+            f"round trip is not a fixpoint for {value!r} on {document!r}"
+        )

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -38,8 +38,20 @@ _KEY_SCHEMAS: list[Any] = [
     True,
     {"not": {"enum": ["bad"]}},
 ]
-_ADDITIONAL: list[Any] = [None, True, False, {"type": "string"}, {"type": "integer"}, {}]
-_PROPERTIES: list[Any] = [None, {}, {"a": {"type": "string"}}, {"xy": {"type": "string"}}]
+_ADDITIONAL: list[Any] = [
+    None,
+    True,
+    False,
+    {"type": "string"},
+    {"type": "integer"},
+    {},
+]
+_PROPERTIES: list[Any] = [
+    None,
+    {},
+    {"a": {"type": "string"}},
+    {"xy": {"type": "string"}},
+]
 _REQUIRED: list[Any] = [None, [], ["a"], ["zz"]]
 
 _VALUES: list[dict[str, Any]] = [

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1699,3 +1699,29 @@ def test_pydantic_literal_keyed_dict_tool_schema_enforces_its_keys() -> None:
     assert schema({"config_hash": "deadbeef"}) == {"config_hash": "deadbeef"}
     with pytest.raises(Invalid):
         schema({"config_hash": {"bogus_key": "deadbeef"}})
+
+
+def test_property_names_const_null_keeps_its_constraint() -> None:
+    """A key schema decoding to None is a real constraint: no JSON key is null."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"const": None},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    with pytest.raises(Invalid):
+        schema({"anything": "x"})
+
+
+def test_required_undeclared_name_with_no_additional_properties_accepts_nothing() -> (
+    None
+):
+    """additionalProperties false forbids the undeclared name that required demands."""
+    schema = from_json_schema(
+        {"type": "object", "additionalProperties": False, "required": ["a"]},
+    )
+    with pytest.raises(Invalid):
+        schema({"a": 1})
+    with pytest.raises(Invalid):
+        schema({})

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1742,3 +1742,30 @@ def test_property_names_const_does_not_replace_a_declared_property() -> None:
         schema({"a": "x"})
     with pytest.raises(Invalid):
         schema({"zz": "x"})
+
+
+def test_property_names_referring_to_the_root_is_refused() -> None:
+    """A key schema pointing at the schema being built cannot be checked yet."""
+    with pytest.raises(SchemaError, match="schema being built"):
+        from_json_schema(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "propertyNames": {"$ref": "#"},
+            },
+        )
+
+
+def test_property_names_with_a_resolvable_ref_still_decodes() -> None:
+    """A $ref key schema that is not self-recursive resolves and constrains keys."""
+    schema = from_json_schema(
+        {
+            "$defs": {"name": {"enum": ["a", "b"]}},
+            "type": "object",
+            "propertyNames": {"$ref": "#/$defs/name"},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    assert schema({"a": "x"}) == {"a": "x"}
+    with pytest.raises(Invalid):
+        schema({"zz": "x"})

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -23,6 +23,7 @@ from probatio.validators import (
     Base64,
     Contains,
     ExactSequence,
+    In,
     Length,
     MultipleOf,
     Range,
@@ -659,7 +660,6 @@ def test_format_byte_decodes_to_base64() -> None:
     "node",
     [
         {"patternProperties": {"^x": {"type": "integer"}}},
-        {"propertyNames": {"maxLength": 3}},
         {"dependentRequired": {"a": ["b"]}},
         {"dependentSchemas": {"a": {"type": "object"}}},
         {"if": {"type": "string"}, "then": {"minLength": 1}},
@@ -1481,3 +1481,221 @@ def test_property_default_is_validated_after_it_is_applied() -> None:
     )
     with pytest.raises(MultipleInvalid):
         schema({})
+
+
+def test_property_names_constrains_undeclared_keys() -> None:
+    """propertyNames decodes to the mapping's key validator (Pydantic dict[Literal, str])."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"enum": ["energy_sources", "device_consumption"]},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    assert schema({"energy_sources": "abc"}) == {"energy_sources": "abc"}
+    with pytest.raises(Invalid):
+        schema({"nope": "abc"})
+
+
+def test_property_names_of_type_string_keeps_the_schema_usable() -> None:
+    """A key schema of {"type": "string"} is what Zod emits for a record; it decodes."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"type": "string"},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    assert schema({"anything": "x"}) == {"anything": "x"}
+    with pytest.raises(Invalid):
+        schema({"anything": 1})
+
+
+def test_property_names_without_additional_properties_leaves_values_free() -> None:
+    """propertyNames alone constrains the keys and lets any value through."""
+    schema = from_json_schema({"type": "object", "propertyNames": {"enum": ["a"]}})
+    assert schema({"a": object}) == {"a": object}
+    with pytest.raises(Invalid):
+        schema({"b": 1})
+
+
+def test_property_names_is_not_bypassed_by_additional_properties_true() -> None:
+    """An open object still has to satisfy propertyNames; ALLOW_EXTRA would skip it."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"enum": ["a"]},
+            "additionalProperties": True,
+        },
+    )
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(Invalid):
+        schema({"b": 1})
+
+
+def test_property_names_forbids_a_declared_property_it_rejects() -> None:
+    """propertyNames covers declared names, so a contradicted property can never appear."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "propertyNames": {"enum": ["b"]},
+        },
+    )
+    forbidden = [key for key in schema.schema if isinstance(key, Forbidden)]
+    assert len(forbidden) == 1
+    with pytest.raises(Invalid):
+        schema({"a": "x"})
+
+
+def test_property_names_applies_without_a_type() -> None:
+    """A typeless propertyNames constrains objects and passes other values through."""
+    schema = from_json_schema({"propertyNames": {"maxLength": 3}})
+    assert schema("not an object") == "not an object"
+    assert schema({"abc": 1}) == {"abc": 1}
+    with pytest.raises(Invalid):
+        schema({"toolong": 1})
+
+
+def test_property_names_round_trips_through_to_json_schema() -> None:
+    """A key validator survives the encode/decode round trip as propertyNames."""
+    encoded = to_json_schema(Schema({In(["a", "b"]): str}))
+    assert encoded["propertyNames"] == {"enum": ["a", "b"]}
+
+    schema = from_json_schema(encoded)
+    assert schema({"a": "x"}) == {"a": "x"}
+    with pytest.raises(Invalid):
+        schema({"zzz": "x"})
+
+
+def test_property_names_allows_a_declared_property_it_accepts() -> None:
+    """A declared name the key schema accepts stays an ordinary property."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "propertyNames": {"enum": ["a"]},
+        },
+    )
+    assert schema({"a": "x"}) == {"a": "x"}
+    assert not [key for key in schema.schema if isinstance(key, Forbidden)]
+
+
+def test_property_names_rejecting_a_required_name_accepts_nothing() -> None:
+    """A required name the key schema forbids leaves the object unsatisfiable.
+
+    The name has to be present and may never be present. Forbidding just that key
+    would still accept every object that omits it, which is wider than the
+    document allows (see ``test_decoder_oracle``).
+    """
+    schema = from_json_schema(
+        {"type": "object", "required": ["a"], "propertyNames": {"enum": ["b"]}},
+    )
+    with pytest.raises(Invalid):
+        schema({"a": 1})
+    with pytest.raises(Invalid):
+        schema({"b": 1})
+    with pytest.raises(Invalid):
+        schema({})
+
+
+@pytest.mark.parametrize("key_schema", [{}, True])
+def test_property_names_that_accepts_anything_is_no_constraint(
+    key_schema: object,
+) -> None:
+    """An accept-anything key schema leaves the object's open shape untouched."""
+    schema = from_json_schema({"type": "object", "propertyNames": key_schema})
+    assert schema({"anything": 1}) == {"anything": 1}
+
+
+def test_property_names_that_cannot_be_a_key_is_refused() -> None:
+    """A key schema decoding to an unhashable mapping cannot take the key slot."""
+    with pytest.raises(SchemaError, match="propertyNames"):
+        from_json_schema(
+            {
+                "type": "object",
+                "propertyNames": {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                },
+            },
+        )
+
+
+def test_property_names_rejects_a_non_string_key() -> None:
+    """The key schema runs on the key itself, so a non-string key is caught.
+
+    voluptuous-openapi rendered this as ``{Extra: str}``, which constrains only the
+    values, so a non-string key passed. A key validator constrains the key.
+    """
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"type": "string"},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    with pytest.raises(Invalid):
+        schema({1: "x"})
+
+
+def test_zod_record_tool_schema_decodes() -> None:
+    """A Zod 4 record argument decodes; refusing it broke real MCP servers.
+
+    Verbatim ``z.toJSONSchema`` output for an object holding
+    ``z.record(z.string(), z.string())``. Zod emits ``propertyNames`` for every
+    record, so refusing the keyword took down any tool with a record argument.
+    """
+    schema = from_json_schema(
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "minLength": 1},
+                "filters": {
+                    "type": "object",
+                    "propertyNames": {"type": "string"},
+                    "additionalProperties": {"type": "string"},
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    )
+    call = {"query": "climate", "filters": {"publication_year": "2020-2024"}}
+    assert schema(call) == call
+    with pytest.raises(Invalid):
+        schema({"query": "climate", "filters": {"publication_year": 2020}})
+
+
+def test_pydantic_literal_keyed_dict_tool_schema_enforces_its_keys() -> None:
+    """A Pydantic dict[Literal[...], str] argument keeps its key constraint.
+
+    Verbatim ``TypeAdapter(str | dict[Literal[...], str] | None).json_schema()``
+    output. The old converter dropped the key set entirely and accepted any key.
+    """
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "config_hash": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {
+                            "additionalProperties": {"type": "string"},
+                            "propertyNames": {
+                                "enum": ["energy_sources", "device_consumption"],
+                            },
+                            "type": "object",
+                        },
+                        {"type": "null"},
+                    ],
+                },
+            },
+        },
+    )
+    ok = {"config_hash": {"energy_sources": "deadbeef"}}
+    assert schema(ok) == ok
+    assert schema({"config_hash": "deadbeef"}) == {"config_hash": "deadbeef"}
+    with pytest.raises(Invalid):
+        schema({"config_hash": {"bogus_key": "deadbeef"}})

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1725,3 +1725,20 @@ def test_required_undeclared_name_with_no_additional_properties_accepts_nothing(
         schema({"a": 1})
     with pytest.raises(Invalid):
         schema({})
+
+
+def test_property_names_const_does_not_replace_a_declared_property() -> None:
+    """A literal key schema stays a key validator, not a key equal to a marker."""
+    schema = from_json_schema(
+        {
+            "type": "object",
+            "propertyNames": {"const": "a"},
+            "properties": {"a": {"type": "integer"}},
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    assert schema({"a": 1}) == {"a": 1}
+    with pytest.raises(Invalid):
+        schema({"a": "x"})
+    with pytest.raises(Invalid):
+        schema({"zz": "x"})

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -966,3 +966,40 @@ def test_strict_raises_on_a_coerce_with_a_non_type_target() -> None:
 
     with pytest.raises(SchemaError, match="non-type target"):
         to_json_schema(Schema(Coerce(str.upper)), strict=True)
+
+
+def test_type_key_emits_no_property_names() -> None:
+    """A plain str key accepts every JSON key, so it adds no propertyNames noise."""
+    assert "propertyNames" not in to_json_schema(Schema({str: int}))
+
+
+def test_restrictive_key_validator_becomes_property_names() -> None:
+    """A key validator is a real constraint; dropping it would widen the schema."""
+    encoded = to_json_schema(Schema({In(["a", "b"]): str}))
+    assert encoded["propertyNames"] == {"enum": ["a", "b"]}
+
+
+def test_several_restrictive_key_validators_merge_into_any_of() -> None:
+    """The engine accepts a key matching any variable key, so they merge as anyOf."""
+    encoded = to_json_schema(Schema({In(["a"]): str, Match(r"^x"): int}))
+    assert encoded["propertyNames"] == {
+        "anyOf": [{"enum": ["a"]}, {"type": "string", "pattern": "^x"}],
+    }
+
+
+def test_one_open_key_validator_drops_property_names() -> None:
+    """A str key alongside a restrictive one accepts everything, so nothing is emitted."""
+    assert "propertyNames" not in to_json_schema(Schema({In(["a"]): str, str: int}))
+
+
+def test_property_names_is_dropped_beside_a_declared_property() -> None:
+    """Emitting it there would narrow: JSON Schema applies it to declared names too.
+
+    A probatio literal key is matched ahead of the variable keys and never sees
+    them, so ``{In(["a"]): str, "x": int}`` accepts ``{"x": 1}``. A document
+    carrying propertyNames would reject it, which is a narrowing; dropping the
+    keyword widens instead.
+    """
+    encoded = to_json_schema(Schema({In(["a"]): str, "x": int}))
+    assert "propertyNames" not in encoded
+    assert encoded["properties"] == {"x": {"type": "integer"}}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1024,3 +1024,28 @@ def test_non_string_const_key_emits_no_property_names() -> None:
 def test_string_const_key_becomes_property_names() -> None:
     """A const key of a string does match a property name, so it is emitted."""
     assert to_json_schema(Schema({Equal("a"): str}))["propertyNames"] == {"const": "a"}
+
+
+def test_strict_refuses_a_key_validator_beside_a_declared_property() -> None:
+    """Dropping the key constraint widens, and strict mode exists to refuse that."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({In(["a"]): str, "x": int})
+    assert "propertyNames" not in to_json_schema(schema)
+    with pytest.raises(SchemaError, match="key validator"):
+        to_json_schema(schema, strict=True)
+
+
+def test_strict_refuses_a_key_validator_that_cannot_match_a_name() -> None:
+    """A coercing key has no property-name form, so strict mode refuses the drop."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({Coerce(int): str})
+    assert "propertyNames" not in to_json_schema(schema)
+    with pytest.raises(SchemaError, match="key validator"):
+        to_json_schema(schema, strict=True)
+
+
+def test_strict_still_allows_an_open_string_key() -> None:
+    """A plain str key constrains nothing, so there is no constraint to refuse."""
+    assert "propertyNames" not in to_json_schema(Schema({str: int}), strict=True)

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1003,3 +1003,24 @@ def test_property_names_is_dropped_beside_a_declared_property() -> None:
     encoded = to_json_schema(Schema({In(["a"]): str, "x": int}))
     assert "propertyNames" not in encoded
     assert encoded["properties"] == {"x": {"type": "integer"}}
+
+
+def test_coercing_key_validator_emits_no_property_names() -> None:
+    """A key rendering as a non-string type would reject every JSON property name."""
+    encoded = to_json_schema(Schema({Coerce(int): str}))
+    assert "propertyNames" not in encoded
+
+
+def test_non_string_enum_key_emits_no_property_names() -> None:
+    """An enum key of non-strings cannot match a property name, so it is dropped."""
+    assert "propertyNames" not in to_json_schema(Schema({In([1, 2]): str}))
+
+
+def test_non_string_const_key_emits_no_property_names() -> None:
+    """A const key of a non-string cannot match a property name either."""
+    assert "propertyNames" not in to_json_schema(Schema({Equal(1): str}))
+
+
+def test_string_const_key_becomes_property_names() -> None:
+    """A const key of a string does match a property name, so it is emitted."""
+    assert to_json_schema(Schema({Equal("a"): str}))["propertyNames"] == {"const": "a"}

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -378,6 +378,30 @@ def test_invalid_extra_policy_stays_interpreted() -> None:
     assert schema({"a": 1}) == {"a": 1}
 
 
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {In(["a", "b"]): str},
+        {"x": int, In(["a", "b"]): str},
+        {Match(r"^[a-z]+$"): int},
+    ],
+    ids=["membership", "with_property", "match"],
+)
+def test_key_validator_mapping_stays_interpreted(mapping: dict) -> None:
+    """A validator key (what propertyNames decodes to) is not generated, and agrees.
+
+    The generator inlines a literal or type key; an arbitrary key validator has to
+    run per key, so it bails to the engine. Compilation declining is the safe
+    outcome, but only if the two paths still agree, so both are asserted here.
+    """
+    compiled = Schema(mapping, compile=True).compile()
+    assert not _is_compiled(compiled)
+
+    interpreted = Schema(mapping, compile=False)
+    for data in ({"a": "s"}, {"x": 1}, {"zz": "s"}, {"a": 1}, {1: "s"}, {}):
+        assert _outcome(interpreted, dict(data)) == _outcome(compiled, dict(data))
+
+
 def test_strenum_key_stays_interpreted() -> None:
     """A StrEnum key is a str, but its repr is not source to emit, so it bails."""
     schema = Schema({_Svc.ON: int}, compile=True).compile()


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

A document carrying `propertyNames` used to raise `SchemaError` and now decodes, so nothing that worked before stops working. Two behavior changes are worth calling out:

- `to_json_schema` now emits `propertyNames` for a restrictive key validator on a mapping that declares no properties. `Schema({In(["a", "b"]): str})` previously emitted only `additionalProperties`, silently dropping the key constraint. A consumer diffing emitted documents will see the new keyword. `Schema({str: int})`, by far the common case, is unchanged.
- Two decoder widenings are closed, so a decoded schema can now reject input it used to accept. Both only trigger on documents that were already contradictory: an object whose `required` name is forbidden by `propertyNames`, and a constrained object that was rendered open by `additionalProperties: true`.

## Proposed change

The decoder refused `propertyNames` outright, on the reasoning that silently dropping a restrictive keyword would widen an untrusted schema. That reasoning holds; the premise did not. A mapping key is itself validated by a schema, so `propertyNames` maps straight onto the key side of a mapping, which is where `additionalProperties` already puts a plain `str`.

Refusing it was expensive in practice. Zod emits `propertyNames` for every `z.record()`, and Pydantic emits it for a `dict` keyed by a `Literal`, so it turns up in most machine-generated documents. Home Assistant's Model Context Protocol integration converts every tool input schema through `from_openapi` and fails the config entry on any error, so a single record-typed tool argument took down a whole MCP server. Two were reported: [openalex-mcp-server](https://github.com/cyanheads/openalex-mcp-server) (`z.record(z.string(), z.string())`) and [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) (`dict[Literal[...], str]`).

Worth noting what the previous converter did here, since this is what the behavior is measured against. `voluptuous-openapi` never handled the keyword at all: it does not appear anywhere in its source. It rendered the Pydantic form as `{Extra: str}`, dropping the key set entirely, so a document permitting exactly three keys accepted any key at all. So this is not just a return to the old behavior, it is a constraint that was never enforced before.

**Decode** maps the keyword onto the mapping's key validator. `{"enum": [...]}` becomes `In([...])`; a key schema that accepts anything stays vacuous, so an open object keeps its shape. A constrained object never renders with `ALLOW_EXTRA`, which would wave through exactly the keys the schema exists to reject, and a required name the key schema forbids leaves the object unsatisfiable rather than merely forbidding that one key.

**Encode** emits the keyword back for a restrictive key validator, but only for a mapping that declares no properties. JSON Schema applies `propertyNames` to declared names too, while a probatio literal key is matched ahead of the variable keys and never sees them, so emitting it beside a declared property would reject input the schema accepts.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: Home Assistant's `mcp` integration, which calls `from_openapi` on every tool input schema

The decoder had no oracle. Both encoder directions have one (`test_encoder_differential` against `jsonschema`, `test_openapi_oracle` against `openapi-schema-validator`), but nothing checked a decoded schema against a reference, so a newly implemented keyword had only hand-written examples holding it up. `tests/codecs/test_decoder_oracle.py` closes that for this keyword: 623 documents against `jsonschema`'s reference implementation, one-directional in the same shape the encoder oracles use, plus a round-trip fixpoint check. It caught both decoder widenings fixed here, one of which I had explicitly waved off as too pathological to matter while writing the first version.

Three pre-existing issues turned up while building the oracle. None are touched here, and each is documented where the test excludes it:

1. `additionalProperties: false` with a `required` name absent from `properties` is unsatisfiable, but probatio accepts objects carrying that name. Reproduces on `main` with no `propertyNames` involved.
2. An emitted document grows an `allOf` nesting level on every round trip, without bound. `Schema({"x": All(str, Match("^x"))})` shows it on the plain value path. Behavior stays stable, which is why the round-trip fuzz never noticed.
3. `tests/strategies.py` builds mappings only from literal markers plus `Extra`, so it never generates a variable key. All three property suites are blind to that region, including plain `{str: int}`.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
