### PR TITLE
Fuzz the mapping keys the strategies never generated

### DIFF
--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -133,8 +133,12 @@ def covers_every_property_name(key: Any) -> bool:
     Shared by both encoders: they ask the same question, and answering it in two
     places is how they drifted apart before.
     """
-    while isinstance(key, Msg | Schema):
-        key = key.validator if isinstance(key, Msg) else key.schema
+    # Exact types, not ``isinstance``. A subclass can override ``__call__`` to
+    # match far less than what it wraps, and unwrapping one to ``str`` would call
+    # it universal and keep a value schema that rejects keys the mapping accepts.
+    # ``DataclassSchema`` and ``TypedDictSchema`` are two such subclasses already.
+    while type(key) in (Msg, Schema):
+        key = key.validator if type(key) is Msg else key.schema
 
     return key is Extra or key is str or key is object
 

--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 from probatio.markers import Extra
+from probatio.schema import Schema
 from probatio.validators import (
     ASCII,
     E164,
@@ -119,9 +120,11 @@ def covers_every_property_name(key: Any) -> bool:
     Nothing else can be assumed to.
 
     Transparent wrappers are unwrapped first. ``Msg`` only swaps the error
-    message, so ``Msg(str, "...")`` matches exactly what ``str`` matches, and
-    treating it as partial would throw away a value schema that is perfectly
-    representable.
+    message and ``Schema`` only compiles what it is given, so ``Msg(str, "...")``
+    and ``Schema(str)`` match exactly what ``str`` matches; treating either as
+    partial would throw away a value schema that is perfectly representable. A
+    bare ``Schema`` cannot be a key (it is unhashable), but one wrapped in a
+    ``Msg`` can, so the loop handles both rather than either alone.
 
     The comparison is by identity on purpose. A key validator's ``__eq__`` is
     user code and can answer anything; a false "yes" would keep a value schema
@@ -130,8 +133,8 @@ def covers_every_property_name(key: Any) -> bool:
     Shared by both encoders: they ask the same question, and answering it in two
     places is how they drifted apart before.
     """
-    while isinstance(key, Msg):
-        key = key.validator
+    while isinstance(key, Msg | Schema):
+        key = key.validator if isinstance(key, Msg) else key.schema
 
     return key is Extra or key is str or key is object
 

--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+from probatio.markers import Extra
 from probatio.validators import (
     ASCII,
     E164,
@@ -34,6 +35,7 @@ from probatio.validators import (
     IPv6Address,
     IsRegex,
     MacAddress,
+    Msg,
     NormalizeMacAddress,
     NoWhitespace,
     PrintableASCII,
@@ -107,6 +109,31 @@ def merge_dependent_required(groups: Iterable[list[str]]) -> dict[str, list[str]
             for member in members:
                 dependent[member] = [other for other in members if other != member]
     return dependent
+
+
+def covers_every_property_name(key: Any) -> bool:
+    """Whether a mapping's variable key matches every property name it can carry.
+
+    ``Extra`` catches every unmatched key by definition, ``str`` matches every
+    JSON property name (they are all strings), and ``object`` matches anything.
+    Nothing else can be assumed to.
+
+    Transparent wrappers are unwrapped first. ``Msg`` only swaps the error
+    message, so ``Msg(str, "...")`` matches exactly what ``str`` matches, and
+    treating it as partial would throw away a value schema that is perfectly
+    representable.
+
+    The comparison is by identity on purpose. A key validator's ``__eq__`` is
+    user code and can answer anything; a false "yes" would keep a value schema
+    that rejects what the mapping accepts.
+
+    Shared by both encoders: they ask the same question, and answering it in two
+    places is how they drifted apart before.
+    """
+    while isinstance(key, Msg):
+        key = key.validator
+
+    return key is Extra or key is str or key is object
 
 
 def ordered_values(values: Any) -> list[Any]:

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -41,6 +41,7 @@ from probatio.error import ContainsInvalid, Invalid, MatchInvalid, SchemaError
 from probatio.markers import (
     Alias,
     Exclusive,
+    Extra,
     Forbidden,
     Inclusive,
     Marker,
@@ -330,6 +331,10 @@ def _convert_mapping(
     # ...and their *key* validators, which become ``propertyNames``: the mirror of
     # the constraint ``from_json_schema`` reads back out of that keyword.
     variable_keys: list[dict[str, Any]] = []
+    # The raw keys as well. A rendered key schema cannot answer "does this cover
+    # every property name": an unrepresentable callable renders ``{}`` exactly as
+    # ``object`` does, and the two want opposite answers.
+    variable_key_names: list[Any] = []
     # A ``Forbidden`` over a type/callable key (``Forbidden(str)`` forbids every
     # string key, so every JSON key) closes the object regardless of the extra
     # policy.
@@ -361,6 +366,7 @@ def _convert_mapping(
             # to the keys it matches, the same as a plain variable key.
             variable_values.append(value_schema)
             variable_keys.append(_child(name))
+            variable_key_names.append(name)
             continue
 
         if not isinstance(name, str):
@@ -397,7 +403,7 @@ def _convert_mapping(
         False
         if forbid_extra
         else _additional_properties(
-            variable_values, variable_keys, allow_extra=allow_extra
+            variable_values, variable_key_names, allow_extra=allow_extra
         )
     )
     result: dict[str, Any] = {
@@ -478,7 +484,7 @@ def _is_required(marker: Marker | None, *, required_default: bool) -> bool:
 
 def _additional_properties(
     variable_values: list[dict[str, Any]],
-    variable_keys: list[dict[str, Any]],
+    variable_keys: list[Any],
     *,
     allow_extra: bool,
 ) -> Any:
@@ -496,10 +502,15 @@ def _additional_properties(
     the policy lets it through with any value, so rendering it as
     ``additionalProperties: {"type": "integer"}`` would reject what the mapping
     accepts. There the object renders open instead.
+
+    ``variable_keys`` holds the keys themselves, not their rendered schemas, and
+    that is load-bearing: a callable with no JSON Schema form renders ``{}`` just
+    as ``object`` does, so the rendering cannot tell a key that matches everything
+    from one that merely could not be written down.
     """
     if not variable_values:
         return allow_extra
-    if allow_extra and not any(key in _ANY_KEY for key in variable_keys):
+    if allow_extra and not any(map(_covers_every_name, variable_keys)):
         return True
     if len(variable_values) == 1:
         return variable_values[0]
@@ -575,6 +586,15 @@ def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
             return True
 
     return False
+
+
+def _covers_every_name(key: Any) -> bool:
+    """Whether a variable key matches every property name a mapping can carry.
+
+    By identity, not equality: a key validator's ``__eq__`` is user code, and a
+    "yes" from it would keep a value schema that narrows.
+    """
+    return key is Extra or key is str or key is object
 
 
 def _decorate_property(

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -396,22 +396,25 @@ def _convert_mapping(
     additional: Any = (
         False
         if forbid_extra
-        else _additional_properties(variable_values, allow_extra=allow_extra)
+        else _additional_properties(
+            variable_values, variable_keys, allow_extra=allow_extra
+        )
     )
     result: dict[str, Any] = {
         "type": "object",
         "properties": properties,
         "additionalProperties": additional,
     }
-    # ``propertyNames`` constrains *every* property name, declared ones included,
-    # but a probatio literal key is matched ahead of the variable keys and never
-    # sees them. Emitting it beside a declared property would therefore narrow the
-    # document, so it is only emitted for a mapping that declares none.
+    # ``propertyNames`` constrains *every* property name, so it can only be
+    # emitted where every name really is constrained. A declared property is
+    # matched ahead of the variable keys and never sees them, and an open mapping
+    # lets an unmatched key through with any value at all. Emitting it in either
+    # case would reject input the mapping accepts.
     property_names = _property_names(variable_keys)
-    if property_names is not None and properties:
+    if property_names is not None and (properties or allow_extra):
         # Dropping it widens, so strict mode refuses: ``_open`` raises there. Its
         # open-schema return is not wanted here, only that refusal.
-        _open("a key validator on a mapping that also declares properties")
+        _open("a key validator that does not constrain every property name")
         property_names = None
     if property_names is not None:
         result["propertyNames"] = property_names
@@ -475,6 +478,7 @@ def _is_required(marker: Marker | None, *, required_default: bool) -> bool:
 
 def _additional_properties(
     variable_values: list[dict[str, Any]],
+    variable_keys: list[dict[str, Any]],
     *,
     allow_extra: bool,
 ) -> Any:
@@ -483,9 +487,19 @@ def _additional_properties(
     No variable key falls back to the extra policy (open or closed). One renders
     as its value schema; several ({str: int, int: str}) merge into an ``anyOf``
     so no pair is silently dropped.
+
+    An *open* mapping keeps its variable-key value schema only where those keys
+    cover every property name, which a plain ``str`` key does: no name can miss
+    it, so the extra policy never comes into play. A partial key is different.
+    ``{int: int}`` with ``ALLOW_EXTRA`` accepts ``{"a": None}``, because "a"
+    matches no schema key and the policy lets it through with any value, so
+    rendering it as ``additionalProperties: {"type": "integer"}`` would reject
+    what the mapping accepts. There the object renders open instead.
     """
     if not variable_values:
         return allow_extra
+    if allow_extra and not all(key in _ANY_KEY for key in variable_keys):
+        return True
     if len(variable_values) == 1:
         return variable_values[0]
     return {"anyOf": variable_values}

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -31,6 +31,7 @@ from probatio.codecs._shared import (
     STRING_TYPES,
     UNSUPPORTED,
     ExclusiveGroup,
+    covers_every_property_name,
     exclusive_constraint,
     merge_dependent_required,
 )
@@ -41,7 +42,6 @@ from probatio.error import ContainsInvalid, Invalid, MatchInvalid, SchemaError
 from probatio.markers import (
     Alias,
     Exclusive,
-    Extra,
     Forbidden,
     Inclusive,
     Marker,
@@ -510,7 +510,7 @@ def _additional_properties(
     """
     if not variable_values:
         return allow_extra
-    if allow_extra and not any(map(_covers_every_name, variable_keys)):
+    if allow_extra and not any(map(covers_every_property_name, variable_keys)):
         return True
     if len(variable_values) == 1:
         return variable_values[0]
@@ -586,15 +586,6 @@ def _matches_a_property_name(key_schema: dict[str, Any]) -> bool:
             return True
 
     return False
-
-
-def _covers_every_name(key: Any) -> bool:
-    """Whether a variable key matches every property name a mapping can carry.
-
-    By identity, not equality: a key validator's ``__eq__`` is user code, and a
-    "yes" from it would keep a value schema that narrows.
-    """
-    return key is Extra or key is str or key is object
 
 
 def _decorate_property(

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -488,17 +488,18 @@ def _additional_properties(
     as its value schema; several ({str: int, int: str}) merge into an ``anyOf``
     so no pair is silently dropped.
 
-    An *open* mapping keeps its variable-key value schema only where those keys
-    cover every property name, which a plain ``str`` key does: no name can miss
-    it, so the extra policy never comes into play. A partial key is different.
-    ``{int: int}`` with ``ALLOW_EXTRA`` accepts ``{"a": None}``, because "a"
-    matches no schema key and the policy lets it through with any value, so
-    rendering it as ``additionalProperties: {"type": "integer"}`` would reject
-    what the mapping accepts. There the object renders open instead.
+    An *open* mapping keeps its variable-key value schema as long as *some* key
+    covers every property name, which a plain ``str`` key does: no name can miss
+    it, so the extra policy never comes into play and the value schemas describe
+    every property there is. Only partial keys are different. ``{int: int}`` with
+    ``ALLOW_EXTRA`` accepts ``{"a": None}``, because "a" matches no schema key and
+    the policy lets it through with any value, so rendering it as
+    ``additionalProperties: {"type": "integer"}`` would reject what the mapping
+    accepts. There the object renders open instead.
     """
     if not variable_values:
         return allow_extra
-    if allow_extra and not all(key in _ANY_KEY for key in variable_keys):
+    if allow_extra and not any(key in _ANY_KEY for key in variable_keys):
         return True
     if len(variable_values) == 1:
         return variable_values[0]

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -364,9 +364,9 @@ def _convert_mapping(
             # A type/callable key is a variable key. ``Remove`` still validates a
             # present value before dropping it, so its value schema still applies
             # to the keys it matches, the same as a plain variable key.
-            variable_values.append(value_schema)
-            variable_keys.append(_child(name))
-            variable_key_names.append(name)
+            _record_variable_key(
+                name, value_schema, variable_values, variable_keys, variable_key_names
+            )
             continue
 
         if not isinstance(name, str):
@@ -416,7 +416,13 @@ def _convert_mapping(
     # matched ahead of the variable keys and never sees them, and an open mapping
     # lets an unmatched key through with any value at all. Emitting it in either
     # case would reject input the mapping accepts.
-    property_names = _property_names(variable_keys)
+    # One universal key means every name is already matched, so there is nothing
+    # a key schema could add and nothing to report dropping.
+    property_names = (
+        None
+        if any(map(covers_every_property_name, variable_key_names))
+        else _property_names(variable_keys)
+    )
     if property_names is not None and (properties or allow_extra):
         # Dropping it widens, so strict mode refuses: ``_open`` raises there. Its
         # open-schema return is not wanted here, only that refusal.
@@ -522,6 +528,26 @@ def _additional_properties(
     if len(variable_values) == 1:
         return variable_values[0]
     return {"anyOf": variable_values}
+
+
+def _record_variable_key(
+    name: Any,
+    value_schema: dict[str, Any],
+    values: list[dict[str, Any]],
+    keys: list[dict[str, Any]],
+    names: list[Any],
+) -> None:
+    """Record one variable key: its value schema, the key itself, its rendering.
+
+    A universal key is deliberately left unrendered. It constrains nothing, so
+    the mapping can emit no ``propertyNames`` at all, and asking for a rendering
+    would report a widening that is not happening: ``Extra`` has no leaf form, so
+    strict mode refused a mapping that renders exactly, as ``additionalProperties``.
+    """
+    values.append(value_schema)
+    names.append(name)
+    if not covers_every_property_name(name):
+        keys.append(_child(name))
 
 
 # Key schemas that constrain nothing. Every JSON object key is a string, so

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -510,7 +510,14 @@ def _additional_properties(
     """
     if not variable_values:
         return allow_extra
+
     if allow_extra and not any(map(covers_every_property_name, variable_keys)):
+        # The value schemas go with the key constraint, and strict mode refuses a
+        # silent drop. ``_property_names`` reports the *key* side; this is the
+        # value side, and only when there is something to lose. An accept-anything
+        # value renders ``{}``, which ``additionalProperties: true`` already says.
+        if any(value != {} for value in variable_values):
+            _open("a variable key's value schema on an open mapping")
         return True
     if len(variable_values) == 1:
         return variable_values[0]

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -512,9 +512,6 @@ def _absorb_extra(
     if any(pval == _OPEN_OBJECT for pval in variable_values):
         return True
 
-    if additional is not None:
-        return additional
-
     if len(variable_values) == 1:
         return variable_values[0]
 

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -481,11 +481,15 @@ def _absorb_extra(
     ask an arbitrary key validator whether it equals ``str``, and a validator's
     ``__eq__`` is user code that can answer anything.
     """
-    if pval == _OPEN_OBJECT:
-        return True
-
+    # Checked ahead of the open-object shortcut below, which drops the value
+    # constraint just as thoroughly: ``{In(["a"]): dict}`` requires the matched
+    # value to be an object, and ``additionalProperties: true`` does not. Strict
+    # mode has to hear about that drop too, whichever branch performs it.
     if not (closed or key is str or key is object):
         _open("a partial variable key on an open mapping")
+        return True
+
+    if pval == _OPEN_OBJECT:
         return True
 
     return pval if additional is None else additional

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -370,7 +370,7 @@ def _oa_mapping(
         elif isinstance(pkey, str):
             properties[pkey] = pval
         else:
-            additional = _absorb_extra(pval, additional)
+            additional = _absorb_extra(pval, additional, pkey, closed=closed)
 
     dependent_required, group_constraints = _group_constraints(
         inclusive, exclusive, version
@@ -464,9 +464,19 @@ def _expand_any_key(
     return {name: pval.copy() for name in names}, None
 
 
-def _absorb_extra(pval: dict[str, Any], additional: Any) -> Any:
-    """Fold a type-key value into the object's ``additionalProperties``."""
-    if pval == _OPEN_OBJECT:
+def _absorb_extra(
+    pval: dict[str, Any], additional: Any, key: Any, *, closed: bool
+) -> Any:
+    """Fold a type-key value into the object's ``additionalProperties``.
+
+    An open mapping keeps the value schema only where the key covers every
+    property name, which ``str`` does (every JSON key is one) as does ``object``.
+    A partial key is different: ``{int: int}`` with ``ALLOW_EXTRA`` accepts
+    ``{"a": None}``, because "a" matches no schema key and the policy lets it
+    through with any value, so ``additionalProperties: {"type": "integer"}`` would
+    reject what the mapping accepts.
+    """
+    if pval == _OPEN_OBJECT or not (closed or key in (str, object)):
         return True
     return pval if additional is None else additional
 

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -38,6 +38,7 @@ from probatio.error import SchemaError
 from probatio.markers import (
     Alias,
     Exclusive,
+    Extra,
     Inclusive,
     Optional,
     Required,
@@ -308,6 +309,11 @@ def _oa_mapping(
     """Render a mapping as an OpenAPI object, mirroring convert()'s key rules."""
     properties: dict[str, Any] = {}
     required: list[str] = []
+    # The variable keys and their value schemas, gathered so universality is
+    # decided across the whole mapping rather than one entry at a time: a partial
+    # key must not undo what a universal one established.
+    variable_keys: list[Any] = []
+    variable_values: list[dict[str, Any]] = []
     constraint_groups: list[list[str]] = []
     inclusive: dict[str, list[str]] = {}
     exclusive: dict[str, ExclusiveGroup] = {}
@@ -370,7 +376,12 @@ def _oa_mapping(
         elif isinstance(pkey, str):
             properties[pkey] = pval
         else:
-            additional = _absorb_extra(pval, additional, pkey, closed=closed)
+            variable_keys.append(pkey)
+            variable_values.append(pval)
+
+    additional = _absorb_extra(
+        variable_values, variable_keys, additional, closed=closed
+    )
 
     dependent_required, group_constraints = _group_constraints(
         inclusive, exclusive, version
@@ -465,34 +476,52 @@ def _expand_any_key(
 
 
 def _absorb_extra(
-    pval: dict[str, Any], additional: Any, key: Any, *, closed: bool
+    variable_values: list[dict[str, Any]],
+    variable_keys: list[Any],
+    additional: Any,
+    *,
+    closed: bool,
 ) -> Any:
-    """Fold a type-key value into the object's ``additionalProperties``.
+    """Fold the variable-key value schemas into the object's ``additionalProperties``.
 
-    An open mapping keeps the value schema only where the key covers every
-    property name, which ``str`` does (every JSON key is one) as does ``object``.
-    A partial key is different: ``{int: int}`` with ``ALLOW_EXTRA`` accepts
-    ``{"a": None}``, because "a" matches no schema key and the policy lets it
-    through with any value, so ``additionalProperties: {"type": "integer"}`` would
-    reject what the mapping accepts. The object renders open there, dropping the
-    value constraint, which is a widening and so an error under ``strict``.
+    An open mapping keeps them as long as *some* key covers every property name,
+    because then no name reaches the extra policy and the value schemas describe
+    every property there is. ``Extra`` is universal by definition (it catches
+    every unmatched key), as are ``str`` (every JSON property name is one) and
+    ``object``.
 
-    The universal keys are recognized by identity. ``key in (str, object)`` would
-    ask an arbitrary key validator whether it equals ``str``, and a validator's
-    ``__eq__`` is user code that can answer anything.
+    Only when every variable key is partial does the object render open.
+    ``{int: int}`` with ``REMOVE_EXTRA`` accepts ``{"a": None}``, since "a" matches
+    no schema key and the policy lets it through with any value, so
+    ``additionalProperties: {"type": "integer"}`` would reject what the mapping
+    accepts. That drop is a widening, and so an error under ``strict``.
+
+    Universality is judged by identity. ``key in (str, object)`` would ask an
+    arbitrary key validator whether it equals ``str``, and a validator's ``__eq__``
+    is user code that can answer anything.
     """
-    # Checked ahead of the open-object shortcut below, which drops the value
-    # constraint just as thoroughly: ``{In(["a"]): dict}`` requires the matched
-    # value to be an object, and ``additionalProperties: true`` does not. Strict
-    # mode has to hear about that drop too, whichever branch performs it.
-    if not (closed or key is str or key is object):
+    if not variable_values:
+        return additional
+
+    if not (closed or any(map(_covers_every_name, variable_keys))):
         _open("a partial variable key on an open mapping")
         return True
 
-    if pval == _OPEN_OBJECT:
-        return True
+    for pval in variable_values:
+        # An "any object" value is folded to the open ``additionalProperties``,
+        # matching voluptuous-openapi. It drops the constraint just as the branch
+        # above does, so strict mode has already had its say by this point.
+        if pval == _OPEN_OBJECT:
+            return True
+        if additional is None:
+            additional = pval
 
-    return pval if additional is None else additional
+    return additional
+
+
+def _covers_every_name(key: Any) -> bool:
+    """Whether a variable key matches every property name a mapping can carry."""
+    return key is Extra or key is str or key is object
 
 
 def _assemble_object(

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -474,10 +474,20 @@ def _absorb_extra(
     A partial key is different: ``{int: int}`` with ``ALLOW_EXTRA`` accepts
     ``{"a": None}``, because "a" matches no schema key and the policy lets it
     through with any value, so ``additionalProperties: {"type": "integer"}`` would
-    reject what the mapping accepts.
+    reject what the mapping accepts. The object renders open there, dropping the
+    value constraint, which is a widening and so an error under ``strict``.
+
+    The universal keys are recognized by identity. ``key in (str, object)`` would
+    ask an arbitrary key validator whether it equals ``str``, and a validator's
+    ``__eq__`` is user code that can answer anything.
     """
-    if pval == _OPEN_OBJECT or not (closed or key in (str, object)):
+    if pval == _OPEN_OBJECT:
         return True
+
+    if not (closed or key is str or key is object):
+        _open("a partial variable key on an open mapping")
+        return True
+
     return pval if additional is None else additional
 
 

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -507,16 +507,23 @@ def _absorb_extra(
         _open("a partial variable key on an open mapping")
         return True
 
-    for pval in variable_values:
-        # An "any object" value is folded to the open ``additionalProperties``,
-        # matching voluptuous-openapi. It drops the constraint just as the branch
-        # above does, so strict mode has already had its say by this point.
-        if pval == _OPEN_OBJECT:
-            return True
-        if additional is None:
-            additional = pval
+    # An "any object" value folds to the open ``additionalProperties``, matching
+    # voluptuous-openapi.
+    if any(pval == _OPEN_OBJECT for pval in variable_values):
+        return True
 
-    return additional
+    if additional is not None:
+        return additional
+
+    if len(variable_values) == 1:
+        return variable_values[0]
+
+    # Several variable keys, so a property matching any one of them is valid.
+    # Taking the first would reject what the others accept: ``{int: int, str: str}``
+    # takes ``{"key": "value"}`` through its ``str`` key, and every JSON property
+    # name is a string, so an integer-only rendering rejects most of what the
+    # mapping allows. The union is the only rendering that does not narrow.
+    return {"anyOf": variable_values}
 
 
 def _covers_every_name(key: Any) -> bool:

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -27,6 +27,7 @@ from probatio.codecs._shared import (
     STRING_TYPES,
     UNSUPPORTED,
     ExclusiveGroup,
+    covers_every_property_name,
     exclusive_constraint,
     merge_dependent_required,
 )
@@ -38,7 +39,6 @@ from probatio.error import SchemaError
 from probatio.markers import (
     Alias,
     Exclusive,
-    Extra,
     Inclusive,
     Optional,
     Required,
@@ -503,7 +503,7 @@ def _absorb_extra(
     if not variable_values:
         return additional
 
-    if not (closed or any(map(_covers_every_name, variable_keys))):
+    if not (closed or any(map(covers_every_property_name, variable_keys))):
         _open("a partial variable key on an open mapping")
         return True
 
@@ -524,11 +524,6 @@ def _absorb_extra(
     # name is a string, so an integer-only rendering rejects most of what the
     # mapping allows. The union is the only rendering that does not narrow.
     return {"anyOf": variable_values}
-
-
-def _covers_every_name(key: Any) -> bool:
-    """Whether a variable key matches every property name a mapping can carry."""
-    return key is Extra or key is str or key is object
 
 
 def _assemble_object(

--- a/tests/codecs/test_encoder_differential.py
+++ b/tests/codecs/test_encoder_differential.py
@@ -59,9 +59,14 @@ def test_emitted_schema_is_valid_and_serializable(spec: Any) -> None:
     _VALIDATOR.check_schema(document)
 
 
+# A narrowing needs a spec and a value that meet: a variable key and a property
+# name it accepts, say. Those are drawn independently, so the pairing is rare and
+# the example count has to be high enough to reach it. At 500 a reintroduced
+# narrowing on a coercing key went undetected; at 2000 it is caught, for about
+# three extra seconds.
 @given(spec=strategies.specs(no_narrowing=True), value=strategies.data(booleans=False))
 @settings(
-    max_examples=500, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
+    max_examples=2000, derandomize=True, suppress_health_check=[HealthCheck.too_slow]
 )
 def test_emitted_schema_never_narrows(spec: Any, value: Any) -> None:
     """The emitted schema never rejects an input probatio accepts."""

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1190,3 +1190,9 @@ def test_a_wrapper_subclass_is_not_assumed_transparent() -> None:
 
     encoded = to_json_schema(Schema({OnlyA(str, "only a"): int}, extra=ALLOW_EXTRA))
     assert encoded["additionalProperties"] is True
+
+
+def test_strict_allows_a_universal_key_with_no_leaf_rendering() -> None:
+    """Extra has no leaf form, but the mapping renders exactly as its values."""
+    encoded = to_json_schema(Schema({Extra: int}), strict=True)
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1137,3 +1137,15 @@ def test_transparent_wrapper_key_is_still_universal() -> None:
 
     encoded = to_json_schema(Schema({Msg(str, "key"): int}, extra=ALLOW_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_a_schema_wrapped_key_is_still_universal() -> None:
+    """Schema only compiles what it wraps, so Schema(str) matches every name.
+
+    A bare Schema cannot be a mapping key (it is unhashable), but one inside a
+    Msg can, which is the route that reaches this.
+    """
+    from probatio import Msg  # noqa: PLC0415
+
+    encoded = to_json_schema(Schema({Msg(Schema(str), "key"): int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1127,7 +1127,9 @@ def test_strict_refuses_a_key_validator_on_an_open_mapping() -> None:
 
     schema = Schema({In(["a"]): int}, extra=ALLOW_EXTRA)
     assert "propertyNames" not in to_json_schema(schema)
-    with pytest.raises(SchemaError, match="key validator"):
+    # Both the key constraint and the value schema are dropped here; the value
+    # side is reported first, and either is a correct refusal.
+    with pytest.raises(SchemaError, match="open mapping"):
         to_json_schema(schema, strict=True)
 
 
@@ -1149,3 +1151,23 @@ def test_a_schema_wrapped_key_is_still_universal() -> None:
 
     encoded = to_json_schema(Schema({Msg(Schema(str), "key"): int}, extra=ALLOW_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_strict_refuses_a_dropped_value_schema_on_an_open_mapping() -> None:
+    """A key that renders vacuous is still partial, and its values are dropped.
+
+    ``All(object)`` matches every name but is not universal by identity, so the
+    key schema reports nothing and only this path can report the value drop.
+    """
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({All(object): int}, extra=ALLOW_EXTRA)
+    assert to_json_schema(schema)["additionalProperties"] is True
+    with pytest.raises(SchemaError, match="value schema"):
+        to_json_schema(schema, strict=True)
+
+
+def test_strict_allows_a_drop_that_loses_nothing() -> None:
+    """An accept-anything value is what additionalProperties true already says."""
+    schema = Schema({All(object): object}, extra=ALLOW_EXTRA)
+    assert to_json_schema(schema, strict=True)["additionalProperties"] is True

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1085,3 +1085,11 @@ def test_open_mapping_emits_no_property_names() -> None:
     assert "propertyNames" not in to_json_schema(
         Schema({In(["a"]): int}, extra=ALLOW_EXTRA)
     )
+
+
+def test_one_universal_key_covers_every_name_for_an_open_mapping() -> None:
+    """A str key beside a partial one still catches every name, so values stand."""
+    encoded = to_json_schema(Schema({str: int, int: str}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}]
+    }

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1093,3 +1093,29 @@ def test_one_universal_key_covers_every_name_for_an_open_mapping() -> None:
     assert encoded["additionalProperties"] == {
         "anyOf": [{"type": "integer"}, {"type": "string"}]
     }
+
+
+def test_unrepresentable_key_is_not_mistaken_for_a_universal_one() -> None:
+    """A key with no JSON Schema form renders {} exactly as ``object`` does.
+
+    So the rendering cannot answer whether the key covers every property name,
+    and reading it as universal would keep a value schema the extra policy makes
+    wrong: this mapping accepts ``{"b": None}`` through ALLOW_EXTRA.
+    """
+
+    from probatio import Invalid  # noqa: PLC0415
+
+    def only_a(value: object) -> object:
+        if value != "a":
+            message = "only the key 'a'"
+            raise Invalid(message)
+        return value
+
+    encoded = to_json_schema(Schema({only_a: int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] is True
+
+
+def test_extra_marker_key_is_universal() -> None:
+    """Extra catches every unmatched key, so its value schema covers them all."""
+    encoded = to_json_schema(Schema({Extra: int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1066,3 +1066,22 @@ def test_union_key_needs_only_one_branch_to_match_a_name() -> None:
     """anyOf is satisfied by a single branch, so one string branch is enough."""
     encoded = to_json_schema(Schema({Any(In(["a"]), In(["b"])): str}))
     assert encoded["propertyNames"] == {"anyOf": [{"enum": ["a"]}, {"enum": ["b"]}]}
+
+
+def test_open_mapping_with_a_partial_key_renders_open() -> None:
+    """A name the key misses falls through to the policy and may take any value."""
+    encoded = to_json_schema(Schema({int: int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] is True
+
+
+def test_open_mapping_with_a_str_key_keeps_its_value_schema() -> None:
+    """A str key covers every property name, so the policy never comes into play."""
+    encoded = to_json_schema(Schema({str: int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_open_mapping_emits_no_property_names() -> None:
+    """An open mapping accepts a key the validator rejects, so it cannot constrain."""
+    assert "propertyNames" not in to_json_schema(
+        Schema({In(["a"]): int}, extra=ALLOW_EXTRA)
+    )

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1119,3 +1119,21 @@ def test_extra_marker_key_is_universal() -> None:
     """Extra catches every unmatched key, so its value schema covers them all."""
     encoded = to_json_schema(Schema({Extra: int}, extra=ALLOW_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_strict_refuses_a_key_validator_on_an_open_mapping() -> None:
+    """An open mapping cannot constrain its keys, and strict refuses the drop."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({In(["a"]): int}, extra=ALLOW_EXTRA)
+    assert "propertyNames" not in to_json_schema(schema)
+    with pytest.raises(SchemaError, match="key validator"):
+        to_json_schema(schema, strict=True)
+
+
+def test_transparent_wrapper_key_is_still_universal() -> None:
+    """Msg only swaps the error message, so Msg(str, ...) matches every name."""
+    from probatio import Msg  # noqa: PLC0415
+
+    encoded = to_json_schema(Schema({Msg(str, "key"): int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1171,3 +1171,22 @@ def test_strict_allows_a_drop_that_loses_nothing() -> None:
     """An accept-anything value is what additionalProperties true already says."""
     schema = Schema({All(object): object}, extra=ALLOW_EXTRA)
     assert to_json_schema(schema, strict=True)["additionalProperties"] is True
+
+
+def test_a_wrapper_subclass_is_not_assumed_transparent() -> None:
+    """A subclass can override __call__ to match far less than what it wraps.
+
+    Unwrapping it would call the key universal and keep a value schema that
+    rejects the keys the extra policy lets through.
+    """
+    from probatio import Invalid, Msg  # noqa: PLC0415
+
+    class OnlyA(Msg):
+        def __call__(self, value: object) -> object:
+            if value != "a":
+                message = "only the key 'a'"
+                raise Invalid(message)
+            return value
+
+    encoded = to_json_schema(Schema({OnlyA(str, "only a"): int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] is True

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -827,3 +827,14 @@ def test_remove_extra_mapping_with_a_str_key_keeps_its_value_schema() -> None:
 
     encoded = to_openapi(Schema({str: int}, extra=REMOVE_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_strict_refuses_a_partial_key_on_an_open_mapping() -> None:
+    """Dropping the value constraint is a widening, which strict mode refuses."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({int: int}, extra=REMOVE_EXTRA)
+    assert to_openapi(schema)["additionalProperties"] is True
+    with pytest.raises(SchemaError, match="partial variable key"):
+        to_openapi(schema, strict=True)

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -853,3 +853,19 @@ def test_strict_refuses_a_partial_key_whose_value_is_an_open_object() -> None:
     assert to_openapi(schema)["additionalProperties"] is True
     with pytest.raises(SchemaError, match="partial variable key"):
         to_openapi(schema, strict=True)
+
+
+def test_extra_marker_is_a_universal_key() -> None:
+    """Extra catches every unmatched key, so its value schema covers them all."""
+    from probatio import REMOVE_EXTRA, Extra  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({Extra: int}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_a_partial_key_does_not_undo_a_universal_one() -> None:
+    """Universality is decided across the mapping, not one entry at a time."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({str: int, int: str}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -811,3 +811,19 @@ def test_decoded_pattern_emits_an_unanchored_openapi_pattern() -> None:
 
     decoded = from_json_schema({"type": "string", "pattern": "x"})
     assert to_openapi(decoded)["pattern"] == "x"
+
+
+def test_remove_extra_mapping_with_a_partial_key_renders_open() -> None:
+    """REMOVE_EXTRA accepts a key the validator misses, with any value at all."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({int: int}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] is True
+
+
+def test_remove_extra_mapping_with_a_str_key_keeps_its_value_schema() -> None:
+    """A str key covers every property name, so its value schema still applies."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({str: int}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -868,4 +868,16 @@ def test_a_partial_key_does_not_undo_a_universal_one() -> None:
     from probatio import REMOVE_EXTRA  # noqa: PLC0415
 
     encoded = to_openapi(Schema({str: int, int: str}, extra=REMOVE_EXTRA))
-    assert encoded["additionalProperties"] == {"type": "integer"}
+    assert encoded["additionalProperties"] == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}]
+    }
+
+
+def test_several_variable_keys_merge_into_any_of() -> None:
+    """Taking the first would reject what the other keys accept."""
+    from probatio import REMOVE_EXTRA  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({int: int, str: str}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] == {
+        "anyOf": [{"type": "integer"}, {"type": "string"}]
+    }

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -838,3 +838,18 @@ def test_strict_refuses_a_partial_key_on_an_open_mapping() -> None:
     assert to_openapi(schema)["additionalProperties"] is True
     with pytest.raises(SchemaError, match="partial variable key"):
         to_openapi(schema, strict=True)
+
+
+def test_strict_refuses_a_partial_key_whose_value_is_an_open_object() -> None:
+    """The open-object shortcut drops the value constraint too, so strict refuses.
+
+    ``{In(["a"]): dict}`` requires the matched value to be an object, which
+    ``additionalProperties: true`` does not, whichever branch emitted it.
+    """
+    from probatio import REMOVE_EXTRA, In  # noqa: PLC0415
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    schema = Schema({In(["a"]): dict}, extra=REMOVE_EXTRA)
+    assert to_openapi(schema)["additionalProperties"] is True
+    with pytest.raises(SchemaError, match="partial variable key"):
+        to_openapi(schema, strict=True)

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -881,3 +881,11 @@ def test_several_variable_keys_merge_into_any_of() -> None:
     assert encoded["additionalProperties"] == {
         "anyOf": [{"type": "integer"}, {"type": "string"}]
     }
+
+
+def test_transparent_wrapper_key_is_still_universal() -> None:
+    """Msg only swaps the error message, so its value schema stays representable."""
+    from probatio import REMOVE_EXTRA, Msg  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({Msg(str, "key"): int}, extra=REMOVE_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -889,3 +889,11 @@ def test_transparent_wrapper_key_is_still_universal() -> None:
 
     encoded = to_openapi(Schema({Msg(str, "key"): int}, extra=REMOVE_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_open_mapping_with_a_universal_key_keeps_its_value_schema() -> None:
+    """ALLOW_EXTRA seeds an open object, but a str key still matches every name."""
+    from probatio import ALLOW_EXTRA  # noqa: PLC0415
+
+    encoded = to_openapi(Schema({str: int}, extra=ALLOW_EXTRA))
+    assert encoded["additionalProperties"] == {"type": "integer"}

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -43,6 +43,31 @@ _json_literals = st.one_of(
 _KEY_KINDS = ("required", "optional")
 _EXTRA_MODES = (None, "allow", "remove")
 
+# What a mapping's catch-all entry is keyed on. ``Extra`` is the marker; the rest
+# are *variable keys*, where the key itself is validated. Those were never
+# generated before, so every property suite was blind to the whole region,
+# ``{str: int}`` included, and to the ``propertyNames`` the encoder renders from a
+# restrictive one.
+_CATCHALL_KINDS = ("extra", "str_key", "int_key", "in_key", "coerce_key")
+
+# Field names and data keys are drawn from this shared alphabet as well as from
+# free text. Both sides used to draw arbitrary text independently, so a generated
+# value almost never landed on a declared property or inside a variable key's
+# set, and the whole mapping region was explored far more shallowly than the
+# example counts suggested. The digits matter for a coercing key, which turns
+# "1" into a number the way a property name never could.
+_KEY_ALPHABET = ("a", "b", "c", "1", "2")
+
+# The membership key's set is fixed rather than drawn: the declared field names
+# are random text, so a fixed set reliably produces both a name inside it and
+# names outside, which is the interesting pairing.
+_IN_KEY_MEMBERS = ("a", "b")
+
+
+def _names() -> st.SearchStrategy[str]:
+    """Property names: the shared alphabet, plus free text for the odd shapes."""
+    return st.sampled_from(_KEY_ALPHABET) | st.text(min_size=1, max_size=3)
+
 
 def specs(*, no_narrowing: bool = False) -> st.SearchStrategy[Any]:
     """A recursive strategy yielding library-agnostic schema specs.
@@ -90,12 +115,15 @@ def specs(*, no_narrowing: bool = False) -> st.SearchStrategy[Any]:
             st.builds(
                 lambda fields, extra, catchall: ("dict", fields, extra, catchall),
                 st.dictionaries(
-                    st.text(min_size=1, max_size=3),
+                    _names(),
                     st.tuples(st.sampled_from(_KEY_KINDS), children),
                     max_size=3,
                 ),
                 st.sampled_from(_EXTRA_MODES),
-                st.one_of(st.none(), children),
+                st.one_of(
+                    st.none(),
+                    st.tuples(st.sampled_from(_CATCHALL_KINDS), children),
+                ),
             ),
         ),
         max_leaves=8,
@@ -118,10 +146,7 @@ def data(*, booleans: bool = True, floats: bool = True) -> st.SearchStrategy[Any
         scalars |= st.booleans()
     return st.recursive(
         scalars,
-        lambda c: (
-            st.lists(c, max_size=3)
-            | st.dictionaries(st.text(min_size=1, max_size=3), c, max_size=3)
-        ),
+        lambda c: st.lists(c, max_size=3) | st.dictionaries(_names(), c, max_size=3),
         max_leaves=6,
     )
 
@@ -160,18 +185,40 @@ def build(spec: Any, lib: Any) -> Any:
 
 
 def _build_dict(spec: Any, lib: Any) -> Any:
-    """Materialize a mapping spec, with marker kinds, an extra policy, and Extra."""
+    """Materialize a mapping spec: marker kinds, an extra policy, and a catch-all."""
     _, fields, extra, catchall = spec
     mapping: dict[Any, Any] = {}
     for key, (key_kind, child) in fields.items():
         marker = (lib.Required if key_kind == "required" else lib.Optional)(key)
         mapping[marker] = build(child, lib)
     if catchall is not None:
-        mapping[lib.Extra] = build(catchall, lib)
+        kind, child = catchall
+        mapping[_catchall_key(kind, lib)] = build(child, lib)
     if extra is None:
         return mapping
     policy = lib.ALLOW_EXTRA if extra == "allow" else lib.REMOVE_EXTRA
     return lib.Schema(mapping, extra=policy)
+
+
+def _catchall_key(kind: str, lib: Any) -> Any:
+    """The key a catch-all entry sits under: the Extra marker or a variable key.
+
+    A variable key is validated like any other schema, so the engine applies it to
+    every key no literal marker matched. ``str`` is the everyday catch-all shape;
+    ``int`` is one no JSON property name can satisfy; the membership key is what a
+    ``propertyNames`` enum decodes to.
+    """
+    if kind == "extra":
+        return lib.Extra
+    if kind == "str_key":
+        return str
+    if kind == "int_key":
+        return int
+    if kind == "coerce_key":
+        # A key that *transforms*: it accepts the property name "1" by turning it
+        # into a number, which no ``{"type": "integer"}`` rendering can express.
+        return lib.Coerce(int)
+    return lib.In(list(_IN_KEY_MEMBERS))
 
 
 def canonical_openapi(node: Any) -> Any:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

`to_json_schema` and `to_openapi` emit `additionalProperties: true` for an open mapping whose variable key does not cover every property name, where they used to emit that key's value schema. The old output rejected input the schema accepts, so this is a narrowing being closed, but a consumer diffing emitted documents will see it. A `str` key is unchanged, and that is the common case.

`to_json_schema` also no longer emits `propertyNames` for an open mapping, for the same reason. Under `strict=True` both drops raise instead, as every other dropped constraint does.

## Proposed change

`_build_dict` keyed every catch-all on `Extra`, so no spec ever produced a *variable key*: not `{In([...]): int}`, not even `{str: int}`. Three property suites run off these specs (`test_fuzz_roundtrip`, `test_encoder_differential`, `test_openapi_oracle`) and all three were blind to the whole region. That is why the `Coerce(int)` key narrowing in #321 had to be found by review rather than by `test_encoder_differential`, which exists precisely to catch narrowings.

A second, quieter problem sat underneath it. Field names and data dict keys both drew independent arbitrary text, so a generated value almost never landed on a declared property or inside a key validator's set. The mapping region was explored far more shallowly than the example counts suggested. Both now draw from a shared small alphabet as well as free text.

The narrowing differential moves from 500 to 2000 examples. A narrowing needs a spec and a value that *meet*, and the two are drawn independently, so the pairing is rare. Measured with a deliberately reintroduced narrowing: undetected at 500, caught at 2000, for about three extra seconds.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #321, where this gap was identified while building the decoder oracle

The new coverage found two pre-existing narrowings before it had run a full suite, both on the same point: an open mapping accepts a key no schema key matched, with any value at all, while `additionalProperties` applies to every undeclared property alike.

```python
Schema({int: int}, extra=ALLOW_EXTRA)({"a": None})   # accepted
to_json_schema(...)  # {"additionalProperties": {"type": "integer"}} rejects it
```

`to_openapi` had the same through `REMOVE_EXTRA`. A `str` key is the exception and keeps its value schema, since every JSON property name is a string and none can miss it.

Both fixes are verified by mutation: reintroducing the open-mapping bug fails `test_emitted_schema_never_narrows`, which it could not have done before this PR.

One honest limit. The `Coerce(int)` key narrowing that motivated this is still not caught by the differential at 2000 examples on the derandomized seed, because it needs a three-way conjunction (a coercing key, a string-typed value schema, and a digit-string property name in the data). It is caught by the suite, through the targeted unit tests added in #321. The differential's job is finding unknown bugs; the unit tests pin the known one.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
