### PR TITLE
Merge extend keys by the literal underneath their marker

### DIFF
--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -325,14 +325,15 @@ Probatio does.
   pathologically deep document with `SchemaError`.
 - **`MultipleInvalid.error_type`.** voluptuous has no such attribute. Probatio
   proxies the first error's type. Additive, so existing code is unaffected.
-- **Comparing a `Remove` marker (`Remove("b") == Required("b")`).** voluptuous
-  compares a `Remove` to the key underneath it, so this is `True`, while hashing it
-  by identity, so equal markers hash differently and the hash/equality contract is
-  broken. Probatio both compares and hashes `Remove` by identity, so this is
-  `False` and the contract holds. Schema behavior is unaffected: a `Remove` still
-  replaces the key it shadows when merged with `extend`, and several `Remove`
-  markers still coexist in one schema. Only a direct `==` between two markers
-  differs.
+- **Comparing a `Remove` marker (`Remove("b") == "b"`).** voluptuous compares a
+  `Remove` to the key underneath it, so that is `True`, while hashing it by
+  identity, so equal markers hash differently and the hash/equality contract is
+  broken. Probatio both compares and hashes `Remove` by identity, so it is `False`.
+  This covers every direct `==` against a `Remove`, whatever is on the other side:
+  a bare key, or another marker for the same key (`Remove("b") == Required("b")`).
+  Schema behavior is unaffected: a `Remove` still replaces the key it shadows when
+  merged with `extend`, and several `Remove` markers still coexist in one schema.
+  Every other marker compares to its underlying key the way voluptuous does.
 - **Missing complex required key (`Required(Any("a", "b"))`).** voluptuous reports
   it twice (the "at least one of [...]" error plus a redundant "required key not
   provided"). Probatio reports the single meaningful error; the first error matches

--- a/docs/src/content/docs/reference/compatibility-matrix.md
+++ b/docs/src/content/docs/reference/compatibility-matrix.md
@@ -325,6 +325,14 @@ Probatio does.
   pathologically deep document with `SchemaError`.
 - **`MultipleInvalid.error_type`.** voluptuous has no such attribute. Probatio
   proxies the first error's type. Additive, so existing code is unaffected.
+- **Comparing a `Remove` marker (`Remove("b") == Required("b")`).** voluptuous
+  compares a `Remove` to the key underneath it, so this is `True`, while hashing it
+  by identity, so equal markers hash differently and the hash/equality contract is
+  broken. Probatio both compares and hashes `Remove` by identity, so this is
+  `False` and the contract holds. Schema behavior is unaffected: a `Remove` still
+  replaces the key it shadows when merged with `extend`, and several `Remove`
+  markers still coexist in one schema. Only a direct `==` between two markers
+  differs.
 - **Missing complex required key (`Required(Any("a", "b"))`).** voluptuous reports
   it twice (the "at least one of [...]" error plus a redundant "required key not
   provided"). Probatio reports the single meaningful error; the first error matches

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -649,9 +649,12 @@ class Schema:
                 # extension key for the same literal adds rather than pops twice.
                 existing_key = existing_keys.pop(_key_literal(key), _NO_MATCH)
             except TypeError:
-                # An unhashable literal is not in the index either, so it matches
-                # nothing; the extension key is added rather than replacing one.
-                existing_key = _NO_MATCH
+                # An unhashable literal is not in the index, so nothing matches
+                # there. The marker around it is still hashable (``Remove`` hashes
+                # by identity), so fall back to the key object: an extension that
+                # reuses the very same marker addresses the entry it already keys,
+                # and a nested mapping under it still merges rather than replaces.
+                existing_key = key if key in merged else _NO_MATCH
             existing = (
                 merged.pop(existing_key) if existing_key is not _NO_MATCH else _NO_MATCH
             )

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -41,7 +41,6 @@ from probatio.error import (
     SchemaError,
 )
 from probatio.markers import (
-    UNDEFINED,
     Extra,
     Marker,
     Optional,
@@ -166,6 +165,13 @@ def _not_built(data: Any) -> Any:  # noqa: ARG001  # pragma: no cover
     """
     message = "internal: a deferred schema's validator was read before it built"
     raise SchemaError(message)
+
+
+# "no key in the base schema matched", for the merge in ``extend``. A private
+# object rather than ``UNDEFINED``, which is public and can itself be a mapping key:
+# a base schema keyed on it would read as unmatched and keep the key the extension
+# meant to replace.
+_NO_MATCH = object()
 
 
 def _key_literal(key: Any) -> Any:
@@ -621,9 +627,9 @@ class Schema:
         for key, value in schema.items():
             # Consumed from the map as well as from ``merged``, so a second
             # extension key for the same literal adds rather than pops twice.
-            existing_key = existing_keys.pop(_key_literal(key), UNDEFINED)
+            existing_key = existing_keys.pop(_key_literal(key), _NO_MATCH)
             existing = (
-                merged.pop(existing_key) if existing_key is not UNDEFINED else UNDEFINED
+                merged.pop(existing_key) if existing_key is not _NO_MATCH else _NO_MATCH
             )
             # When both sides are mappings, merge them recursively rather than
             # replacing wholesale, so an extension touching one nested key keeps

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -41,6 +41,7 @@ from probatio.error import (
     SchemaError,
 )
 from probatio.markers import (
+    UNDEFINED,
     Extra,
     Marker,
     Optional,
@@ -165,6 +166,23 @@ def _not_built(data: Any) -> Any:  # noqa: ARG001  # pragma: no cover
     """
     message = "internal: a deferred schema's validator was read before it built"
     raise SchemaError(message)
+
+
+def _key_literal(key: Any) -> Any:
+    """Return the bare key under a (possibly nested) marker chain.
+
+    ``Required("a")``, ``Remove("a")`` and ``Optional(Secret("a"))`` all describe
+    the same key, ``"a"``. Merging schemas matches on that literal rather than on
+    the marker objects, because marker hashing does not line them up:
+    ``Remove`` hashes by identity, so a dict lookup keyed by one never finds
+    another marker for the same key.
+
+    This deliberately does not go through ``resolve_key``: merging must not reject
+    a contradictory chain that the schema it came from has not built yet.
+    """
+    while isinstance(key, Marker):
+        key = key.schema
+    return key
 
 
 class Schema:
@@ -553,9 +571,11 @@ class Schema:
     ) -> Schema:
         """Return a new Schema with ``schema``'s keys merged into this mapping.
 
-        Keys in ``schema`` replace equal keys in this schema (marker and value
-        both), so a bare key can override a ``Required`` one. ``required`` and
-        ``extra`` override this schema's settings, or inherit them when omitted.
+        Keys are matched by the bare key underneath any marker, and a key in
+        ``schema`` replaces the matching one here (marker and value both), so a
+        bare key can override a ``Required`` one and a ``Remove`` overrides both.
+        ``required`` and ``extra`` override this schema's settings, or inherit them
+        when omitted.
 
         ``schema`` may be a plain mapping or another ``Schema`` (voluptuous PR
         #538). Extending with a ``Schema`` carries its ``required`` intent across
@@ -590,10 +610,21 @@ class Schema:
             raise SchemaError(message)
 
         merged = dict(self.schema)
+        # Match on the bare key underneath every marker, so an extension key
+        # replaces the existing one whatever marker either side wears: a bare key
+        # overrides a ``Required`` one, and a ``Remove`` overrides both. Popping by
+        # the key object instead would rely on marker hashing, which ``Remove``
+        # breaks by hashing on identity: the pop misses and the shadowed key stays
+        # in the merged schema, neither removed nor optional (issue #352).
+        existing_keys = {_key_literal(key): key for key in merged}
+
         for key, value in schema.items():
-            # ``pop`` finds the existing key by its literal (markers hash by their
-            # underlying key), so a bare key overrides a ``Required`` one.
-            existing = merged.pop(key, None)
+            # Consumed from the map as well as from ``merged``, so a second
+            # extension key for the same literal adds rather than pops twice.
+            existing_key = existing_keys.pop(_key_literal(key), UNDEFINED)
+            existing = (
+                merged.pop(existing_key) if existing_key is not UNDEFINED else UNDEFINED
+            )
             # When both sides are mappings, merge them recursively rather than
             # replacing wholesale, so an extension touching one nested key keeps
             # the base's other nested keys (voluptuous semantics).

--- a/src/probatio/schema.py
+++ b/src/probatio/schema.py
@@ -191,6 +191,25 @@ def _key_literal(key: Any) -> Any:
     return key
 
 
+def _literal_index(keys: dict[Any, Any]) -> dict[Any, Any]:
+    """Index a mapping schema's keys by the literal underneath their markers.
+
+    A key whose literal is unhashable is left out. ``Remove`` hashes by identity,
+    so it can legally wrap a key schema that is not itself hashable (a callable
+    validator whose class defines ``__eq__``, say); indexing it would raise, and
+    the index is the wrong place to fail, since the merge may not touch that key at
+    all. Nothing is lost: matching an extension key means hashing its literal too,
+    so an unhashable one could never have matched. It just survives the merge.
+    """
+    index: dict[Any, Any] = {}
+    for key in keys:
+        try:
+            index[_key_literal(key)] = key
+        except TypeError:
+            continue
+    return index
+
+
 class Schema:
     """A compiled, callable schema.
 
@@ -622,12 +641,17 @@ class Schema:
         # the key object instead would rely on marker hashing, which ``Remove``
         # breaks by hashing on identity: the pop misses and the shadowed key stays
         # in the merged schema, neither removed nor optional (issue #352).
-        existing_keys = {_key_literal(key): key for key in merged}
+        existing_keys = _literal_index(merged)
 
         for key, value in schema.items():
-            # Consumed from the map as well as from ``merged``, so a second
-            # extension key for the same literal adds rather than pops twice.
-            existing_key = existing_keys.pop(_key_literal(key), _NO_MATCH)
+            try:
+                # Consumed from the map as well as from ``merged``, so a second
+                # extension key for the same literal adds rather than pops twice.
+                existing_key = existing_keys.pop(_key_literal(key), _NO_MATCH)
+            except TypeError:
+                # An unhashable literal is not in the index either, so it matches
+                # nothing; the extension key is added rather than replacing one.
+                existing_key = _NO_MATCH
             existing = (
                 merged.pop(existing_key) if existing_key is not _NO_MATCH else _NO_MATCH
             )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -127,6 +127,20 @@ def nested_schema_subclass(lib: Any) -> Any:
     return lib.Schema({lib.Required("device"): Defaulting({lib.Required("name"): str})})
 
 
+def extend_with_remove(lib: Any) -> Any:
+    """A Remove marker merged in over an existing Required key."""
+    base = lib.Schema({lib.Required("a"): int, lib.Required("b"): int})
+    return base.extend({lib.Remove("b"): int}, extra=lib.ALLOW_EXTRA)
+
+
+def extend_over_remove(lib: Any) -> Any:
+    """A Required marker merged in over an existing Remove key."""
+    base = lib.Schema(
+        {lib.Required("a"): int, lib.Remove("b"): int}, extra=lib.ALLOW_EXTRA
+    )
+    return base.extend({lib.Required("b"): int})
+
+
 def some_of(lib: Any) -> Any:
     """A SomeOf with a minimum pass count."""
     return lib.Schema(lib.SomeOf(min_valid=2, validators=[lib.Range(1, 5), int, 3]))
@@ -175,6 +189,10 @@ CASES: list[tuple[Any, Any]] = [
     (unordered_pair, [1, 2]),
     (nested_schema_subclass, {"device": {"name": "Lamp"}}),
     (nested_schema_subclass, {"device": {"name": 5}}),
+    (extend_with_remove, {"a": 1, "b": 2}),
+    (extend_with_remove, {"a": 1}),
+    (extend_over_remove, {"a": 1, "b": 2}),
+    (extend_over_remove, {"a": 1}),
     (some_of, 3),
     (some_of, 7),
 ]

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -6,6 +6,7 @@ import pytest
 
 from probatio import (
     ALLOW_EXTRA,
+    UNDEFINED,
     MultipleInvalid,
     Optional,
     Remove,
@@ -193,6 +194,15 @@ def test_extend_keeps_unrelated_remove_keys() -> None:
     extended = base.extend({"c": int})
 
     assert extended({"a": 1, 5: "x", 2.5: "y", "c": 3}) == {"a": 1, "c": 3}
+
+
+def test_extend_matches_a_key_that_is_itself_a_public_sentinel() -> None:
+    """The merge tells "no match" apart from a base key that is a public value."""
+    base = Schema({UNDEFINED: int, "a": int})
+    extended = base.extend({Remove(UNDEFINED): int}, extra=ALLOW_EXTRA)
+
+    assert [repr(key) for key in extended.schema] == ["'a'", "Remove(<undefined>)"]
+    assert extended({UNDEFINED: 1, "a": 2}) == {"a": 2}
 
 
 def test_extend_returns_the_same_schema_subclass() -> None:

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -20,6 +20,20 @@ from probatio import (
 from probatio.markers import Marker
 
 
+@dataclass  # eq=True without frozen=True, so instances are unhashable.
+class ShorterThan:
+    """A callable key validator whose instances cannot be hashed."""
+
+    limit: int
+
+    def __call__(self, value: str) -> str:
+        """Accept a key shorter than the limit."""
+        if len(value) >= self.limit:
+            message = "too long"
+            raise Invalid(message)
+        return value
+
+
 def test_extend_adds_keys() -> None:
     """Extending merges new keys into the mapping schema."""
     base = Schema({"a": int})
@@ -216,20 +230,6 @@ def test_extend_keeps_a_remove_wrapping_an_unhashable_key_schema() -> None:
     must not hash that one, or extending the schema over an unrelated key would
     fail with a TypeError.
     """
-
-    @dataclass  # eq=True with no frozen=True, so instances are unhashable.
-    class ShorterThan:
-        """A callable key validator whose instances cannot be hashed."""
-
-        limit: int
-
-        def __call__(self, value: str) -> str:
-            """Accept a key shorter than the limit."""
-            if len(value) >= self.limit:
-                message = "too long"
-                raise Invalid(message)
-            return value
-
     unhashable = Remove(ShorterThan(3))
     base = Schema({"a": int, unhashable: str}, extra=ALLOW_EXTRA)
 
@@ -241,6 +241,23 @@ def test_extend_keeps_a_remove_wrapping_an_unhashable_key_schema() -> None:
     # so the key is added rather than replacing one.
     other = Remove(ShorterThan(5))
     assert list(base.extend({other: str}).schema) == ["a", unhashable, other]
+
+
+def test_extend_reusing_an_unhashable_remove_still_merges_its_mapping() -> None:
+    """Reusing the same Remove object addresses the entry it already keys.
+
+    The literal under the marker cannot be indexed, but the marker itself hashes
+    by identity, so an extension that passes the very same object must still find
+    the base entry. Missing it would replace a nested mapping wholesale instead of
+    merging into it, silently dropping the base's other keys.
+    """
+    marker = Remove(ShorterThan(3))
+    base = Schema({"z": int, marker: {"a": int, "b": int}}, extra=ALLOW_EXTRA)
+
+    extended = base.extend({marker: {"b": str}})
+
+    assert list(extended.schema) == ["z", marker]
+    assert extended.schema[marker] == {"a": int, "b": str}
 
 
 def test_extend_returns_the_same_schema_subclass() -> None:

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pytest
 
 from probatio import (
     ALLOW_EXTRA,
     UNDEFINED,
+    Invalid,
     MultipleInvalid,
     Optional,
     Remove,
@@ -203,6 +206,41 @@ def test_extend_matches_a_key_that_is_itself_a_public_sentinel() -> None:
 
     assert [repr(key) for key in extended.schema] == ["'a'", "Remove(<undefined>)"]
     assert extended({UNDEFINED: 1, "a": 2}) == {"a": 2}
+
+
+def test_extend_keeps_a_remove_wrapping_an_unhashable_key_schema() -> None:
+    """A Remove around an unhashable validator survives a merge that ignores it.
+
+    Remove hashes by identity, so it can legally wrap a key schema that is not
+    itself hashable. Indexing the merge by the bare key underneath every marker
+    must not hash that one, or extending the schema over an unrelated key would
+    fail with a TypeError.
+    """
+
+    @dataclass  # eq=True with no frozen=True, so instances are unhashable.
+    class ShorterThan:
+        """A callable key validator whose instances cannot be hashed."""
+
+        limit: int
+
+        def __call__(self, value: str) -> str:
+            """Accept a key shorter than the limit."""
+            if len(value) >= self.limit:
+                message = "too long"
+                raise Invalid(message)
+            return value
+
+    unhashable = Remove(ShorterThan(3))
+    base = Schema({"a": int, unhashable: str}, extra=ALLOW_EXTRA)
+
+    extended = base.extend({"c": int})
+    assert list(extended.schema) == ["a", unhashable, "c"]
+    assert extended({"a": 1, "xy": "dropped", "c": 2}) == {"a": 1, "c": 2}
+
+    # The same on the extension side: an unhashable literal cannot match anything,
+    # so the key is added rather than replacing one.
+    other = Remove(ShorterThan(5))
+    assert list(base.extend({other: str}).schema) == ["a", unhashable, other]
 
 
 def test_extend_returns_the_same_schema_subclass() -> None:

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -8,6 +8,7 @@ from probatio import (
     ALLOW_EXTRA,
     MultipleInvalid,
     Optional,
+    Remove,
     Required,
     Schema,
     SchemaError,
@@ -151,6 +152,47 @@ def test_extend_merges_nested_mappings_recursively() -> None:
     base = Schema({"a": {"b": int, "c": float}})
     extended = base.extend({"d": str, "a": {"b": str, "e": int}})
     assert extended.schema == {"a": {"b": str, "c": float, "e": int}, "d": str}
+
+
+def test_extend_with_remove_replaces_the_shadowed_key() -> None:
+    """A Remove in the extension takes over the base key's slot (issue #352).
+
+    Remove hashes by identity, so matching the extension's keys against the base
+    by the key object misses and leaves the shadowed key in the merged schema:
+    the key is then neither stripped from the output nor allowed to be absent.
+    Matching on the bare key underneath the marker is what keeps ``extend`` and
+    the same schema written out in one go equivalent, as voluptuous has them.
+    """
+    base = Schema({Required("a"): int, Required("b"): int})
+    extended = base.extend({Remove("b"): int}, extra=ALLOW_EXTRA)
+    direct = Schema({Required("a"): int, Remove("b"): int}, extra=ALLOW_EXTRA)
+
+    # Remove compares by identity, so the merged keys are checked by repr.
+    assert [repr(key) for key in extended.schema] == ["'a'", "Remove('b')"]
+    assert extended({"a": 1, "b": 2}) == direct({"a": 1, "b": 2}) == {"a": 1}
+    assert extended({"a": 1}) == direct({"a": 1}) == {"a": 1}
+
+
+def test_extend_over_a_remove_key_restores_it() -> None:
+    """A marker in the extension takes back a key the base removed."""
+    base = Schema({Required("a"): int, Remove("b"): int}, extra=ALLOW_EXTRA)
+    extended = base.extend({Required("b"): int})
+
+    assert list(extended.schema) == ["a", "b"]
+    assert extended({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+    with pytest.raises(MultipleInvalid) as caught:
+        extended({"a": 1})
+    (error,) = caught.value.errors
+    assert error.path == ["b"]
+
+
+def test_extend_keeps_unrelated_remove_keys() -> None:
+    """Remove keys the extension does not name survive the merge intact."""
+    base = Schema({"a": int, Remove(int): str, Remove(float): str}, extra=ALLOW_EXTRA)
+    extended = base.extend({"c": int})
+
+    assert extended({"a": 1, 5: "x", 2.5: "y", "c": 3}) == {"a": 1, "c": 3}
 
 
 def test_extend_returns_the_same_schema_subclass() -> None:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -99,6 +99,21 @@ def test_remove_markers_are_distinct_keys() -> None:
     assert "Remove(" in repr(Remove(str))
 
 
+def test_remove_does_not_compare_equal_to_its_own_key() -> None:
+    """A Remove compares by identity, so it is unequal to the key it wraps.
+
+    A documented deviation: voluptuous compares a Remove to its underlying key
+    while hashing it by identity, which breaks the hash/equality contract. Nothing
+    in schema building leans on the comparison, so probatio keeps both by identity.
+    """
+    marker = Remove("b")
+    key = "b"
+    assert marker != key
+    # Reflected: str.__eq__ defers, so the marker's __eq__ answers here too.
+    assert key != marker
+    assert marker != Required("b")
+
+
 def test_default_factory_handles_each_case() -> None:
     """default_factory returns UNDEFINED, the callable, or a value factory."""
     assert default_factory(UNDEFINED) is UNDEFINED


### PR DESCRIPTION
<!--
  You're awesome, thanks for contributing to probatio!

  Please do not delete the sections of this template. Fill in what applies and
  write "None" where it does not; the structure helps reviewers process your
  pull request quickly.
-->

## Breaking change

<!--
  Does this change behavior for existing users (an API change, a different
  validation result, a removed or renamed option)? If so, describe what breaks,
  how to adapt, and why the change is worth it. Write "None" if nothing breaks.
-->

None. It restores the voluptuous behavior that was missing.

## Proposed change

<!--
  Describe the change and, just as important, why it should be accepted. Link the
  issue or discussion it addresses so reviewers have the full picture.
-->

`Schema.extend` merged by popping the extension key straight out of the base dict, which relies on marker hashing lining up. `Marker.__hash__` hashes by the underlying key, so `Required("b")` shares `"b"`'s slot and the pop finds it. `Remove` overrides `__hash__`/`__eq__` to identity, so several `Remove` markers can share one schema, and the pop misses.

Both markers then survived the merge. The key was neither stripped from the output nor allowed to be absent, while the same schema written out in one go worked fine. It bit in Home Assistant 2026.9 after the shim swap: an event schema built with `extend` started rejecting every payload, and the failure was non-fatal in that code path, so it took a while to trace.

voluptuous does not merge by hashing at all. It builds an explicit literal to key-object map first, so `Remove` never trips it. This does the same, with a `_key_literal` helper that walks a nested marker chain down to the bare key. The helper deliberately does not go through `resolve_key`: merging must not reject a contradictory chain that the schema it came from has not built yet, which would move when a `SchemaError` surfaces under the LAZY build policy. It also consumes from the map, so two extension keys with the same literal add rather than pop twice (voluptuous raises `KeyError` there).

`Remove`'s hashing is left alone. Identity for both hash and equality is self-consistent, where voluptuous pairs an identity hash with a schema-based equality and so breaks the hash/equality contract. With `extend` no longer leaning on hashing, the difference stops being observable in schema behavior; the one thing that still differs is a direct `Remove("b") == Required("b")`, now listed in the compatibility matrix.

Tests: three in `test_extend.py` (a `Remove` over a `Required`, a marker taking a removed key back, unrelated `Remove` keys surviving the merge) and two differential cases in `test_conformance.py` pinned against voluptuous 0.16.0. Verified they fail without the fix, and ran a wider matrix of nine `extend` and marker combinations against voluptuous with full agreement.

## Type of change

<!-- Put an `x` in the one box that best describes this PR. -->

- [ ] Dependency or tooling upgrade
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Deprecation (replaces or removes a feature, with a migration path)
- [ ] Breaking change (a fix or feature that changes existing behavior)
- [ ] Code quality, refactor, or test-only change
- [ ] Documentation only

## Additional information

<!-- Details help reviewers. Remove the lines that do not apply. -->

- This PR fixes or closes issue: fixes #352

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] I fully understand the code in this pull request and can explain every line, including any AI-assisted changes.
- [x] The change is covered by tests, and `uv run --no-sync just test` passes locally. **A pull request cannot be merged unless CI is green.**
- [x] `uv run --no-sync just lint` passes.
- [x] `uv run --no-sync just typecheck` passes.
- [x] No commented-out or dead code is left in the pull request.

<!--
  Reviewer time is the scarcest resource on most projects. If you have a moment,
  reviewing one or two other open pull requests is a great way to help out, and a
  good way to get to know the codebase.
-->
