### PR TITLE
Cover a mapping with two variable keys

### DIFF
--- a/tests/codecs/test_decoder_oracle.py
+++ b/tests/codecs/test_decoder_oracle.py
@@ -26,7 +26,18 @@ from typing import Any
 import jsonschema
 import pytest
 
-from probatio import Invalid, from_json_schema, to_json_schema
+from probatio import (
+    ALLOW_EXTRA,
+    REMOVE_EXTRA,
+    Coerce,
+    Extra,
+    In,
+    Invalid,
+    Schema,
+    from_json_schema,
+    to_json_schema,
+    to_openapi,
+)
 
 _VALIDATOR = jsonschema.Draft202012Validator
 
@@ -260,3 +271,59 @@ def test_a_typeless_keyword_survives_re_encoding(document: dict[str, Any]) -> No
             assert reference.is_valid(value), (
                 f"re-encoding {document} narrows: it rejects {value!r}"
             )
+
+
+# Every ordered pair of variable-key kinds. Order matters: it decides which key an
+# encoder reaches first, and taking the first key's value schema rejects what the
+# others accept. Enumerated rather than sampled, because the property fuzz draws
+# its schema and its value independently and the conjunction that exposes this is
+# rare (a partial key first, a universal one second, and a value whose key lands
+# on the second).
+_KEY_KINDS: dict[str, Any] = {
+    "extra": Extra,
+    "str": str,
+    "int": int,
+    "in": In(["a", "b"]),
+    "coerce": Coerce(int),
+}
+_KEY_PAIRS = [
+    (first, second) for first in _KEY_KINDS for second in _KEY_KINDS if first != second
+]
+_KEY_PROBES: list[dict[str, Any]] = [
+    {},
+    {"a": 1},
+    {"a": "s"},
+    {"c": 1},
+    {"c": "s"},
+    {"1": 1},
+    {"1": "s"},
+    {"zz": 1},
+    {"zz": "s"},
+]
+
+
+@pytest.mark.parametrize("policy", ["closed", "allow", "remove"])
+@pytest.mark.parametrize(("first", "second"), _KEY_PAIRS, ids=str)
+def test_a_pair_of_variable_keys_never_narrows(
+    first: str,
+    second: str,
+    policy: str,
+) -> None:
+    """Two variable keys keep both contracts, in either order and every policy."""
+    extra = {
+        "closed": {},
+        "allow": {"extra": ALLOW_EXTRA},
+        "remove": {"extra": REMOVE_EXTRA},
+    }[policy]
+    schema = Schema({_KEY_KINDS[first]: int, _KEY_KINDS[second]: str}, **extra)
+
+    for emit in (to_json_schema, to_openapi):
+        document = emit(schema)
+        _VALIDATOR.check_schema(document)
+        reference = _VALIDATOR(document)
+        for value in _KEY_PROBES:
+            if _accepts(schema, value):
+                assert reference.is_valid(value), (
+                    f"{emit.__name__} narrows for {first}+{second} ({policy}): "
+                    f"{value!r} is accepted but {document!r} rejects it"
+                )

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -63,6 +63,34 @@ _KEY_ALPHABET = ("a", "b", "c", "1", "2")
 # names outside, which is the interesting pairing.
 _IN_KEY_MEMBERS = ("a", "b")
 
+# A mapping can carry more than one variable key, and which one a name lands on
+# decides its value schema, so the pairing matters: with ``{int: int, str: str}``
+# the universal ``str`` key accepts a value the partial one does not. Every
+# *ordered* pair is generated, because order decides which key an encoder reaches
+# first, and enumerating beats picking the combinations that come to mind.
+_CATCHALL_PAIRS = (
+    ("extra", "str_key"),
+    ("extra", "int_key"),
+    ("extra", "in_key"),
+    ("extra", "coerce_key"),
+    ("str_key", "extra"),
+    ("str_key", "int_key"),
+    ("str_key", "in_key"),
+    ("str_key", "coerce_key"),
+    ("int_key", "extra"),
+    ("int_key", "str_key"),
+    ("int_key", "in_key"),
+    ("int_key", "coerce_key"),
+    ("in_key", "extra"),
+    ("in_key", "str_key"),
+    ("in_key", "int_key"),
+    ("in_key", "coerce_key"),
+    ("coerce_key", "extra"),
+    ("coerce_key", "str_key"),
+    ("coerce_key", "int_key"),
+    ("coerce_key", "in_key"),
+)
+
 
 def _names() -> st.SearchStrategy[str]:
     """Property names: the shared alphabet, plus free text for the odd shapes."""
@@ -123,6 +151,11 @@ def specs(*, no_narrowing: bool = False) -> st.SearchStrategy[Any]:
                 st.one_of(
                     st.none(),
                     st.tuples(st.sampled_from(_CATCHALL_KINDS), children),
+                    # A pair carries a value schema *each*. Sharing one makes the
+                    # pair useless for the thing it exists to check: taking the
+                    # first key's value and merging both produce the same document
+                    # when the values are identical.
+                    st.tuples(st.sampled_from(_CATCHALL_PAIRS), children, children),
                 ),
             ),
         ),
@@ -192,8 +225,13 @@ def _build_dict(spec: Any, lib: Any) -> Any:
         marker = (lib.Required if key_kind == "required" else lib.Optional)(key)
         mapping[marker] = build(child, lib)
     if catchall is not None:
-        kind, child = catchall
-        mapping[_catchall_key(kind, lib)] = build(child, lib)
+        kinds, *children = catchall
+        # A single kind comes with one child; a pair comes with one each, so a
+        # mapping can hold two variable keys wanting different values.
+        for one, child in zip(
+            (kinds,) if isinstance(kinds, str) else kinds, children, strict=True
+        ):
+            mapping[_catchall_key(one, lib)] = build(child, lib)
     if extra is None:
         return mapping
     policy = lib.ALLOW_EXTRA if extra == "allow" else lib.REMOVE_EXTRA


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None. Tests only.

## Proposed change

`tests/strategies.py` built one variable key per mapping, so nothing exercised the pairing, and which key a name lands on decides its value schema. This was the last open item from #325.

Two pieces, because the fuzz alone does not do the job here:

- `specs()` generates every *ordered* pair of key kinds, each with its own value schema. Order matters, since it decides which key an encoder reaches first.
- The decoder oracle enumerates all 20 pairs against all 3 extra policies in both encoders. This is what actually catches a regression. The property fuzz draws its schema and its value independently, and the conjunction that exposes a pair bug needs a partial key first, a universal one second, and a value whose key lands on the second. Rare enough that it never fired in practice.

**Nothing was found.** All 120 combinations already agree with the reference implementation, because the #325 work (merging into `anyOf`, deciding universality across the whole mapping) fixed this region. The enumeration locks it in.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #325, where the single-variable-key limit was identified, and #328, which had to land first

Verified by mutation rather than assumed, which is the point of the PR:

| reintroduced bug | enumerated cases failing |
| --- | --- |
| take the first key's value instead of merging (JSON Schema) | 31 |
| take the first key's value instead of merging (OpenAPI) | 31 |
| universality must hold for *every* key (JSON Schema) | 4 |
| universality must hold for *every* key (OpenAPI) | 0 |

The fourth is a **widening**, and a no-narrowing oracle allows those by design, so it cannot be caught there. The unit tests added in #325 hold it: mutating that check fails `test_a_partial_key_does_not_undo_a_universal_one` and `test_several_variable_keys_merge_into_any_of`.

Two things I got wrong on the way, both caught by mutation testing before this was pushed:

- My first version had both keys in a pair share one value schema. That makes the pair useless for the thing it exists to check, since merging identical values and taking the first produce the same document. All four mutations passed. They each carry their own value schema now.
- I had assumed the property fuzz would guard this once pairs were generated. It does not, for the independent-draw reason above, which is why the enumerated test carries the weight and the fuzz addition is a broadening rather than the guard.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
