### PR TITLE
Decode a JSON Schema pattern as the search it is

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -525,10 +525,14 @@ def _property_names(variable_keys: list[dict[str, Any]]) -> dict[str, Any] | Non
 def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
     """Whether a rendered key schema can match a string, the only kind of key.
 
-    A combinator is read through: one branch asserting a string is enough, since
-    that is what makes a property name possible at all. Anything else this cannot
-    read reports False and drops the keyword, which widens. Widening is the
-    direction the encoder is allowed to be wrong in.
+    A combinator is read through, with the quantifier its own semantics demand.
+    ``allOf`` holds every branch at once, so a property name has to satisfy all of
+    them; one string branch beside ``{"type": "integer"}`` describes a key nothing
+    can be, and emitting it would reject every object the mapping accepts. A union
+    only needs one branch to work out.
+
+    Anything else this cannot read reports False and drops the keyword, which
+    widens. Widening is the direction the encoder is allowed to be wrong in.
     """
     if key_schema.get("type") == "string":
         return True
@@ -540,11 +544,18 @@ def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
     # A merged ``All`` renders as ``allOf``, which is how a decoded pattern comes
     # back around on a second trip; without this the constraint would be dropped
     # there and the round trip would quietly widen.
-    for combinator in ("allOf", "anyOf", "oneOf"):
-        branches = key_schema.get(combinator)
-        if isinstance(branches, list) and any(
+    branches = key_schema.get("allOf")
+    if isinstance(branches, list) and branches:
+        return all(
             isinstance(branch, dict) and _matches_a_property_name(branch)
             for branch in branches
+        )
+
+    for combinator in ("anyOf", "oneOf"):
+        union = key_schema.get(combinator)
+        if isinstance(union, list) and any(
+            isinstance(branch, dict) and _matches_a_property_name(branch)
+            for branch in union
         ):
             return True
 

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -37,7 +37,7 @@ from probatio.codecs._shared import (
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
 from probatio.codecs._shared import json_safe as _json_safe
 from probatio.codecs._shared import ordered_values as _ordered
-from probatio.error import ContainsInvalid, Invalid, SchemaError
+from probatio.error import ContainsInvalid, Invalid, MatchInvalid, SchemaError
 from probatio.markers import (
     Alias,
     Exclusive,
@@ -525,9 +525,10 @@ def _property_names(variable_keys: list[dict[str, Any]]) -> dict[str, Any] | Non
 def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
     """Whether a rendered key schema can match a string, the only kind of key.
 
-    Deliberately conservative: a shape this cannot read as string-matching (an
-    ``allOf`` of merged constraints, say) reports False and drops the keyword,
-    which widens. Widening is the direction the encoder is allowed to be wrong in.
+    A combinator is read through: one branch asserting a string is enough, since
+    that is what makes a property name possible at all. Anything else this cannot
+    read reports False and drops the keyword, which widens. Widening is the
+    direction the encoder is allowed to be wrong in.
     """
     if key_schema.get("type") == "string":
         return True
@@ -535,6 +536,18 @@ def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
         return all(isinstance(member, str) for member in key_schema["enum"])
     if "const" in key_schema:
         return isinstance(key_schema["const"], str)
+
+    # A merged ``All`` renders as ``allOf``, which is how a decoded pattern comes
+    # back around on a second trip; without this the constraint would be dropped
+    # there and the round trip would quietly widen.
+    for combinator in ("allOf", "anyOf", "oneOf"):
+        branches = key_schema.get(combinator)
+        if isinstance(branches, list) and any(
+            isinstance(branch, dict) and _matches_a_property_name(branch)
+            for branch in branches
+        ):
+            return True
+
     return False
 
 
@@ -803,7 +816,7 @@ def _convert_constraint(node: Any) -> dict[str, Any] | None:
     if isinstance(node, Length):
         return _convert_length(node)
 
-    if isinstance(node, Match):
+    if isinstance(node, Match | _JsonPattern):
         return _convert_match(node)
 
     if isinstance(node, Maybe):
@@ -950,7 +963,7 @@ _PYTHON_ONLY_REGEX = re.compile(
 )
 
 
-def _convert_match(node: Match) -> dict[str, Any]:
+def _convert_match(node: Match | _JsonPattern) -> dict[str, Any]:
     """Render a Match as a string, with a JSON Schema ``pattern`` when ECMA-safe.
 
     JSON Schema patterns are ECMA-262 regular expressions, while ``Match`` holds a
@@ -961,7 +974,9 @@ def _convert_match(node: Match) -> dict[str, Any]:
     ``Match`` validates with ``re.match`` (anchored at the start), while a JSON
     Schema ``pattern`` is an unanchored ``re.search``. Wrapping an unanchored
     source as ``^(?:...)`` preserves the start anchoring, so the emitted schema
-    does not accept a value with a matching suffix that ``Match`` rejects.
+    does not accept a value with a matching suffix that ``Match`` rejects. A
+    ``_JsonPattern`` came *from* a JSON Schema ``pattern`` and already searches,
+    so it needs no wrapper and keeps its meaning across a round trip.
 
     A ``bytes`` pattern has no JSON Schema (JSON strings are text), so it renders
     as a plain string rather than crashing on the ``str``/``bytes`` mismatch.
@@ -969,6 +984,12 @@ def _convert_match(node: Match) -> dict[str, Any]:
     source = node.pattern.pattern
     if isinstance(source, bytes) or _PYTHON_ONLY_REGEX.search(source):
         return {"type": "string"}
+
+    # A decoded ``pattern`` already carries the spec's search semantics, so it
+    # goes back out exactly as it came in.
+    if isinstance(node, _JsonPattern):
+        return {"type": "string", "pattern": source}
+
     # A source already anchored at the start needs no wrapper; otherwise wrap it
     # (grouped, so a top-level alternation stays under the anchor).
     anchored = source if source.startswith("^") else f"^(?:{source})"
@@ -1540,6 +1561,41 @@ class _Not:
         raise Invalid(translation_key="must_not_match_not_schema")
 
 
+class _JsonPattern:
+    """Decode of JSON Schema ``pattern``: an unanchored search, not a match.
+
+    JSON Schema defines ``pattern`` as "the regular expression matches somewhere
+    in the string", the semantics of ``re.search``. ``Match`` mirrors voluptuous
+    and uses ``re.match``, which is anchored at the start, so decoding a pattern
+    to it rejected values the document allows. On its own that only narrowed, and
+    went unnoticed; under ``not`` it inverted into a widening, accepting exactly
+    what the document forbids.
+
+    The pattern is kept compiled (read the source as ``.pattern.pattern``) so the
+    encoder can re-emit it unanchored and the round trip keeps its meaning.
+    """
+
+    def __init__(self, pattern: str) -> None:
+        """Compile the pattern (already vetted by ``_safe_pattern``)."""
+        self.pattern = re.compile(pattern)
+
+    def __repr__(self) -> str:
+        """Render readably for error paths."""
+        return f"JsonPattern({self.pattern.pattern!r})"
+
+    def __call__(self, value: Any) -> Any:
+        """Return the value if the pattern is found anywhere in it."""
+        try:
+            found = self.pattern.search(value)
+        except TypeError as exc:
+            raise MatchInvalid(translation_key="expected_string") from exc
+
+        if not found:
+            raise MatchInvalid(translation_key="does_not_match_pattern")
+
+        return value
+
+
 def _unique_key(value: Any) -> Any:
     """Reduce a JSON value to a hashable key with JSON equality semantics.
 
@@ -1846,7 +1902,7 @@ def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
             ),
         )
     if "pattern" in node:
-        constraints.append(Match(_safe_pattern(node["pattern"])))
+        constraints.append(_JsonPattern(_safe_pattern(node["pattern"])))
     # When array keywords are present, the array facet below reads uniqueItems
     # and contains itself, scoped to arrays; adding them standalone here too
     # would double-apply them.
@@ -2460,7 +2516,7 @@ def _from_string(node: dict[str, Any]) -> Any:
             ),
         )
     if "pattern" in node:
-        constraints.append(Match(_safe_pattern(node["pattern"])))
+        constraints.append(_JsonPattern(_safe_pattern(node["pattern"])))
     if not constraints:
         return base
 

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -33,6 +33,7 @@ from probatio.codecs._shared import (
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
 from probatio.codecs._shared import json_safe as _json_safe
 from probatio.codecs._shared import ordered_values as _ordered
+from probatio.codecs.jsonschema import _JsonPattern
 from probatio.error import SchemaError
 from probatio.markers import (
     Alias,
@@ -607,6 +608,10 @@ def _oa_combinator(node: Any, custom: Any, version: str) -> dict[str, Any] | Non
         # A Unix timestamp on the wire is a number (``FromEpoch`` takes an int or a
         # fractional-second float); the datetime is internal.
         return {"type": "number"}
+    if isinstance(node, _JsonPattern):
+        # A decoded JSON Schema ``pattern``. OpenAPI ``pattern`` is an unanchored
+        # search too, so it goes back out exactly as it came in.
+        return {"pattern": node.pattern.pattern}
     if isinstance(node, Match):
         source = node.pattern.pattern
         # A bytes pattern has no OpenAPI form (schema strings are text), so it

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -13,13 +13,9 @@ Probatio being stricter is expected and allowed: a declared property set is a
 closed contract here (its deliberate strict default), where JSON Schema leaves the
 object open unless ``additionalProperties`` says otherwise.
 
-The matrix deliberately carries no negated ``pattern``. JSON Schema ``pattern`` is
-an unanchored search while ``Match`` is an anchored ``re.match``, so ``{"not":
-{"pattern": "x"}}`` accepts the key ``"ax"`` where the reference rejects it. That
-is a real widening, but it belongs to every decoded ``pattern`` rather than to
-key schemas (``_convert_match`` already compensates in the encode direction and
-the decoder has no counterpart), so it is tracked separately rather than papered
-over with a key-schema-shaped exclusion here.
+The matrix carries a negated unanchored ``pattern`` on purpose. It is what caught
+the search/match gap: JSON Schema ``pattern`` searches while ``Match`` anchors,
+which only narrowed on its own but inverted into a widening under ``not``.
 """
 
 from __future__ import annotations
@@ -45,6 +41,8 @@ _KEY_SCHEMAS: list[Any] = [
     {},
     True,
     {"not": {"enum": ["bad"]}},
+    {"not": {"pattern": "x"}},
+    {"pattern": "x"},
 ]
 _ADDITIONAL: list[Any] = [
     None,

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -1769,3 +1769,47 @@ def test_property_names_with_a_resolvable_ref_still_decodes() -> None:
     assert schema({"a": "x"}) == {"a": "x"}
     with pytest.raises(Invalid):
         schema({"zz": "x"})
+
+
+def test_pattern_is_an_unanchored_search() -> None:
+    """JSON Schema pattern matches anywhere in the string, unlike Match."""
+    schema = from_json_schema({"type": "string", "pattern": "x"})
+    assert schema("ax") == "ax"
+    assert schema("xa") == "xa"
+    with pytest.raises(Invalid):
+        schema("nope")
+
+
+def test_anchored_pattern_still_anchors() -> None:
+    """A pattern the document anchors itself keeps rejecting a matching suffix."""
+    schema = from_json_schema({"type": "string", "pattern": "^x"})
+    assert schema("xa") == "xa"
+    with pytest.raises(Invalid):
+        schema("ax")
+
+
+def test_negated_pattern_does_not_widen() -> None:
+    """The search/match gap inverted under not, accepting what the document forbids."""
+    schema = from_json_schema({"not": {"pattern": "x"}})
+    assert schema("nope") == "nope"
+    with pytest.raises(Invalid):
+        schema("ax")
+
+
+def test_pattern_rejects_a_non_string() -> None:
+    """A non-string cannot be searched, so it is a clean Invalid, not a TypeError."""
+    with pytest.raises(Invalid):
+        from_json_schema({"pattern": "x"})(123)
+
+
+def test_decoded_pattern_repr_names_its_source() -> None:
+    """The decoded pattern renders readably for error paths."""
+    schema = from_json_schema({"type": "string", "pattern": "x"})
+    assert "x" in repr(schema.schema)
+
+
+def test_pattern_round_trips_unanchored() -> None:
+    """Re-emitting a decoded pattern keeps its meaning, so it is not re-anchored."""
+    encoded = to_json_schema(from_json_schema({"type": "string", "pattern": "x"}))
+    again = from_json_schema(encoded)
+    assert again("ax") == "ax"

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1049,3 +1049,20 @@ def test_strict_refuses_a_key_validator_that_cannot_match_a_name() -> None:
 def test_strict_still_allows_an_open_string_key() -> None:
     """A plain str key constrains nothing, so there is no constraint to refuse."""
     assert "propertyNames" not in to_json_schema(Schema({str: int}), strict=True)
+
+
+def test_conjunction_key_needs_every_branch_to_match_a_name() -> None:
+    """allOf holds every branch at once, so one string branch is not enough.
+
+    ``All(str, Coerce(int))`` accepts the key "1" by coercing it, and renders as an
+    ``allOf`` of a string and an integer. Emitting that as propertyNames would
+    describe a key nothing can be, rejecting every object the mapping accepts.
+    """
+    encoded = to_json_schema(Schema({All(str, Coerce(int)): str}))
+    assert "propertyNames" not in encoded
+
+
+def test_union_key_needs_only_one_branch_to_match_a_name() -> None:
+    """anyOf is satisfied by a single branch, so one string branch is enough."""
+    encoded = to_json_schema(Schema({Any(In(["a"]), In(["b"])): str}))
+    assert encoded["propertyNames"] == {"anyOf": [{"enum": ["a"]}, {"enum": ["b"]}]}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -803,3 +803,11 @@ def test_strict_allows_a_faithfully_open_schema() -> None:
 def test_non_strict_still_widens_by_default() -> None:
     """Without strict, an unrepresentable construct still widens to an open schema."""
     assert to_openapi(Schema(frozenset[int])) == {}
+
+
+def test_decoded_pattern_emits_an_unanchored_openapi_pattern() -> None:
+    """OpenAPI pattern is an unanchored search too, so it round-trips as written."""
+    from probatio import from_json_schema  # noqa: PLC0415
+
+    decoded = from_json_schema({"type": "string", "pattern": "x"})
+    assert to_openapi(decoded)["pattern"] == "x"


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

A decoded `pattern` becomes more permissive, so a schema built by `from_json_schema` can now accept input it used to reject. `{"pattern": "x"}` accepts `"ax"`, as the specification says it should; previously only a match at position 0 counted. A pattern the document anchors itself (`^x`, `^[a-z]+$`) is unaffected, and the great majority of real patterns are anchored.

`to_json_schema` and `to_openapi` emit a decoded pattern unanchored rather than wrapping it as `^(?:...)`, so a consumer diffing emitted documents will see the change. An anchored `Match` written by hand still gets the wrapper, unchanged.

## Proposed change

JSON Schema defines `pattern` as "the regular expression matches somewhere in the string", which is `re.search`. The decoder built a `Match`, and `Match` mirrors voluptuous by using `re.match`, anchored at the start. So a decoded `{"pattern": "x"}` rejected `"ax"`, which the document allows.

On its own that only narrows, which is why it survived this long. Under `not` it inverts into a widening:

```python
from_json_schema({"not": {"pattern": "x"}})("ax")   # accepted; the document forbids it
```

The same reaches through a `propertyNames` key schema, which is where [@copilot spotted it](https://github.com/frenck/probatio/pull/321#discussion_r3867013333) during the review of #321.

The encoder already knew about the mismatch. `_convert_match` wraps an unanchored `Match` source as `^(?:...)` precisely so the emitted document does not accept a suffix match the validator rejects, and its docstring spells that out. The decoder never got the other half.

`_JsonPattern` is that half. It sits with the other decode-side classes that carry JSON semantics Python's own do not (`_JsonConst`, `_JsonEnum`, `_JsonUnique`), and both encoders re-emit it unanchored so a round trip preserves the pattern's meaning instead of quietly anchoring it. `to_openapi` gets the same branch, where an unanchored `pattern` was already the correct output and a decoded one now genuinely means it.

The oracle matrix from #321 carries a negated unanchored pattern from here on, since that is the shape that catches this class.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #321, where the review surfaced this

Measured across six patterns in seven positions (typed, bare, negated, `propertyNames`, negated `propertyNames`, array items, `anyOf`) against `jsonschema`'s reference implementation:

| values | widenings before | widenings after |
| ------ | ---------------- | --------------- |
| strings | 42 | 0 |
| non-strings | 42 | 42 |

The non-string column does not move, and deliberately so: it is a different, pre-existing bug. JSON Schema applies a type-specific keyword vacuously to values of other types, so `{"pattern": "x"}` accepts `5`, and `{"not": {"pattern": "x"}}` therefore rejects it. The decoder applies these keywords unconditionally, so `not` inverts them.

That affects a whole family, not just `pattern`, and all of it reproduces on `main`:

```python
from_json_schema({"not": {"minLength": 5}})(5)    # accepted; the document forbids it
from_json_schema({"not": {"minimum": 10}})("str") # same
from_json_schema({"not": {"multipleOf": 2}})("str")
```

The array keywords are already scoped correctly through `_WhenType`; the string and number ones never were. Fixing that means type-scoping five keywords in `_from_constraints`, which is its own change with its own blast radius, so it is not folded in here. Happy to follow up with it.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
