### PR TITLE
Type the substitution factory instead of widening it to Any

### DIFF
--- a/docs/src/content/docs/guides/validators.md
+++ b/docs/src/content/docs/guides/validators.md
@@ -707,7 +707,7 @@ Schema(SetTo(42))("anything")  # 42
 A callable given to `DefaultTo` or `SetTo` is read as a factory, not as the value
 itself, so `DefaultTo(list)` substitutes a new empty list and two validated values
 never share one mutable default. This is the same normalization a marker default
-gets (`Optional("tags", default=list)`), through the same `default_factory` helper.
+gets (`Optional("tags", default=list)`).
 
 ```python
 Schema(DefaultTo(list))(None)  # [] (a new list each time, not the list type)

--- a/src/probatio/validators/coerce.py
+++ b/src/probatio/validators/coerce.py
@@ -5,17 +5,35 @@ from __future__ import annotations
 import enum
 import typing
 from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING
 
 from probatio.error import BooleanInvalid, CoerceInvalid, Invalid, SchemaError
-from probatio.markers import UNDEFINED, default_factory
+from probatio.markers import UNDEFINED
 from probatio.validators._base import _SafeValidator
 from probatio.validators.decorators import message
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _TRUE_STRINGS = frozenset({"1", "true", "yes", "on", "enable"})
 _FALSE_STRINGS = frozenset({"0", "false", "no", "off", "disable"})
 # The empty values ``EmptyToNone`` maps to ``None``: a string or a container with no
 # items. A falsy scalar (``0``, ``False``) is a value, not an absence, so it is left.
 _EMPTY_CONTAINERS = (str, bytes, list, tuple, dict, set, frozenset)
+
+
+def _value_factory(value: typing.Any) -> Callable[[], typing.Any]:
+    """Normalize a substitution value into a zero-argument factory.
+
+    This is ``markers.default_factory`` minus the sentinel: that one passes
+    ``UNDEFINED`` through uncalled, because a marker uses it to mean "no default
+    was given". Here the value is a required argument, so there is no absence to
+    preserve and every input normalizes into something callable.
+    """
+    if callable(value):
+        factory: Callable[[], typing.Any] = value
+        return factory
+    return lambda: value
 
 
 class Coerce[T](_SafeValidator):
@@ -150,8 +168,7 @@ class SetTo(_SafeValidator):
 
     def __init__(self, value: typing.Any) -> None:
         """Store the value to set, normalized into a zero-argument factory."""
-        # ``Any`` rather than the factory union, so the call below reads plainly.
-        self.value: typing.Any = default_factory(value)
+        self.value = _value_factory(value)
 
     def __repr__(self) -> str:
         """Render as a constructor call showing the value, matching voluptuous."""
@@ -228,8 +245,7 @@ class DefaultTo(_SafeValidator):
 
     def __init__(self, default: typing.Any, msg: str | None = None) -> None:
         """Store the default for a None value, as a zero-argument factory."""
-        # ``Any`` rather than the factory union, so the call below reads plainly.
-        self.default: typing.Any = default_factory(default)
+        self.default = _value_factory(default)
         self.msg = msg
 
     def __repr__(self) -> str:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None that can reach real code. `DefaultTo(UNDEFINED)` and `SetTo(UNDEFINED)` now substitute the sentinel where they raised `TypeError: 'Undefined' object is not callable`, because the sentinel arm is gone. `UNDEFINED` means "no default was given", which only a marker can say; these two take the value as a required argument, so passing it is already nonsense. Garbage in either way, and this way does not crash.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

Follow-up to #356. That PR annotated `DefaultTo.default` and `SetTo.value` as `typing.Any`, with a comment calling it a readability choice:

```python
# ``Any`` rather than the factory union, so the call below reads plainly.
self.default: typing.Any = default_factory(default)
```

It is not a readability choice. It silences mypy about the `Undefined` arm of `default_factory`'s return type, and that arm is exactly what makes `self.default()` fail. Drop the annotation on main today and mypy reports five errors:

```
src/probatio/validators/coerce.py:157: error: "Undefined" not callable  [operator]
src/probatio/validators/coerce.py:162: error: "Undefined" not callable  [operator]
src/probatio/validators/coerce.py:235: error: "Undefined" not callable  [operator]
src/probatio/validators/coerce.py:240: error: "Undefined" not callable  [operator]
src/probatio/codecs/jsonschema.py:980: error: "Undefined" not callable  [operator]
```

A marker needs that arm. `DefaultTo` and `SetTo` do not: there is no absence to preserve when the value is a required argument. So they get `_value_factory`, the same normalization minus the sentinel, and the attribute types as a plain `Callable[[], Any]`. No `Any`, no `cast`, and the five call sites are type-checked again.

Validation behavior is unchanged. The differential against voluptuous 0.16.0 still matches on every case #356 fixed, repr formatting included:

```
OK  Schema(DefaultTo(list))(None): probatio=[] | voluptuous=[]
OK  Schema(SetTo(list))('x'): probatio=[] | voluptuous=[]
OK  repr(DefaultTo(list)): probatio='DefaultTo([])' | voluptuous='DefaultTo([])'
OK  HA command_line: probatio={'args': []} | voluptuous={'args': []}
```

One wart, called out so it is a decision and not an accident: `covdefaults` only excludes the bare `if TYPE_CHECKING:` spelling, not `if typing.TYPE_CHECKING:`, so the dotted form drops coverage to 99.98% on the import line. Hence `from typing import TYPE_CHECKING` next to the existing `import typing`. Mixed style in that file, but no other validators module uses `TYPE_CHECKING` at all, so there was no local precedent to match.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [x] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: None
- This PR is related to: #356, #355
- Link to a separate documentation pull request: None

The docs line claiming `DefaultTo` goes "through the same `default_factory` helper" is trimmed, since it no longer does. The normalization it describes is still the same.

Two things found while reading, neither handled here:

- `DefaultTo`, `SetTo`, and marker defaults all leak whatever a user factory raises, past `MultipleInvalid`, and `__probatio_safe__` tells the compiler to skip the guard that would have caught it. `Schema({Optional("a", default=boom): object})({})` already did this before #356. voluptuous leaks too, so closing it is a deliberate deviation that wants its own issue and a compatibility-matrix entry. `tests/validators/test_safe_contract.py` pins `DefaultTo(0)` and `SetTo(5)`, so the fuzzer cannot reach a callable default.
- `Map(mapping, default=list)` still stores the raw type, so two spellings of "default to a fresh list" normalize and one does not. `Map` is probatio-only, so there is no voluptuous constraint either way.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
