### PR TITLE
Admit null beside a negation on OpenAPI 3.0

### DIFF
--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -212,22 +212,27 @@ def _mark_nullable(result: dict[str, Any], version: str) -> None:
     if isinstance(enum, list) and None not in enum:
         result["enum"] = [*enum, None]
 
-    combinator = next((key for key in _COMBINATORS if key in result), None)
-    if combinator is not None:
-        # A combinator has no type to carry null, so admit it with a branch.
-        result[combinator] = [*result[combinator], _oa_null(version)]
-        result.pop("nullable", None)
-        return
-
     if "not" in result:
         # A negation has no type to carry null either, and 3.0 ignores the flag
         # beside one, so ``Maybe(NotIn([None]))`` came out rejecting the null it
         # exists to accept. Everything the schema asserted moves into one branch
         # of a union with null, which keeps the siblings honest: "all of this, or
         # null" rather than "all of this, and separately maybe null".
+        #
+        # Checked before the combinator below, and not instead of it: a result can
+        # carry both (``All(NotIn(...), Any(...))`` renders sibling ``not`` and
+        # ``anyOf`` keys), and adding a branch to the combinator leaves the
+        # negation still excluding null. Rewriting the whole thing covers both.
         asserted = {key: value for key, value in result.items() if key != "nullable"}
         result.clear()
         result["anyOf"] = [asserted, _oa_null(version)]
+        return
+
+    combinator = next((key for key in _COMBINATORS if key in result), None)
+    if combinator is not None:
+        # A combinator has no type to carry null, so admit it with a branch.
+        result[combinator] = [*result[combinator], _oa_null(version)]
+        result.pop("nullable", None)
         return
 
     if version == _V3_1:

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -219,6 +219,17 @@ def _mark_nullable(result: dict[str, Any], version: str) -> None:
         result.pop("nullable", None)
         return
 
+    if "not" in result:
+        # A negation has no type to carry null either, and 3.0 ignores the flag
+        # beside one, so ``Maybe(NotIn([None]))`` came out rejecting the null it
+        # exists to accept. Everything the schema asserted moves into one branch
+        # of a union with null, which keeps the siblings honest: "all of this, or
+        # null" rather than "all of this, and separately maybe null".
+        asserted = {key: value for key, value in result.items() if key != "nullable"}
+        result.clear()
+        result["anyOf"] = [asserted, _oa_null(version)]
+        return
+
     if version == _V3_1:
         del result["nullable"]
         node_type = result.get("type")

--- a/tests/codecs/test_openapi_oracle.py
+++ b/tests/codecs/test_openapi_oracle.py
@@ -141,6 +141,16 @@ _NULLABLE_INNERS: list[tuple[str, Any]] = [
     ("negated_null", probatio.NotIn([None])),
     ("negated_null_in_any", probatio.Any(probatio.NotIn([None]))),
     ("negated_value", probatio.NotIn(["a"])),
+    # Renders sibling ``not`` and combinator keys, so appending a branch to the
+    # combinator alone leaves the negation still excluding null.
+    (
+        "negated_null_beside_a_union",
+        probatio.All(probatio.NotIn([None]), probatio.Any(int, str)),
+    ),
+    (
+        "negated_null_beside_an_enum",
+        probatio.All(probatio.NotIn([None]), probatio.In(["a", "b"])),
+    ),
     ("scalar", int),
     ("enum", probatio.In(["a", "b"])),
     ("pattern", probatio.Match("^x")),

--- a/tests/codecs/test_openapi_oracle.py
+++ b/tests/codecs/test_openapi_oracle.py
@@ -131,3 +131,49 @@ def test_exclusive_group_agrees_with_the_reference_validator(version: str) -> No
     assert validator.is_valid({"a": 1})
     assert validator.is_valid({"b": 2})
     assert not validator.is_valid({"a": 1, "b": 2})
+
+
+# ``Maybe(X)`` means "X or null", so every emitted document has to accept null,
+# on both versions. The wrappers with no type of their own are the interesting
+# ones: 3.0 spells null with a ``nullable`` flag, and a flag needs a type to sit
+# on, so a combinator or a negation has to grow a dedicated null branch instead.
+_NULLABLE_INNERS: list[tuple[str, Any]] = [
+    ("negated_null", probatio.NotIn([None])),
+    ("negated_null_in_any", probatio.Any(probatio.NotIn([None]))),
+    ("negated_value", probatio.NotIn(["a"])),
+    ("scalar", int),
+    ("enum", probatio.In(["a", "b"])),
+    ("pattern", probatio.Match("^x")),
+    ("bounded_string", probatio.All(str, probatio.Length(min=2))),
+    ("bare_range", probatio.Range(min=0)),
+    ("union", probatio.Any(int, str)),
+    ("union_with_null", probatio.Any(int, None)),
+    ("mapping", {"a": int}),
+    ("sequence", [int]),
+]
+
+
+@pytest.mark.parametrize("version", ["3.0", "3.1.0"])
+@pytest.mark.parametrize(
+    ("name", "inner"), _NULLABLE_INNERS, ids=[n for n, _ in _NULLABLE_INNERS]
+)
+def test_a_nullable_schema_really_admits_null(
+    name: str,
+    inner: Any,
+    version: str,
+) -> None:
+    """A Maybe emits a document that accepts null, whatever it wraps.
+
+    ``Maybe(NotIn([None]))`` used to emit a 3.0 document rejecting null: the
+    negation's own enum admits null, so the ``not`` excluded it, and 3.0 ignores
+    a ``nullable`` flag with no type to carry it.
+    """
+    schema = probatio.Schema(probatio.Maybe(inner))
+    assert _probatio_accepts(schema, None), f"{name} should accept null"
+
+    document = probatio.to_openapi(schema, openapi_version=version)
+    json.dumps(document)
+    _VALIDATOR[version].check_schema(document)
+    assert _VALIDATOR[version](document).is_valid(None), (
+        f"{name} emits a {version} document that rejects null: {document!r}"
+    )


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

A `Maybe` wrapping a negation renders differently on OpenAPI 3.0: `to_openapi(Schema(Maybe(NotIn([None]))))` was `{"not": {...}, "nullable": true}` and is now an `anyOf` of the negation and an explicit null branch. The old document rejected null, which is the bug; a consumer diffing emitted documents will see the new shape. Nothing else changes, and 3.1 is untouched.

## Proposed change

`Maybe(X)` means "X or null", so the emitted document has to accept null. `Maybe(NotIn([None]))` did not, on 3.0:

```python
to_openapi(Schema(Maybe(NotIn([None]))))
# {"not": {"enum": [null], "nullable": true}, "nullable": true}  -> rejects null
```

Two things combine. The negation's own enum admits null, so the `not` excludes it. And 3.0 spells null with a `nullable` flag, which needs a type to sit on and is ignored beside a `not`.

`_mark_nullable` already solves exactly this for a combinator, which has no type either, by adding a dedicated null branch. A negation now gets the same treatment. Everything the schema asserted moves into one branch of a union with null, so the siblings stay honest: "all of this, or null" rather than "all of this, and separately maybe null".

3.1 was never affected. It keeps null as an explicit branch rather than a flag, so the shape never arises there.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #325, where a hypothesis falsifying example surfaced this and it was deliberately left out of scope

The sweep that found it is now a test rather than a scratch script: every `Maybe` shape, on both versions, must emit a document that accepts null. The fix is mutation-verified, removing the negation branch fails two of those cases.

Two corrections to the report this came from, which was my own:

- I had recorded it as one bug from a single falsifying example. My first probe showed **twelve** narrowing shapes, and I nearly wrote that up before noticing the 3.1 column was identical for every input. I was passing `"3.1"` where the encoder wants `"3.1.0"`. The real count is **two**, both on 3.0, both `Maybe(NotIn([None]))`.
- Which leaves a separate, smaller thing worth its own look: **an unrecognised `openapi_version` is silently accepted**. `to_openapi(schema, openapi_version="banana")` returns a 3.0-shaped document rather than raising, which is what let a broken probe produce 28 confident-looking rows. Not fixed here.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
