### PR TITLE
Scope the standalone keywords to their own JSON type

### DIFF
--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -1657,7 +1657,9 @@ class _JsonPattern:
         """Return the value if the pattern is found anywhere in it."""
         try:
             found = self.pattern.search(value)
-        except TypeError as exc:
+        except TypeError as exc:  # pragma: no cover - scoped to strings already
+            # Unreachable: both construction sites sit behind a string check now.
+            # Kept so the class cannot leak a raw TypeError if that ever changes.
             raise MatchInvalid(translation_key="expected_string") from exc
 
         if not found:
@@ -1909,6 +1911,11 @@ _OBJECT_KEYWORDS = frozenset(
 )
 _ARRAY_KEYWORDS = frozenset({"items", "prefixItems", "minItems", "maxItems"})
 
+# The Python types a JSON number can arrive as, for scoping the numeric keywords.
+# ``bool`` is absent by design; ``_WhenType`` passes booleans through, since
+# Python calls one an ``int`` and JSON does not.
+_JSON_NUMBER_TYPES = (int, float)
+
 
 class _WhenType:
     """Apply a subschema only to instances of one JSON type.
@@ -1920,18 +1927,26 @@ class _WhenType:
     rest.
     """
 
-    def __init__(self, base: type, subschema: Any) -> None:
+    def __init__(self, base: type | tuple[type, ...], subschema: Any) -> None:
         """Compile the subschema and remember the instance type it applies to."""
         self._base = base
         self._schema = Schema(subschema)
 
     def __repr__(self) -> str:
         """Render readably for error paths."""
-        return f"WhenType({self._base.__name__}, {self._schema.schema!r})"
+        names = (
+            self._base.__name__
+            if isinstance(self._base, type)
+            else "|".join(base.__name__ for base in self._base)
+        )
+        return f"WhenType({names}, {self._schema.schema!r})"
 
     def __call__(self, value: Any) -> Any:
         """Validate instances of the type; pass every other value through."""
-        if not isinstance(value, self._base):
+        # A JSON boolean is not a string, a number, an array or an object, so it
+        # passes vacuously like any other value of the wrong type. Spelled out
+        # because Python calls a boolean an ``int`` and JSON does not.
+        if isinstance(value, bool) or not isinstance(value, self._base):
             return value
         return self._schema(value)
 
@@ -1962,24 +1977,30 @@ def _from_constraints(node: dict[str, Any], ctx: _Decode) -> list[Any]:
     constraints: list[Any] = []
     has_array = bool(_ARRAY_KEYWORDS & node.keys())
     if _NUMERIC_BOUND_KEYS & node.keys():
-        constraints.append(_from_range(node))
+        constraints.append(_WhenType(_JSON_NUMBER_TYPES, _from_range(node)))
     if "multipleOf" in node:
-        constraints.append(MultipleOf(_numeric(node, "multipleOf")))
+        constraints.append(
+            _WhenType(_JSON_NUMBER_TYPES, MultipleOf(_numeric(node, "multipleOf"))),
+        )
     if "minLength" in node or "maxLength" in node:
         constraints.append(
-            Length(
-                min=_item_count(node, "minLength"), max=_item_count(node, "maxLength")
+            _WhenType(
+                str,
+                Length(
+                    min=_item_count(node, "minLength"),
+                    max=_item_count(node, "maxLength"),
+                ),
             ),
         )
     if "pattern" in node:
-        constraints.append(_JsonPattern(_safe_pattern(node["pattern"])))
+        constraints.append(_WhenType(str, _JsonPattern(_safe_pattern(node["pattern"]))))
     # When array keywords are present, the array facet below reads uniqueItems
     # and contains itself, scoped to arrays; adding them standalone here too
     # would double-apply them.
     if node.get("uniqueItems") is True and not has_array:
         constraints.append(_JsonUnique())
     if "contains" in node and not has_array:
-        constraints.append(_from_contains(node, ctx))
+        constraints.append(_WhenType(list, _from_contains(node, ctx)))
     if _OBJECT_KEYWORDS & node.keys():
         constraints.append(_WhenType(dict, _from_object(node, ctx)))
     if has_array:
@@ -2469,7 +2490,9 @@ class _ContainsCount:
         """Return the value if the matching-item count is in range, else raise."""
         try:
             items = list(value)
-        except TypeError as exc:
+        except TypeError as exc:  # pragma: no cover - scoped to arrays already
+            # Unreachable: both construction sites sit behind a list check now.
+            # Kept so the class cannot leak a raw TypeError if that ever changes.
             raise ContainsInvalid(translation_key="not_a_collection") from exc
 
         count = 0

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -218,6 +218,19 @@ def _convert(node: Any, *, required_default: bool, allow_extra: bool) -> dict[st
             allow_extra=node.extra in (ALLOW_EXTRA, REMOVE_EXTRA),
         )
 
+    if isinstance(node, _WhenType):
+        # The wrapper carries "applies only to this JSON type", which is what a
+        # JSON Schema keyword already means, so it re-emits as its contents with
+        # the type dropped. Keeping the ``type`` the inner renderer adds would
+        # narrow: ``{"pattern": "x"}`` accepts the number 123 vacuously, and
+        # ``{"type": "string", "pattern": "x"}`` rejects it.
+        inner = _convert(
+            node.subschema,
+            required_default=required_default,
+            allow_extra=allow_extra,
+        )
+        return {key: value for key, value in inner.items() if key != "type"}
+
     custom = _options().custom
     if custom is not None:
         result = custom(node)
@@ -1930,6 +1943,8 @@ class _WhenType:
     def __init__(self, base: type | tuple[type, ...], subschema: Any) -> None:
         """Compile the subschema and remember the instance type it applies to."""
         self._base = base
+        # Kept raw (unwrapped) so the encoder can re-emit it.
+        self.subschema = subschema
         self._schema = Schema(subschema)
 
     def __repr__(self) -> str:

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -164,3 +164,65 @@ def test_property_names_roundtrip_reaches_a_behavioral_fixpoint(
         assert _accepts(twice, value) == _accepts(thrice, value), (
             f"round trip is not a fixpoint for {value!r} on {document!r}"
         )
+
+
+# Every standalone constraint keyword, with the JSON type it constrains. A value
+# of any other type satisfies it without inspection, so wrapping it in ``not``
+# must reject that value rather than accept it.
+_TYPE_SCOPED: list[tuple[str, dict[str, Any]]] = [
+    ("minLength", {"minLength": 5}),
+    ("maxLength", {"maxLength": 2}),
+    ("pattern", {"pattern": "x"}),
+    ("minimum", {"minimum": 10}),
+    ("maximum", {"maximum": 1}),
+    ("exclusiveMinimum", {"exclusiveMinimum": 10}),
+    ("exclusiveMaximum", {"exclusiveMaximum": 1}),
+    ("multipleOf", {"multipleOf": 2}),
+    ("minItems", {"minItems": 3}),
+    ("maxItems", {"maxItems": 1}),
+    ("uniqueItems", {"uniqueItems": True}),
+    ("contains", {"contains": {"const": 9}}),
+    ("minProperties", {"minProperties": 2}),
+    ("maxProperties", {"maxProperties": 1}),
+]
+
+_MIXED_TYPES: list[Any] = [
+    "str",
+    "",
+    "xy",
+    5,
+    5.5,
+    True,
+    False,
+    None,
+    [],
+    [1, 1],
+    [9],
+    {},
+    {"a": 1},
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "body"), _TYPE_SCOPED, ids=[n for n, _ in _TYPE_SCOPED]
+)
+@pytest.mark.parametrize("form", ["bare", "negated"])
+def test_a_standalone_keyword_is_scoped_to_its_own_type(
+    name: str,
+    body: dict[str, Any],
+    form: str,
+) -> None:
+    """A typeless keyword agrees with the reference on values of every JSON type.
+
+    Unscoped, these only narrowed, which is easy to miss. Under ``not`` the same
+    gap inverts into a widening, so both forms are checked.
+    """
+    document = {"not": body} if form == "negated" else body
+    _VALIDATOR.check_schema(document)
+    reference = _VALIDATOR(document)
+    schema = from_json_schema(document)
+
+    for value in _MIXED_TYPES:
+        assert _accepts(schema, value) == reference.is_valid(value), (
+            f"{name} disagrees with the reference on {value!r} ({form})"
+        )

--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -226,3 +226,37 @@ def test_a_standalone_keyword_is_scoped_to_its_own_type(
         assert _accepts(schema, value) == reference.is_valid(value), (
             f"{name} disagrees with the reference on {value!r} ({form})"
         )
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"pattern": "x"},
+        {"minLength": 5},
+        {"minimum": 10},
+        {"multipleOf": 2},
+        {"minItems": 3},
+        {"contains": {"const": 9}},
+        {"properties": {"a": {"type": "integer"}}},
+        {"maxProperties": 1},
+    ],
+    ids=str,
+)
+def test_a_typeless_keyword_survives_re_encoding(document: dict[str, Any]) -> None:
+    """Re-emitting a type-scoped keyword keeps it, and adds no type of its own.
+
+    The scoping wrapper means what a JSON Schema keyword already means, so it
+    re-emits as the bare keyword. Carrying the inner renderer's ``type`` out with
+    it would narrow, since the typeless form accepts other types vacuously.
+    """
+    schema = from_json_schema(document)
+    emitted = to_json_schema(schema)
+    _VALIDATOR.check_schema(emitted)
+    assert emitted, f"{document} re-encoded to an open schema, losing the keyword"
+
+    reference = _VALIDATOR(emitted)
+    for value in _MIXED_TYPES:
+        if _accepts(schema, value):
+            assert reference.is_valid(value), (
+                f"re-encoding {document} narrows: it rejects {value!r}"
+            )

--- a/tests/codecs/test_from_json_schema.py
+++ b/tests/codecs/test_from_json_schema.py
@@ -878,11 +878,16 @@ def test_min_and_max_contains() -> None:
 
 
 def test_contains_count_on_a_non_collection() -> None:
-    """A counted contains on a non-iterable is refused cleanly, not leaked."""
-    # Typeless so the count validator (not a list-type guard) sees the raw value.
+    """A counted contains passes a non-array vacuously, and never leaks a TypeError.
+
+    ``contains`` constrains arrays; the spec has every other type satisfy it
+    without inspection, which the reference implementation agrees with.
+    """
     schema = from_json_schema({"contains": {"const": 5}, "minContains": 1})
+    assert schema(5) == 5
+    assert schema([5]) == [5]
     with pytest.raises(Invalid):
-        schema(5)
+        schema([1, 2])
 
 
 def test_max_and_exclusive_maximum_keep_the_tighter_one() -> None:
@@ -1796,10 +1801,13 @@ def test_negated_pattern_does_not_widen() -> None:
         schema("ax")
 
 
-def test_pattern_rejects_a_non_string() -> None:
-    """A non-string cannot be searched, so it is a clean Invalid, not a TypeError."""
+def test_pattern_passes_a_non_string_vacuously() -> None:
+    """pattern constrains strings; every other type satisfies it without inspection."""
+    schema = from_json_schema({"pattern": "x"})
+    assert schema(123) == 123
+    assert schema("axb") == "axb"
     with pytest.raises(Invalid):
-        from_json_schema({"pattern": "x"})(123)
+        schema("nope")
 
 
 def test_decoded_pattern_repr_names_its_source() -> None:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

`to_openapi` now renders a decoded *typeless* keyword as an open schema. `to_openapi(from_json_schema({"minimum": 10}))` was `{"minimum": 10}` and is now `{}`. Only the typeless form is affected; a keyword carried alongside a `type` is unchanged, which is the overwhelming majority of real documents. It widens rather than narrows, so it never rejects input the schema accepts. See the note at the end for why it is not fixed here.

A decoded typeless keyword now accepts values of other types. `from_json_schema({"minLength": 5})` accepts the number `5`, as the specification says it should; previously it rejected everything that was not a long enough string. A schema that carries a `type` alongside the keyword is unaffected, which is the overwhelming majority of real documents.

The inverse also changes: under `not`, those same documents now *reject* what they used to accept. That direction is the bug being closed.

## Proposed change

JSON Schema has a type-specific keyword apply only to its own type. A value of any other type satisfies it without inspection, so `{"minLength": 5}` accepts the number `5`. The decoder applied the string, number, and standalone array keywords unconditionally.

On its own that only narrows, which is easy to miss. Under `not` it inverts into a widening, and that is the shape that matters for an untrusted document:

```python
from_json_schema({"not": {"minLength": 5}})(5)      # was accepted
from_json_schema({"not": {"minimum": 10}})("str")   # was accepted
from_json_schema({"not": {"multipleOf": 2}})("str") # was accepted
```

`minLength`, `maxLength` and `pattern` are scoped to strings now, `minimum`/`maximum`/their exclusive forms and `multipleOf` to numbers, and a standalone `contains` to arrays. The object and array keywords already went through `_WhenType`; these never did.

`_WhenType` also passes booleans through. Python calls a boolean an `int` and JSON does not, so a boolean has to satisfy a numeric keyword vacuously like any other non-number.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #324, where this family was identified and deliberately left out of scope

The family was enumerated by asking `jsonschema`'s reference implementation about every standalone keyword against a value of every JSON type, in both the bare and negated forms, rather than by listing the ones that came to mind. That is what turned up the standalone `contains`, which was not in the original report. The sweep went from 20/40 clean keyword-and-form combinations to 38/40, and it is now a test rather than a throwaway script.

Each of the three scopings is mutation-verified: removing any one of them fails the new test.

The two remaining combinations are `properties`, bare and negated, on an undeclared key. That is the deliberate closed-by-default deviation rather than a scoping gap, so it is left alone; changing it would be an ADR-level decision about probatio's strict default.

Two existing tests pinned the old behaviour and are corrected here, both confirmed against the reference first:

- `test_pattern_rejects_a_non_string` (added in #324, by me) asserted that a typeless `pattern` rejects `123`
- `test_contains_count_on_a_non_collection` asserted that a counted `contains` rejects a non-array

Their protective intent, that neither leaks a raw `TypeError`, is kept. The guards themselves are now unreachable from both construction sites and are marked as such rather than deleted, so the classes cannot start leaking if that changes.

### The OpenAPI encoder, and why this stops where it does

`_WhenType` has never been encodable. On `main`, `to_json_schema(from_json_schema({"properties": {...}}))` already returns `{}`, because the object and array keywords have gone through the wrapper all along. Scoping the string and number keywords put them in the same position, so the JSON Schema encoder gained a branch that re-emits the wrapper as its contents with the type dropped, which fixes both the new cases and the old ones.

The same branch in `to_openapi` does not work, and I tried it before concluding that:

| document | with the branch |
| --- | --- |
| `{"maxProperties": 1}` | `{"maxLength": 1}` |
| `{"properties": {"a": {"type": "integer"}}}` | `{"properties": {"a": {"type": "string"}}}` |
| `{"minItems": 3}` | narrows, rejecting `[1, 2, 3]` |

`_retarget_length` in the OpenAPI encoder only runs while merging an `All`, so a bare `Length` renders the string-length keywords whatever type it was scoped to. The type is what disambiguates it, and dropping the type is exactly what the wrapper requires. Emitting wrong keywords is worse than emitting nothing, and keeping the type instead trades a widening for a narrowing.

So `to_openapi` widens to `{}` for a typeless keyword, consistently for all of them now rather than only for the object and array ones. Making it faithful means teaching its `Length` rendering about the scoped type, which is its own change in a subsystem this PR does not otherwise touch.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
