### PR TITLE
Stop the auto-compile counter from calling itself

### DIFF
--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -438,9 +438,17 @@ class Schema:
             calls += 1
             if calls == _AUTO_COMPILE_THRESHOLD:
                 self._compiled = self._compile_from(interpreted)
-            if calls >= _AUTO_COMPILE_THRESHOLD:
-                return self._compiled(data)
-            return interpreted(data)
+
+            # Read once, and never call it if it is still this counter. Another
+            # caller can cross the threshold while the generation above is still
+            # running, and code generation is not quick; delegating to
+            # ``_compiled`` then lands back here, increments again, and recurses
+            # until the stack gives out. Validating interpreted for the few calls
+            # that fall in that window costs nothing and cannot recurse.
+            compiled = self._compiled
+            if compiled is validate:
+                return interpreted(data)
+            return compiled(data)
 
         return validate
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -714,3 +714,36 @@ def test_tuple_sequence_schema_stays_interpreted() -> None:
     schema = Schema((str,), compile=True).compile()
     assert not _is_compiled(schema)
     assert schema(("a", "b")) == ("a", "b")
+
+
+def test_a_call_arriving_during_generation_does_not_recurse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second caller crossing the threshold mid-generation must not re-enter.
+
+    Generation is real work, so another caller can arrive while it runs and find
+    ``_compiled`` still holding the counter. Delegating to it there lands back on
+    the counter, which increments and delegates again, until the stack gives out.
+    Reported against Home Assistant blueprint validation, where config is
+    validated from an executor thread.
+    """
+    set_compile_policy(CompilePolicy.AUTO)
+    schema = Schema({"a": int})
+    data = {"a": 1}
+
+    original = Schema._compile_from
+    arrived: list[bool] = []
+
+    def reentrant(self: Schema, interpreted: object) -> object:
+        # Stands in for the caller that arrives while generation is running.
+        if not arrived:
+            arrived.append(True)
+            schema(data)
+        return original(self, interpreted)
+
+    monkeypatch.setattr(Schema, "_compile_from", reentrant)
+
+    for _ in range(_AUTO_COMPILE_THRESHOLD + 5):
+        assert schema(data) == data
+
+    assert arrived, "the re-entrant call never happened, so nothing was proven"


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None. A schema that used to crash now validates.

## Proposed change

A schema under the `AUTO` policy validates interpreted and generates code once it has been called 50 times. The counter that arranges this delegated through `self._compiled` from the threshold onward:

```python
calls += 1
if calls == _AUTO_COMPILE_THRESHOLD:
    self._compiled = self._compile_from(interpreted)   # generating, takes a while
if calls >= _AUTO_COMPILE_THRESHOLD:
    return self._compiled(data)                        # still this very counter
```

During that generation call, `self._compiled` is still the counter. So a caller crossing the threshold while another is generating lands back on the counter, increments, is still past the threshold, and delegates again. It recurses until the stack gives out.

Reported against Home Assistant, which validates automation config from an executor thread against the blueprint and selector schemas. Those are large, so generation takes long enough to make the window wide:

```
  File "probatio/schema.py", line 442, in validate
    return self._compiled(data)
  [Previous line repeated 960 more times]
RecursionError: maximum recursion depth exceeded
```

The counter now reads `_compiled` once and never calls it while it is still the counter, validating interpreted for the few calls that fall in that window. That cannot recurse, needs no lock on the hot path, and leaves the resolved case as it was: a single identity check.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR is related to: #55, where the adaptive compiled variant landed

Not blueprint-specific, and not new: any `AUTO` schema validated concurrently can cross call 50 in two callers at once, and the counter has delegated this way since #55. It also recovers on its own once generation finishes, so it presents as an intermittent failure rather than a dead schema. In Home Assistant that reads as `Setup failed for 'automation': Invalid config`.

The regression test is deterministic rather than threaded. It has `_compile_from` call back into the schema once while generating, which is the same re-entrancy a second thread causes, without a sleep to make it likely. Verified in both directions: `RecursionError` without the fix, green with it.

A threaded harness reproduces it too, but only with generation artificially slowed. That is why the committed test uses re-entrancy instead: a timing-dependent test for this would pass on most runs and prove nothing.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
