### PR TITLE
Name the module when a Schema is not probatio's

### DIFF
--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -144,21 +144,24 @@ def covers_every_property_name(key: Any) -> bool:
 
 
 def foreign_schema_detail(node: Any) -> str | None:
-    """Describe a ``Schema`` that came from some module other than probatio's.
+    """Describe a ``voluptuous`` ``Schema`` that has reached a codec.
 
     Two ``Schema`` classes live in one process when a real ``voluptuous`` is
     imported before ``install_as_voluptuous`` aliases it away. Every
     ``isinstance`` check that unwraps a schema then stops matching, and the codecs
-    fail somewhere far from the cause: the field-list codec reports a schema it
-    cannot serialize, and the JSON Schema and OpenAPI codecs raise a bare
-    ``TypeError: unhashable type: 'Schema'``. Neither names the actual problem,
-    and the two classes even share a ``repr``, so the traceback cannot be told
-    apart from an ordinary bug.
+    fail far from the cause: an unserializable-schema error, or a bare
+    ``TypeError: unhashable type: 'Schema'``. The two classes share a ``repr`` by
+    design, so the traceback cannot be told apart from an ordinary bug.
 
-    Returns None for anything else, including probatio's own ``Schema``.
+    Provenance is checked rather than guessed: only a class from a ``voluptuous``
+    module qualifies. A class that merely happens to be named ``Schema`` belongs
+    to somebody else, and each codec renders it the way it renders any other
+    node it does not know, which is what it did before this check existed.
     """
     cls = type(node)
-    if cls.__name__ != "Schema" or cls is Schema or not hasattr(node, "schema"):
+    if cls is Schema or cls.__module__.split(".")[0] != "voluptuous":
+        return None
+    if cls.__name__ != "Schema" or not hasattr(node, "schema"):
         return None
 
     return (

--- a/src/probatio/codecs/_shared.py
+++ b/src/probatio/codecs/_shared.py
@@ -143,6 +143,32 @@ def covers_every_property_name(key: Any) -> bool:
     return key is Extra or key is str or key is object
 
 
+def foreign_schema_detail(node: Any) -> str | None:
+    """Describe a ``Schema`` that came from some module other than probatio's.
+
+    Two ``Schema`` classes live in one process when a real ``voluptuous`` is
+    imported before ``install_as_voluptuous`` aliases it away. Every
+    ``isinstance`` check that unwraps a schema then stops matching, and the codecs
+    fail somewhere far from the cause: the field-list codec reports a schema it
+    cannot serialize, and the JSON Schema and OpenAPI codecs raise a bare
+    ``TypeError: unhashable type: 'Schema'``. Neither names the actual problem,
+    and the two classes even share a ``repr``, so the traceback cannot be told
+    apart from an ordinary bug.
+
+    Returns None for anything else, including probatio's own ``Schema``.
+    """
+    cls = type(node)
+    if cls.__name__ != "Schema" or cls is Schema or not hasattr(node, "schema"):
+        return None
+
+    return (
+        f"got a Schema from {cls.__module__!r}, which is not probatio's. Two "
+        f"Schema classes are live in this process, so probatio cannot recognize "
+        f"this one. Call probatio.compat.install_as_voluptuous() before anything "
+        f"imports voluptuous, or take the real voluptuous out of the environment"
+    )
+
+
 def ordered_values(values: Any) -> list[Any]:
     """List a container's values, sorting a set so the emitted schema is stable.
 

--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -16,7 +16,7 @@ import enum
 from collections.abc import Hashable, Mapping
 from typing import Any, cast
 
-from probatio.codecs._shared import UNSUPPORTED
+from probatio.codecs._shared import UNSUPPORTED, foreign_schema_detail
 from probatio.markers import (
     Forbidden,
     Optional,
@@ -195,6 +195,10 @@ def to_field_list(schema: Any, *, custom_serializer: Any = None) -> _Serialized:
     is called first for each node and may return a dict to override the default,
     or ``UNSUPPORTED`` to defer.
     """
+    detail = foreign_schema_detail(schema)
+    if detail is not None:
+        raise ValueError(detail)
+
     if isinstance(schema, Schema):
         schema = schema.schema
     return _serialize_node(schema, custom_serializer)
@@ -267,7 +271,11 @@ def _serialize_value(node: Any, custom: Any) -> dict[str, Any]:
         # is an ``int`` subclass, so it is covered. ``None`` is not a constant
         # there, so it falls through to the error, matching the oracle.
         return {"type": "constant", "value": node}
-    message = f"unable to serialize schema: {node!r}"
+    # A ``Schema`` reaching here is a nested one the caller has to unwrap, or a
+    # foreign class; either way the repr alone does not say which, so name the
+    # module it came from.
+    detail = foreign_schema_detail(node)
+    message = detail or f"unable to serialize schema: {node!r}"
     raise ValueError(message)
 
 

--- a/src/probatio/codecs/fields.py
+++ b/src/probatio/codecs/fields.py
@@ -195,10 +195,6 @@ def to_field_list(schema: Any, *, custom_serializer: Any = None) -> _Serialized:
     is called first for each node and may return a dict to override the default,
     or ``UNSUPPORTED`` to defer.
     """
-    detail = foreign_schema_detail(schema)
-    if detail is not None:
-        raise ValueError(detail)
-
     if isinstance(schema, Schema):
         schema = schema.schema
     return _serialize_node(schema, custom_serializer)

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -33,6 +33,7 @@ from probatio.codecs._shared import (
     ExclusiveGroup,
     covers_every_property_name,
     exclusive_constraint,
+    foreign_schema_detail,
     merge_dependent_required,
 )
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
@@ -177,6 +178,10 @@ def to_json_schema(
     recursion is caught and reported as a clean ``SchemaError`` instead of a bare
     ``RecursionError``.
     """
+    detail = foreign_schema_detail(schema)
+    if detail is not None:
+        raise SchemaError(detail)
+
     token = _OPTIONS.set(_Options(strict=strict, custom=custom_serializer))
     try:
         return _convert(schema, required_default=False, allow_extra=False)

--- a/src/probatio/codecs/jsonschema.py
+++ b/src/probatio/codecs/jsonschema.py
@@ -178,10 +178,6 @@ def to_json_schema(
     recursion is caught and reported as a clean ``SchemaError`` instead of a bare
     ``RecursionError``.
     """
-    detail = foreign_schema_detail(schema)
-    if detail is not None:
-        raise SchemaError(detail)
-
     token = _OPTIONS.set(_Options(strict=strict, custom=custom_serializer))
     try:
         return _convert(schema, required_default=False, allow_extra=False)
@@ -241,6 +237,12 @@ def _convert(node: Any, *, required_default: bool, allow_extra: bool) -> dict[st
         result = custom(node)
         if result is not UNSUPPORTED:
             return cast("dict[str, Any]", result)
+
+    # After the hook, so an override still wins, and on every node rather than
+    # only the argument: a foreign schema nested in a mapping reaches here too.
+    detail = foreign_schema_detail(node)
+    if detail is not None:
+        raise SchemaError(detail)
 
     if isinstance(node, dict):
         return _convert_mapping(

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -29,6 +29,7 @@ from probatio.codecs._shared import (
     ExclusiveGroup,
     covers_every_property_name,
     exclusive_constraint,
+    foreign_schema_detail,
     merge_dependent_required,
 )
 from probatio.codecs._shared import UNREPRESENTABLE as _UNREPRESENTABLE
@@ -165,6 +166,10 @@ def to_openapi(
     finite rendering, so the runaway recursion is reported as a clean
     ``SchemaError`` rather than a bare ``RecursionError``.
     """
+    detail = foreign_schema_detail(schema)
+    if detail is not None:
+        raise SchemaError(detail)
+
     token = _STRICT.set(strict)
     try:
         rendered = _oa(schema, custom_serializer, openapi_version)

--- a/src/probatio/codecs/openapi.py
+++ b/src/probatio/codecs/openapi.py
@@ -166,10 +166,6 @@ def to_openapi(
     finite rendering, so the runaway recursion is reported as a clean
     ``SchemaError`` rather than a bare ``RecursionError``.
     """
-    detail = foreign_schema_detail(schema)
-    if detail is not None:
-        raise SchemaError(detail)
-
     token = _STRICT.set(strict)
     try:
         rendered = _oa(schema, custom_serializer, openapi_version)
@@ -279,6 +275,12 @@ def _oa(node: Any, custom: Any, version: str) -> dict[str, Any]:
         result = custom(node)
         if result is not UNSUPPORTED:
             return cast("dict[str, Any]", result)
+
+    # After the hook, so an override still wins, and on every node rather than
+    # only the argument: a foreign schema nested in a mapping reaches here too.
+    detail = foreign_schema_detail(node)
+    if detail is not None:
+        raise SchemaError(detail)
 
     if node is Self:
         # ``Self`` is the recursive reference to the whole enclosing schema; ``#``

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -331,27 +331,47 @@ def test_serialize_marks_allow_none_for_either_any_order() -> None:
     }
 
 
-def test_a_foreign_schema_names_the_module_it_came_from() -> None:
-    """A Schema from another module reports that, not "unable to serialize".
+class _VoluptuousSchema:
+    """Stands in for ``voluptuous.schema_builder.Schema``, provenance included."""
 
-    Two Schema classes live in one process when a real voluptuous is imported
-    before the compat shim aliases it away. The two share a repr, so without the
-    module name the traceback is indistinguishable from an ordinary bug. Reported
-    against Home Assistant, where it cost a long diagnosis.
-    """
+    __module__ = "voluptuous.schema_builder"
+    __qualname__ = "Schema"
+    __name__ = "Schema"
+
+    def __init__(self, schema: object) -> None:
+        self.schema = schema
+
+
+_VoluptuousSchema.__name__ = "Schema"
+
+
+def test_a_voluptuous_schema_names_the_module_it_came_from() -> None:
+    """A Schema from voluptuous reports that, not "unable to serialize"."""
+    with pytest.raises(ValueError, match="not probatio's") as caught:
+        to_field_list(_VoluptuousSchema({"a": int}))
+
+    assert "voluptuous.schema_builder" in str(caught.value)
+
+
+def test_an_unrelated_class_named_schema_is_left_alone() -> None:
+    """Provenance is checked, so somebody else's Schema is not claimed as ours."""
 
     class Schema:
         def __init__(self, schema: object) -> None:
             self.schema = schema
 
-    with pytest.raises(ValueError, match="not probatio's") as caught:
+    with pytest.raises(ValueError, match="unable to serialize"):
         to_field_list(Schema({"a": int}))
 
-    assert __name__ in str(caught.value), "the message must name the source module"
 
+def test_the_custom_serializer_still_wins_over_the_diagnosis() -> None:
+    """The documented hook runs first, so an override always comes first."""
 
-def test_probatio_own_schema_is_not_mistaken_for_a_foreign_one() -> None:
-    """The check keys on the class, so probatio's own Schema passes through."""
-    assert to_field_list(Schema({"a": int})) == [
-        {"type": "integer", "name": "a", "required": False}
+    def hook(node: object) -> object:
+        if isinstance(node, _VoluptuousSchema):
+            return [{"name": "handled"}]
+        return UNSUPPORTED
+
+    assert to_field_list(_VoluptuousSchema({"a": int}), custom_serializer=hook) == [
+        {"name": "handled"}
     ]

--- a/tests/codecs/test_fields.py
+++ b/tests/codecs/test_fields.py
@@ -329,3 +329,29 @@ def test_serialize_marks_allow_none_for_either_any_order() -> None:
         "type": "string",
         "allow_none": True,
     }
+
+
+def test_a_foreign_schema_names_the_module_it_came_from() -> None:
+    """A Schema from another module reports that, not "unable to serialize".
+
+    Two Schema classes live in one process when a real voluptuous is imported
+    before the compat shim aliases it away. The two share a repr, so without the
+    module name the traceback is indistinguishable from an ordinary bug. Reported
+    against Home Assistant, where it cost a long diagnosis.
+    """
+
+    class Schema:
+        def __init__(self, schema: object) -> None:
+            self.schema = schema
+
+    with pytest.raises(ValueError, match="not probatio's") as caught:
+        to_field_list(Schema({"a": int}))
+
+    assert __name__ in str(caught.value), "the message must name the source module"
+
+
+def test_probatio_own_schema_is_not_mistaken_for_a_foreign_one() -> None:
+    """The check keys on the class, so probatio's own Schema passes through."""
+    assert to_field_list(Schema({"a": int})) == [
+        {"type": "integer", "name": "a", "required": False}
+    ]

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1196,3 +1196,15 @@ def test_strict_allows_a_universal_key_with_no_leaf_rendering() -> None:
     """Extra has no leaf form, but the mapping renders exactly as its values."""
     encoded = to_json_schema(Schema({Extra: int}), strict=True)
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_a_foreign_schema_is_refused_with_the_module_named() -> None:
+    """A Schema from another module fails clearly, not as an unhashable TypeError."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    class Schema:
+        def __init__(self, schema: object) -> None:
+            self.schema = schema
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_json_schema(Schema({"a": int}))

--- a/tests/codecs/test_jsonschema.py
+++ b/tests/codecs/test_jsonschema.py
@@ -1198,13 +1198,52 @@ def test_strict_allows_a_universal_key_with_no_leaf_rendering() -> None:
     assert encoded["additionalProperties"] == {"type": "integer"}
 
 
-def test_a_foreign_schema_is_refused_with_the_module_named() -> None:
-    """A Schema from another module fails clearly, not as an unhashable TypeError."""
+class _VoluptuousSchema:
+    """Stands in for ``voluptuous.schema_builder.Schema``, provenance included."""
+
+    __module__ = "voluptuous.schema_builder"
+
+    def __init__(self, schema: object) -> None:
+        self.schema = schema
+
+
+_VoluptuousSchema.__name__ = "Schema"
+
+
+def test_a_voluptuous_schema_is_refused_with_the_module_named() -> None:
+    """A Schema from voluptuous fails clearly, not as an unhashable TypeError."""
     from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_json_schema(_VoluptuousSchema({"a": int}))
+
+
+def test_a_nested_voluptuous_schema_is_refused_too() -> None:
+    """The check sits on every node, so a foreign schema inside a mapping is caught."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_json_schema(Schema({"a": _VoluptuousSchema({"x": int})}))
+
+
+def test_an_unrelated_class_named_schema_still_renders_open() -> None:
+    """Provenance is checked, so an unknown node renders as it always did."""
 
     class Schema:
         def __init__(self, schema: object) -> None:
             self.schema = schema
 
-    with pytest.raises(SchemaError, match="not probatio's"):
-        to_json_schema(Schema({"a": int}))
+    assert to_json_schema(Schema({"a": int})) == {}
+
+
+def test_a_non_schema_from_voluptuous_is_not_reported_as_a_schema() -> None:
+    """Only a Schema gets the mixed-install message; another validator does not.
+
+    A foreign ``In`` or marker reaching a codec is a different problem, and
+    claiming two Schema classes are live would send the reader somewhere useless.
+    """
+
+    class In:
+        __module__ = "voluptuous.validators"
+
+    assert to_json_schema(In()) == {}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -899,13 +899,39 @@ def test_open_mapping_with_a_universal_key_keeps_its_value_schema() -> None:
     assert encoded["additionalProperties"] == {"type": "integer"}
 
 
-def test_a_foreign_schema_is_refused_with_the_module_named() -> None:
-    """A Schema from another module fails clearly, not as an unhashable TypeError."""
+class _VoluptuousSchema:
+    """Stands in for ``voluptuous.schema_builder.Schema``, provenance included."""
+
+    __module__ = "voluptuous.schema_builder"
+
+    def __init__(self, schema: object) -> None:
+        self.schema = schema
+
+
+_VoluptuousSchema.__name__ = "Schema"
+
+
+def test_a_voluptuous_schema_is_refused_with_the_module_named() -> None:
+    """A Schema from voluptuous fails clearly, not as an unhashable TypeError."""
     from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_openapi(_VoluptuousSchema({"a": int}))
+
+
+def test_a_nested_voluptuous_schema_is_refused_too() -> None:
+    """The check sits on every node, so a foreign schema inside a mapping is caught."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_openapi(Schema({"a": _VoluptuousSchema({"x": int})}))
+
+
+def test_an_unrelated_class_named_schema_still_renders_open() -> None:
+    """Provenance is checked, so an unknown node renders as it always did."""
 
     class Schema:
         def __init__(self, schema: object) -> None:
             self.schema = schema
 
-    with pytest.raises(SchemaError, match="not probatio's"):
-        to_openapi(Schema({"a": int}))
+    assert to_openapi(Schema({"a": int})) == {}

--- a/tests/codecs/test_openapi.py
+++ b/tests/codecs/test_openapi.py
@@ -897,3 +897,15 @@ def test_open_mapping_with_a_universal_key_keeps_its_value_schema() -> None:
 
     encoded = to_openapi(Schema({str: int}, extra=ALLOW_EXTRA))
     assert encoded["additionalProperties"] == {"type": "integer"}
+
+
+def test_a_foreign_schema_is_refused_with_the_module_named() -> None:
+    """A Schema from another module fails clearly, not as an unhashable TypeError."""
+    from probatio.error import SchemaError  # noqa: PLC0415
+
+    class Schema:
+        def __init__(self, schema: object) -> None:
+            self.schema = schema
+
+    with pytest.raises(SchemaError, match="not probatio's"):
+        to_openapi(Schema({"a": int}))


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

None for a working setup. A `Schema` from another module used to raise `ValueError: unable to serialize schema: ...` or `TypeError: unhashable type: 'Schema'` and now raises with a message naming the cause. `to_json_schema` and `to_openapi` raise `SchemaError` there instead of `TypeError`, which is the error they already use for input they cannot handle.

## Proposed change

A real `voluptuous` imported before `install_as_voluptuous` leaves two `Schema` classes in the process. Every `isinstance` that unwraps a schema stops matching, and the codecs then fail a long way from the cause:

```
ValueError: unable to serialize schema: <Schema({'mode': In(['bridge', 'accessory']), ...})>
TypeError: unhashable type: 'Schema'
```

Neither says what is actually wrong. Worse, the two classes share a `repr` **by design**, since probatio mirrors voluptuous, so the traceback is indistinguishable from an ordinary serializer bug:

```python
repr(vol.Schema(body))       # <Schema({...}, extra=PREVENT_EXTRA, required=False) object at 0x...>
repr(probatio.Schema(body))  # <Schema({...}, extra=PREVENT_EXTRA, required=False) object at 0x...>
```

The three codec entry points now recognize a `Schema` that is not probatio's and say so:

```
got a Schema from 'voluptuous.schema_builder', which is not probatio's. Two Schema
classes are live in this process, so probatio cannot recognize this one. Call
probatio.compat.install_as_voluptuous() before anything imports voluptuous, or take
the real voluptuous out of the environment
```

The field-list codec names it on its deeper failure too, where a foreign construct can arrive without passing through the entry check.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

This came out of a Home Assistant report where a config flow raised the `unable to serialize schema` error. Diagnosing it took a long detour, because the message points at the serializer and the repr gives nothing away. Along the way I confirmed, and want to record:

- `to_field_list` is behaviourally identical to `voluptuous_serialize.convert` across every nesting shape tried, including the ones that raise. This is not a serialization regression.
- Installing a real voluptuous alongside probatio is harmless on its own. After the shim, `voluptuous.__path__` points into probatio and every submodule resolves there, including a copy vendored under another package's namespace.
- So the only way to hold a foreign `Schema` is a reference taken before `install_as_voluptuous` ran.

None of that was visible from the traceback, which is the point of this change: the next such report answers itself in one line.

The shim itself is unchanged. This is diagnosis, not a behaviour fix, and a mixed environment stays a broken environment: the two classes disagree on markers and validation semantics too, so quietly accepting a foreign `Schema` would only move the failure somewhere less obvious.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
