### PR TITLE
Run a nested Schema subclass's overridden __call__

### DIFF
--- a/src/probatio/_compile.py
+++ b/src/probatio/_compile.py
@@ -682,13 +682,22 @@ def _compile_nested_schema(schema: Any) -> CompiledSchema | None:
     composition costs one delegating frame instead. Reading ``_compiled`` live
     (not capturing it) follows the inner schema's own bootstrap and compile swaps.
 
-    ``None`` means "keep the wrapper", in two cases. Inside a combinator, because
+    ``None`` means "keep the wrapper", in three cases. Inside a combinator, because
     voluptuous resolves ``Any(Schema(int), float)`` on a miss to the branch's own
     error ("expected int"), and the ``MultipleInvalid`` the wrapper raises is what
-    preserves that; unwrapping would turn it into the combined ``AnyInvalid``. And
-    for a ``Self``-using inner, whose ``__call__`` records the active root that
-    ``Self`` resolves against.
+    preserves that; unwrapping would turn it into the combined ``AnyInvalid``. For
+    a ``Self``-using inner, whose ``__call__`` records the active root that ``Self``
+    resolves against. And for a subclass that overrides ``__call__``, where the
+    override is the whole point of the instance.
     """
+    # A subclass that overrides ``__call__`` post-processes (or replaces) what
+    # validation returns, and voluptuous runs that override in every position
+    # because it compiles a nested Schema as a plain callable. Delegating to the
+    # engine would skip it, silently: the data comes back unprocessed and nothing
+    # says so. So keep the wrapper and call the instance (issue #350).
+    if type(schema).__call__ is not _SCHEMA_CLS.__call__:
+        return None
+
     # A lazily-deferred inner must build now: its ``_uses_self`` and engine are read
     # here to decide the delegation, so a half-built one cannot be reasoned about.
     schema._ensure_built()  # noqa: SLF001

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -112,6 +112,21 @@ def unordered_pair(lib: Any) -> Any:
     return lib.Schema(lib.Unordered([str, int]))
 
 
+def nested_schema_subclass(lib: Any) -> Any:
+    """A Schema subclass that post-processes in __call__, nested as a value."""
+
+    class Defaulting(lib.Schema):  # type: ignore[misc, name-defined]
+        """Fill in a missing key once the wrapped schema has validated."""
+
+        def __call__(self, data: Any) -> Any:
+            """Validate, then default the icon key."""
+            result = super().__call__(data)
+            result.setdefault("icon", None)
+            return result
+
+    return lib.Schema({lib.Required("device"): Defaulting({lib.Required("name"): str})})
+
+
 def some_of(lib: Any) -> Any:
     """A SomeOf with a minimum pass count."""
     return lib.Schema(lib.SomeOf(min_valid=2, validators=[lib.Range(1, 5), int, 3]))
@@ -158,6 +173,8 @@ CASES: list[tuple[Any, Any]] = [
     (unordered_pair, [1, "a"]),
     (unordered_pair, ["a", 1]),
     (unordered_pair, [1, 2]),
+    (nested_schema_subclass, {"device": {"name": "Lamp"}}),
+    (nested_schema_subclass, {"device": {"name": 5}}),
     (some_of, 3),
     (some_of, 7),
 ]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from probatio import (
@@ -214,6 +216,40 @@ def test_composed_schema_matches_the_inline_form() -> None:
         assert type(composed_error) is type(inline_error)
         assert composed_error.msg == inline_error.msg
         assert composed_error.path == inline_error.path
+
+
+def test_nested_schema_subclass_runs_its_overridden_call() -> None:
+    """A nested Schema subclass keeps running its own __call__ (issue #350).
+
+    Composition normally delegates straight to the inner engine, which would skip
+    an overridden ``__call__`` and silently drop whatever it does. voluptuous
+    compiles a nested Schema as a plain callable, so the override runs in every
+    position; this pins that it does here too, nested and direct.
+    """
+
+    class Defaulting(Schema):
+        """Fill in a missing key once the wrapped schema has validated."""
+
+        def __call__(self, data: Any) -> Any:
+            """Validate, then default the icon key."""
+            result = super().__call__(data)
+            result.setdefault("icon", None)
+            return result
+
+    inner = Defaulting({Required("name"): str})
+    payload = {"name": "Lamp"}
+    expected = {"name": "Lamp", "icon": None}
+
+    assert inner(dict(payload)) == expected
+    assert Schema({Required("device"): inner})({"device": dict(payload)}) == {
+        "device": expected
+    }
+    assert Schema([inner])([dict(payload)]) == [expected]
+
+    with pytest.raises(MultipleInvalid) as caught:
+        Schema({Required("device"): inner})({"device": {"name": 5}})
+    (error,) = caught.value.errors
+    assert error.path == ["device", "name"]
 
 
 def test_combinator_branch_schema_keeps_its_branch_error() -> None:


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. It restores the voluptuous behavior that was missing.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

A `Schema` subclass that overrides `__call__` to post-process the validated output worked when called directly, but not when the instance was nested inside another schema. The post-processing was silently dropped, no error, no warning.

The cause is the composition optimization in `_compile_nested_schema`. A prebuilt `Schema` reused as a mapping value or sequence element compiles to a direct delegation to its own engine, saving the callable wrapper and several frames per matched value. For a plain `Schema` that is unobservable. For a subclass it skips exactly the thing the subclass exists for.

It was order-dependent on top of that: whether the delegation applied at all depended on whether the inner schema had already armed itself for codegen when the outer one compiled, so the override sometimes ran and sometimes did not, in the same process.

voluptuous compiles a nested `Schema` as a plain callable, so the override runs in every position. This keeps the wrapper when the instance's class overrides `__call__`, alongside the existing bail-outs for combinator branches and `Self`-using inners. Everything else keeps the fast path; the check is one identity comparison at compile time.

Real-world impact: this is what broke the [MyHOME](https://github.com/anotherjulien/MyHOME) custom integration on Home Assistant Core 2026.9.0. Its `validate.py` nests `Schema` subclasses whose `__call__` rekeys devices and injects default keys, and setup crashed with `KeyError`s once the post-processing went missing.

Tests: a differential conformance case run against voluptuous 0.16.0 as the oracle, and a targeted test pinning the direct, mapping-nested, and sequence-nested positions plus the error path. Both fail without the fix. Verified under all three compile policies (`ON`, `OFF`, and `AUTO` driven hot enough to trigger codegen) and through `install_as_voluptuous()`.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #350

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
